### PR TITLE
chore(ci): Group all arcjet packages together for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,8 @@ updates:
         update-types:
           - minor
           - patch
+      # Arcjet packages are grouped alone due to not being major/minor/patch yet
+      arcjet-js:
+        patterns:
+          - "arcjet"
+          - "@arcjet/*"


### PR DESCRIPTION
I noticed that all the arcjet packages were updated as separate PRs. I believe this is due to them being in alpha and not receiving major/minor/patch updates.

This will group them together.