### PR TITLE
feat: add troubleshooting documentation for health probes and Arcjet

### DIFF
--- a/src/content/docs/rate-limiting/reference/nextjs.mdx
+++ b/src/content/docs/rate-limiting/reference/nextjs.mdx
@@ -242,6 +242,12 @@ Rate limit rules can be configured in two ways:
   configure rules in a single place or apply them globally to all routes, but
   it means the rules are not located alongside the code they are protecting.
 
+:::note
+If you use a platform that performs health checks or liveness probes, ensure
+that Arcjet is not enabled for those routes. These requests will not have all
+of the metadata that Arcjet requires to make security decisions.
+:::
+
 ### Per route
 
 If you define your rate limit within an API route Arcjet assumes that the limit

--- a/src/content/docs/troubleshooting.mdx
+++ b/src/content/docs/troubleshooting.mdx
@@ -22,6 +22,61 @@ You can fix this by ensuring that Arcjet is only called once per request. You
 can combine multiple rules into a single client configuration and/or you can
 exclude routes from your middleware.
 
+### Decision errors from platform liveness or health checks when using Arcjet as a middleware
+
+Platforms like Kubernetes have support for automatic liveness and health
+check probes. These requests do not come from a browser and do not have all
+the same metadata that browsers do (and will not include important headers
+like `X-Real-Ip` or `X-Forwarded-For`). This will cause Arcjet to reject these
+probes, which will make the platform think your app is either not alive or
+unhealthy. This can manifest in CrashLoopBackoff errors in Kubernetes or your
+platform of choice restarting your app constantly.
+
+In order to fix this, omit your healthcheck route from your Arcjet middleware.
+
+#### Next.js
+
+Assuming your app is configured to use the `src` directory and you have your
+Arcjet middleware at `src/middleware.ts`, adjust the `config.matcher` regex
+to include an omission for the `/_healthz` route:
+
+```diff
+ export const config = {
+   // matcher tells Next.js which routes to run the middleware on.
+   // This runs the middleware on all routes except for static assets.
+-  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
++  matcher: ["/((?!_next/static|_next/image|favicon.ico|_healthz).*)"],
+ };
+```
+
+:::note
+Do not include the leading slash in the match that you add. That will cause
+the regex to match on `//_healthz`, which is almost certainly not what you want.
+:::
+
+Then create an API route for your health check logic:
+
+```ts
+// src/app/_healthz/route.ts
+import { NextRequest, NextResponse } from "next/server";
+
+export const GET = async (req: NextRequest) => {
+  // Adjust or remove this as needed depending on how your platform is configured.
+  if (req.headers.get("user-agent") !== "healthz") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return new Response("OK", {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  });
+};
+```
+
+When you deploy your app next, Arcjet should not trigger on this route.
+
 ## Common errors
 
 ### [unauthenticated] invalid key

--- a/src/content/docs/troubleshooting.mdx
+++ b/src/content/docs/troubleshooting.mdx
@@ -9,6 +9,10 @@ import { Tabs, TabItem, Code } from "@astrojs/starlight/components";
 import RequestFieldsExpressTS from "/src/snippets/reference/nodejs/RequestFieldsExpress.ts?raw";
 import RequestFieldsTS from "/src/snippets/reference/nodejs/RequestFields.ts?raw";
 import RequestFieldsHonoNodeTS from "/src/snippets/reference/nodejs/RequestFieldsHonoNode.ts?raw";
+import HealthzRouteAppJS from "/src/snippets/reference/nextjs/HealthzRouteApp.js?raw";
+import HealthzRouteAppTS from "/src/snippets/reference/nextjs/HealthzRouteApp.ts?raw";
+import HealthzRoutePagesJS from "/src/snippets/reference/nextjs/HealthzRoutePages.js?raw";
+import HealthzRoutePagesTS from "/src/snippets/reference/nextjs/HealthzRoutePages.ts?raw";
 
 ## Common problems
 
@@ -36,9 +40,8 @@ In order to fix this, omit your healthcheck route from your Arcjet middleware.
 
 #### Next.js
 
-Assuming your app is configured to use the `src` directory and you have your
-Arcjet middleware at `src/middleware.ts`, adjust the `config.matcher` regex
-to include an omission for the `/healthz` route:
+Assuming you have your Arcjet middleware at `middleware.ts`, adjust the
+`config.matcher` regex to include an omission for the `/healthz` route:
 
 ```diff
  export const config = {
@@ -54,26 +57,28 @@ Do not include the leading slash in the match that you add. That will cause
 the regex to match on `//healthz`, which is almost certainly not what you want.
 :::
 
-Then create an API route for your health check logic:
+<Tabs>
+<TabItem label="TS (App)">
+Then create an API route at `/app/healthz/route.ts`:
 
-```ts
-// src/app/healthz/route.ts
-import { NextRequest, NextResponse } from "next/server";
+<Code code={HealthzRouteAppTS} title="app/healthz/route.ts" lang="ts" />
+</TabItem>
+<TabItem label="TS (Pages)">
+Then create an API route at `/pages/healthz.ts`:
 
-export const GET = async (req: NextRequest) => {
-  // Adjust or remove this as needed depending on how your platform is configured.
-  if (req.headers.get("user-agent") !== "healthz") {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
+<Code code={HealthzRoutePagesTS} title="pages/healthz.ts" lang="ts" />
+</TabItem>
+<TabItem label="JS (App)">
+Then create an API route at `/app/healthz/route.js`:
 
-  return new Response("OK", {
-    status: 200,
-    headers: {
-      "Content-Type": "text/plain",
-    },
-  });
-};
-```
+<Code code={HealthzRouteAppJS} title="app/healthz/route.js" lang="js" />
+</TabItem>
+<TabItem label="JS (Pages)">
+Then create an API route at `/pages/healthz.js`:
+
+<Code code={HealthzRoutePagesJS} title="pages/healthz.js" lang="js" />
+</TabItem>
+</Tabs>
 
 When you deploy your app next, Arcjet should not trigger on this route.
 

--- a/src/content/docs/troubleshooting.mdx
+++ b/src/content/docs/troubleshooting.mdx
@@ -38,26 +38,26 @@ In order to fix this, omit your healthcheck route from your Arcjet middleware.
 
 Assuming your app is configured to use the `src` directory and you have your
 Arcjet middleware at `src/middleware.ts`, adjust the `config.matcher` regex
-to include an omission for the `/_healthz` route:
+to include an omission for the `/healthz` route:
 
 ```diff
  export const config = {
    // matcher tells Next.js which routes to run the middleware on.
    // This runs the middleware on all routes except for static assets.
 -  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
-+  matcher: ["/((?!_next/static|_next/image|favicon.ico|_healthz).*)"],
++  matcher: ["/((?!_next/static|_next/image|favicon.ico|healthz).*)"],
  };
 ```
 
 :::note
 Do not include the leading slash in the match that you add. That will cause
-the regex to match on `//_healthz`, which is almost certainly not what you want.
+the regex to match on `//healthz`, which is almost certainly not what you want.
 :::
 
 Then create an API route for your health check logic:
 
 ```ts
-// src/app/_healthz/route.ts
+// src/app/healthz/route.ts
 import { NextRequest, NextResponse } from "next/server";
 
 export const GET = async (req: NextRequest) => {

--- a/src/snippets/reference/nextjs/HealthzRouteApp.js
+++ b/src/snippets/reference/nextjs/HealthzRouteApp.js
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+export const GET = async (req) => {
+  if (req.headers.get("user-agent") !== "healthz") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return new Response("OK", {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  });
+};

--- a/src/snippets/reference/nextjs/HealthzRouteApp.ts
+++ b/src/snippets/reference/nextjs/HealthzRouteApp.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const GET = async (req: NextRequest) => {
+  if (req.headers.get("user-agent") !== "healthz") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return new Response("OK", {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  });
+};

--- a/src/snippets/reference/nextjs/HealthzRoutePages.js
+++ b/src/snippets/reference/nextjs/HealthzRoutePages.js
@@ -1,0 +1,7 @@
+export default function handler(req, res) {
+  if (req.headers["user-agent"] !== "healthz") {
+    return res.status(404).send("Not found");
+  }
+
+  res.status(200).send("OK");
+}

--- a/src/snippets/reference/nextjs/HealthzRoutePages.ts
+++ b/src/snippets/reference/nextjs/HealthzRoutePages.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.headers["user-agent"] !== "healthz") {
+    return res.status(404).send("Not found");
+  }
+
+  res.status(200).send("OK");
+}


### PR DESCRIPTION
Closes #112 

I wasn't able to find anywhere else that included a copy-and-paste example of a middleware with Arcjet, so I included the fix for Next.js.

Please let me know if this should be moved somewhere else, I wasn't able to find a good home for this in the existing ontology so I took a guess.