### PR TITLE
fix: add getBody to the RequestFields example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "docs",
       "version": "0.0.1",
       "dependencies": {
+        "@arcjet/body": "1.0.0-alpha.22",
         "@arcjet/bun": "1.0.0-alpha.22",
         "@arcjet/decorate": "1.0.0-alpha.22",
         "@arcjet/env": "1.0.0-alpha.22",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@arcjet/bun": "1.0.0-alpha.22",
+    "@arcjet/body": "1.0.0-alpha.22",
     "@arcjet/decorate": "1.0.0-alpha.22",
     "@arcjet/env": "1.0.0-alpha.22",
     "@arcjet/eslint-config": "1.0.0-alpha.22",

--- a/src/content/docs/reference/snippets/nodejs/RequestFields.ts
+++ b/src/content/docs/reference/snippets/nodejs/RequestFields.ts
@@ -1,5 +1,6 @@
 import { createConnectTransport } from "@connectrpc/connect-node";
 import arcjet, { shield } from "arcjet";
+import { readBody } from "@arcjet/body";
 import { createClient } from "@arcjet/protocol/client.js";
 import { baseUrl } from "@arcjet/env";
 import * as http from "http";
@@ -41,8 +42,15 @@ const server = http.createServer(async function (
     headers: req.headers,
   };
 
-  // @ts-ignore
-  const decision = await aj.protect({}, details);
+  // Provide a function to get the body in case it is needed by a rule.
+  const getBody = async () => {
+    return await readBody(req, {
+      // Only read up to 1 MiB of the body
+      limit: 1048576,
+    });
+  };
+
+  const decision = await aj.protect({ getBody }, details);
   console.log(decision);
 
   if (decision.isDenied()) {

--- a/src/content/docs/reference/snippets/nodejs/RequestFields.ts
+++ b/src/content/docs/reference/snippets/nodejs/RequestFields.ts
@@ -44,10 +44,15 @@ const server = http.createServer(async function (
 
   // Provide a function to get the body in case it is needed by a rule.
   const getBody = async () => {
-    return await readBody(req, {
-      // Only read up to 1 MiB of the body
-      limit: 1048576,
-    });
+    try {
+      return await readBody(req, {
+        // Only read up to 1 MiB of the body
+        limit: 1048576,
+      });
+    } catch {
+      // Return undefined in case of failure to allow the rule that called `getBody` handle it.
+      return undefined;
+    }
   };
 
   const decision = await aj.protect({ getBody }, details);


### PR DESCRIPTION
This shows how to use `@arcjet/body` to get the body of a Node.js `IncomingMessage` when manually constructing the request for the SDK.

Closes #27
