### PR TITLE
fix: Correct documentation around production vs development

### DIFF
--- a/src/content/docs/bot-protection/reference/bun.mdx
+++ b/src/content/docs/bot-protection/reference/bun.mdx
@@ -156,9 +156,9 @@ be identified as zero, one, or more bots—all of which will be available on the
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `ARCJET_ENV` is `"production"` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an
 `ERROR` type and you can check the `reason` property for more information, like

--- a/src/content/docs/bot-protection/reference/nextjs.mdx
+++ b/src/content/docs/bot-protection/reference/nextjs.mdx
@@ -374,9 +374,9 @@ Create a new API route at `/pages/api/arcjet.js`:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an
 `ERROR` type and you can check the `reason` property for more information, like

--- a/src/content/docs/bot-protection/reference/nodejs.mdx
+++ b/src/content/docs/bot-protection/reference/nodejs.mdx
@@ -156,9 +156,9 @@ be identified as zero, one, or more bots—all of which will be available on the
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an
 `ERROR` type and you can check the `reason` property for more information, like

--- a/src/content/docs/bot-protection/reference/sveltekit.mdx
+++ b/src/content/docs/bot-protection/reference/sveltekit.mdx
@@ -232,9 +232,9 @@ be identified as zero, one, or more bots—all of which will be available on the
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an
 `ERROR` type and you can check the `reason` property for more information, like

--- a/src/content/docs/email-validation/quick-start/nodejs.mdx
+++ b/src/content/docs/email-validation/quick-start/nodejs.mdx
@@ -55,8 +55,11 @@ yarn add @arcjet/node
 
 [Create a free Arcjet account](https://app.arcjet.com) then follow the
 instructions to add a site and get a key. Add it to a `.env.local` file in your
-project root. `NODE_ENV` isn't set by default, so you also need to tell
-Arcjet you're in development mode.
+project root.
+
+Arcjet only accepts non-local IP addresses with a fallback to 127.0.0.1 in
+development mode. Since Node.js doesn't set `NODE_ENV` for you, you also need to
+set `ARCJET_ENV` in your environment file.
 
 ```ini title=".env.local"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev

--- a/src/content/docs/email-validation/reference/bun.mdx
+++ b/src/content/docs/email-validation/reference/bun.mdx
@@ -121,9 +121,9 @@ type ArcjetEmailType =
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `ARCJET_ENV` is `"production"` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 

--- a/src/content/docs/email-validation/reference/nextjs.mdx
+++ b/src/content/docs/email-validation/reference/nextjs.mdx
@@ -151,9 +151,9 @@ type ArcjetEmailType =
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 

--- a/src/content/docs/email-validation/reference/nodejs.mdx
+++ b/src/content/docs/email-validation/reference/nodejs.mdx
@@ -121,9 +121,9 @@ type ArcjetEmailType =
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 

--- a/src/content/docs/email-validation/reference/sveltekit.mdx
+++ b/src/content/docs/email-validation/reference/sveltekit.mdx
@@ -131,9 +131,9 @@ type ArcjetEmailType =
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 

--- a/src/content/docs/get-started/bun.mdx
+++ b/src/content/docs/get-started/bun.mdx
@@ -40,8 +40,7 @@ bun add @arcjet/bun
 
 [Create a free Arcjet account](https://app.arcjet.com) then follow the
 instructions to add a site and get a key. Add it to a `.env.local` file in your
-Bun project root. `NODE_ENV` isn't set by default, so you also need to tell
-Arcjet you're in development mode.
+Bun project root.
 
 Arcjet only accepts non-local IP addresses with a fallback to 127.0.0.1 in
 development mode. Since Bun doesn't set `NODE_ENV` for you, you also need to

--- a/src/content/docs/rate-limiting/reference/bun.mdx
+++ b/src/content/docs/rate-limiting/reference/bun.mdx
@@ -260,9 +260,9 @@ your responses with appropriate `RateLimit` headers based on a decision.
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `ARCJET_ENV` is `"production"` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 

--- a/src/content/docs/rate-limiting/reference/nextjs.mdx
+++ b/src/content/docs/rate-limiting/reference/nextjs.mdx
@@ -421,9 +421,9 @@ Create a new API route at `/pages/api/arcjet.js`:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 

--- a/src/content/docs/rate-limiting/reference/nodejs.mdx
+++ b/src/content/docs/rate-limiting/reference/nodejs.mdx
@@ -262,9 +262,9 @@ your responses with appropriate `RateLimit` headers based on a decision.
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 

--- a/src/content/docs/rate-limiting/reference/sveltekit.mdx
+++ b/src/content/docs/rate-limiting/reference/sveltekit.mdx
@@ -362,9 +362,9 @@ your responses with appropriate `RateLimit` headers based on a decision.
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 

--- a/src/content/docs/reference/bun.mdx
+++ b/src/content/docs/reference/bun.mdx
@@ -490,9 +490,9 @@ remove the need for null-ish checks.
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `ARCJET_ENV` is `"production"` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 
@@ -529,9 +529,9 @@ Arcjet will automatically detect the IP address of the client making the request
 based on the context provided. The implementation is open source in our
 [@arcjet/ip package](https://github.com/arcjet/arcjet-js/blob/main/ip).
 
-In non-production environments, we allow private/internal addresses so that the
-SDKs work correctly locally. As Bun doesn't set `NODE_ENV` for you, you need to
-set `ARCJET_ENV=development` in your environment file for this to work.
+In development environments (`NODE_ENV === "development"` or
+`ARCJET_ENV === "development"`), we allow private/internal addresses so that the
+SDKs work correctly locally.
 
 ## Client override
 

--- a/src/content/docs/reference/nextjs.mdx
+++ b/src/content/docs/reference/nextjs.mdx
@@ -589,9 +589,9 @@ fields we have data for will be returned:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 
@@ -640,8 +640,9 @@ Arcjet will automatically detect the IP address of the client making the request
 based on the context provided. The implementation is open source in our
 [@arcjet/ip package](https://github.com/arcjet/arcjet-js/blob/main/ip).
 
-In non-production environments (`NODE_ENV !== "production"`), we allow
-private/internal addresses so that the SDKs work correctly locally.
+In development environments (`NODE_ENV === "development"` or
+`ARCJET_ENV === "development"`), we allow private/internal addresses so that the
+SDKs work correctly locally.
 
 ## Client override
 

--- a/src/content/docs/reference/nodejs.mdx
+++ b/src/content/docs/reference/nodejs.mdx
@@ -475,9 +475,9 @@ fields we have data for will be returned:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 
@@ -517,8 +517,9 @@ Arcjet will automatically detect the IP address of the client making the request
 based on the context provided. The implementation is open source in our
 [@arcjet/ip package](https://github.com/arcjet/arcjet-js/blob/main/ip).
 
-In non-production environments (`NODE_ENV !== "production"`), we allow
-private/internal addresses so that the SDKs work correctly locally.
+In development environments (`NODE_ENV === "development"` or
+`ARCJET_ENV === "development"`), we allow private/internal addresses so that the
+SDKs work correctly locally.
 
 ## Client override
 

--- a/src/content/docs/reference/snippets/bun/ClientOverride.js
+++ b/src/content/docs/reference/snippets/bun/ClientOverride.js
@@ -4,9 +4,9 @@ import { baseUrl } from "@arcjet/env";
 const client = createRemoteClient({
   baseUrl: baseUrl(Bun.env),
   // timeout is the maximum time to wait for a response from the server. It
-  // defaults to 500ms when NODE_ENV is "production" and 1000ms otherwise. This
-  // is a conservative limit to fail open by default. In most cases, the
-  // response time will be <20-30ms.
+  // defaults to 1000ms when NODE_ENV or ARCJET_ENV is "development" and 500ms
+  // otherwise. This is a conservative limit to fail open by default. In most
+  // cases, the response time will be <20-30ms.
   timeout: 500,
 });
 import { env } from "bun";

--- a/src/content/docs/reference/snippets/bun/ClientOverride.ts
+++ b/src/content/docs/reference/snippets/bun/ClientOverride.ts
@@ -4,9 +4,9 @@ import { baseUrl } from "@arcjet/env";
 const client = createRemoteClient({
   baseUrl: baseUrl(Bun.env),
   // timeout is the maximum time to wait for a response from the server. It
-  // defaults to 500ms when NODE_ENV is "production" and 1000ms otherwise. This
-  // is a conservative limit to fail open by default. In most cases, the
-  // response time will be <20-30ms.
+  // defaults to 1000ms when NODE_ENV or ARCJET_ENV is "development" and 500ms
+  // otherwise. This is a conservative limit to fail open by default. In most
+  // cases, the response time will be <20-30ms.
   timeout: 500,
 });
 import { env } from "bun";

--- a/src/content/docs/reference/snippets/bun/Logger.js
+++ b/src/content/docs/reference/snippets/bun/Logger.js
@@ -3,7 +3,7 @@ import { env } from "bun";
 import pino from "pino";
 
 const logger =
-  env.ARCJET_ENV === "production"
+  env.ARCJET_ENV !== "development"
     ? // JSON in production, default to warn
       pino({ level: process.env.ARCJET_LOG_LEVEL || "warn" })
     : // Pretty print in development, default to debug

--- a/src/content/docs/reference/snippets/bun/Logger.ts
+++ b/src/content/docs/reference/snippets/bun/Logger.ts
@@ -3,7 +3,7 @@ import { env } from "bun";
 import pino, { type Logger } from "pino";
 
 const logger: Logger =
-  env.ARCJET_ENV === "production"
+  env.ARCJET_ENV !== "development"
     ? // JSON in production, default to warn
       pino({ level: process.env.ARCJET_LOG_LEVEL || "warn" })
     : // Pretty print in development, default to debug

--- a/src/content/docs/reference/snippets/nextjs/ClientOverride.js
+++ b/src/content/docs/reference/snippets/nextjs/ClientOverride.js
@@ -7,9 +7,9 @@ const client = createRemoteClient({
   // variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server. It
-  // defaults to 500ms when NODE_ENV is "production" and 1000ms otherwise. This
-  // is a conservative limit to fail open by default. In most cases, the
-  // response time will be <20-30ms.
+  // defaults to 1000ms when NODE_ENV or ARCJET_ENV is "development" and 500ms
+  // otherwise. This is a conservative limit to fail open by default. In most
+  // cases, the response time will be <20-30ms.
   timeout: 500,
 });
 

--- a/src/content/docs/reference/snippets/nextjs/ClientOverride.ts
+++ b/src/content/docs/reference/snippets/nextjs/ClientOverride.ts
@@ -7,9 +7,9 @@ const client = createRemoteClient({
   // variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server. It
-  // defaults to 500ms when NODE_ENV is "production" and 1000ms otherwise. This
-  // is a conservative limit to fail open by default. In most cases, the
-  // response time will be <20-30ms.
+  // defaults to 1000ms when NODE_ENV or ARCJET_ENV is "development" and 500ms
+  // otherwise. This is a conservative limit to fail open by default. In most
+  // cases, the response time will be <20-30ms.
   timeout: 500,
 });
 

--- a/src/content/docs/reference/snippets/nextjs/Logger.js
+++ b/src/content/docs/reference/snippets/nextjs/Logger.js
@@ -2,7 +2,7 @@ import arcjet, { shield } from "@arcjet/next";
 import pino from "pino";
 
 const logger =
-  process.env.NODE_ENV === "production"
+  process.env.NODE_ENV !== "development"
     ? // JSON in production, default to warn
       pino({ level: process.env.ARCJET_LOG_LEVEL || "warn" })
     : // Pretty print in development, default to debug

--- a/src/content/docs/reference/snippets/nextjs/Logger.ts
+++ b/src/content/docs/reference/snippets/nextjs/Logger.ts
@@ -2,7 +2,7 @@ import arcjet, { shield } from "@arcjet/next";
 import pino, { type Logger } from "pino";
 
 const logger: Logger =
-  process.env.NODE_ENV === "production"
+  process.env.NODE_ENV !== "development"
     ? // JSON in production, default to warn
       pino({ level: process.env.ARCJET_LOG_LEVEL || "warn" })
     : // Pretty print in development, default to debug

--- a/src/content/docs/reference/snippets/nodejs/ClientOverride.js
+++ b/src/content/docs/reference/snippets/nodejs/ClientOverride.js
@@ -7,9 +7,9 @@ const client = createRemoteClient({
   // variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server. It
-  // defaults to 500ms when NODE_ENV is "production" and 1000ms otherwise. This
-  // is a conservative limit to fail open by default. In most cases, the
-  // response time will be <20-30ms.
+  // defaults to 1000ms when NODE_ENV or ARCJET_ENV is "development" and 500ms
+  // otherwise. This is a conservative limit to fail open by default. In most
+  // cases, the response time will be <20-30ms.
   timeout: 500,
 });
 

--- a/src/content/docs/reference/snippets/nodejs/ClientOverride.ts
+++ b/src/content/docs/reference/snippets/nodejs/ClientOverride.ts
@@ -7,9 +7,9 @@ const client = createRemoteClient({
   // variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server. It
-  // defaults to 500ms when NODE_ENV is "production" and 1000ms otherwise. This
-  // is a conservative limit to fail open by default. In most cases, the
-  // response time will be <20-30ms.
+  // defaults to 1000ms when NODE_ENV or ARCJET_ENV is "development" and 500ms
+  // otherwise. This is a conservative limit to fail open by default. In most
+  // cases, the response time will be <20-30ms.
   timeout: 500,
 });
 

--- a/src/content/docs/reference/snippets/nodejs/Logger.js
+++ b/src/content/docs/reference/snippets/nodejs/Logger.js
@@ -2,7 +2,7 @@ import arcjet, { shield } from "@arcjet/node";
 import pino from "pino";
 
 const logger =
-  process.env.NODE_ENV === "production"
+  process.env.ARCJET_ENV !== "development"
     ? // JSON in production, default to warn
       pino({ level: process.env.ARCJET_LOG_LEVEL || "warn" })
     : // Pretty print in development, default to debug

--- a/src/content/docs/reference/snippets/nodejs/Logger.ts
+++ b/src/content/docs/reference/snippets/nodejs/Logger.ts
@@ -2,7 +2,7 @@ import arcjet, { shield } from "@arcjet/node";
 import pino, { type Logger } from "pino";
 
 const logger: Logger =
-  process.env.NODE_ENV === "production"
+  process.env.ARCJET_ENV !== "development"
     ? // JSON in production, default to warn
       pino({ level: process.env.ARCJET_LOG_LEVEL || "warn" })
     : // Pretty print in development, default to debug

--- a/src/content/docs/reference/sveltekit.mdx
+++ b/src/content/docs/reference/sveltekit.mdx
@@ -507,9 +507,9 @@ remove the need for null-ish checks.
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 
@@ -566,8 +566,9 @@ Arcjet will automatically detect the IP address of the client making the request
 based on the context provided. The implementation is open source in our
 [@arcjet/ip package](https://github.com/arcjet/arcjet-js/blob/main/ip).
 
-In non-production environments (`NODE_ENV !== "production"`), we allow
-private/internal addresses so that the SDKs work correctly locally.
+In development environments (`NODE_ENV === "development"` or
+`ARCJET_ENV === "development"`), we allow private/internal addresses so that the
+SDKs work correctly locally.
 
 ## Client override
 

--- a/src/content/docs/shield/reference/bun.mdx
+++ b/src/content/docs/shield/reference/bun.mdx
@@ -106,9 +106,9 @@ This example will log the full result as well as the shield rule:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `ARCJET_ENV` is `"production"` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an
 `ERROR` type and you can check the `reason` property for more information, like

--- a/src/content/docs/shield/reference/nextjs.mdx
+++ b/src/content/docs/shield/reference/nextjs.mdx
@@ -209,9 +209,9 @@ Create a new API route at `/pages/api/arcjet.js`:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an
 `ERROR` type and you can check the `reason` property for more information, like

--- a/src/content/docs/shield/reference/nodejs.mdx
+++ b/src/content/docs/shield/reference/nodejs.mdx
@@ -106,9 +106,9 @@ This example will log the full result as well as the shield rule:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an
 `ERROR` type and you can check the `reason` property for more information, like

--- a/src/content/docs/shield/reference/sveltekit.mdx
+++ b/src/content/docs/shield/reference/sveltekit.mdx
@@ -185,9 +185,9 @@ Create a new API route at `/src/routes/api/arcjet/+server.js`:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an
 `ERROR` type and you can check the `reason` property for more information, like

--- a/src/content/docs/signup-protection/reference/bun.mdx
+++ b/src/content/docs/signup-protection/reference/bun.mdx
@@ -138,9 +138,9 @@ users who sign up with a free email address.
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `ARCJET_ENV` is `"production"` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 

--- a/src/content/docs/signup-protection/reference/nextjs.mdx
+++ b/src/content/docs/signup-protection/reference/nextjs.mdx
@@ -172,9 +172,9 @@ users who sign up with a free email address.
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 

--- a/src/content/docs/signup-protection/reference/nodejs.mdx
+++ b/src/content/docs/signup-protection/reference/nodejs.mdx
@@ -138,9 +138,9 @@ users who sign up with a free email address.
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK will also time out and fail open after 500ms
-when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
-the response time will be less than 20-30ms.
+not block all requests. The SDK will also time out and fail open after 1000ms
+when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
+in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition, Arcjet will return an `ERROR` `conclusion`.
 


### PR DESCRIPTION
Awhile ago, we flipped all our logic to check for an explicit `ARCJET_ENV === "development"` or `NODE_ENV === "development"`. If unset, we assume production.

This PR flips all the wording to setting `development` instead of `production`.

Closes #51