### PR TITLE
deps: Update rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3647,9 +3647,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -11984,12 +11984,12 @@
     },
     "node_modules/rollup": {
       "name": "@rollup/wasm-node",
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/wasm-node/-/wasm-node-4.20.0.tgz",
-      "integrity": "sha512-NxIRJDju9ZzXwpCZ+TMYEflT/KJPgcamVrkInPwB/jSzEIEhckHGgbC9C8Fkzt77nEZZpfF/H2BedwKfjxO9qQ==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@rollup/wasm-node/-/wasm-node-4.23.0.tgz",
+      "integrity": "sha512-jEeXqGlX+FpWml3/A15rv1mgNqhY5dyvtX8U5w2ff0p5PkxIjU1Y/GABHEjkoE7EF29ayGBtKR6kUZ+JELtjyg==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.6"
       },
       "bin": {
         "rollup": "dist/bin/rollup"


### PR DESCRIPTION
Dependabot doesn't know how to update dependencies that use `overrides`, so I updated rollup manually.