### PR TITLE
chore: Adjust Plausible domain

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -38,7 +38,7 @@ export default defineConfig({
           tag: "script",
           attrs: {
             src: "https://plausible.io/js/script.js",
-            "data-domain": "docs.arcjet.com",
+            "data-domain": "arcjet.com",
             defer: true,
           },
         },


### PR DESCRIPTION
Allows us to track across subdomains.

See https://plausible.io/blog/conversion-attribution-across-domain-subdomains
