### PR TITLE
chore: Add example of handling missing user-agent header

### DIFF
--- a/src/content/docs/bot-protection/concepts.mdx
+++ b/src/content/docs/bot-protection/concepts.mdx
@@ -36,14 +36,27 @@ Arcjet will help you reduce bot traffic and give you more control over which
 requests reach your application, but it's important to understand that it's not
 possible to achieve 100% accuracy.
 
-:::note
-Please be aware that requests without `User-Agent` headers can not be identified
-as any particular bot and will be marked as an errored decision. Developers
-should take caution to check `decision.isErrored()` and decide if you want to
-allow or deny the request. See the Error Handling section in the SDK reference
-for an example. Our recommendation is to block requests without `User-Agent`
-headers because most clients always send this header.
-:::
+### `User-Agent` header
+
+Requests without `User-Agent` headers can not be identified as any particular
+bot and will be marked as an errored decision. Check `decision.isErrored()` and
+decide if you want to allow or deny the request. Our recommendation is to block
+requests without `User-Agent` headers because most legitimate clients always
+send this header.
+
+```ts
+if (decision.isErrored()) {
+  if (decision.reason.message.includes("missing User-Agent header")) {
+    log.warn({ error: decision.reason.message }, "Arcjet user-agent warning");
+    // You could return a 400 Bad request error here
+    // Next.js example:
+    // return NextResponse.json({ error: "Bad request" }, { status: 400 });
+  } else {
+    // Just log the error and continue
+    log.error({ error: decision.reason.message }, "Arcjet error");
+  }
+}
+```
 
 ## Blocking based on fingerprint
 

--- a/src/content/docs/bot-protection/identifying-bots.mdx
+++ b/src/content/docs/bot-protection/identifying-bots.mdx
@@ -19,12 +19,13 @@ This list is used to allow developers to choose to allow or deny any or all of
 these bots.
 
 :::note
-Please be aware that requests without `User-Agent` headers can not be identified
-as any particular bot and will be marked as an errored decision. Developers
-should take caution to check `decision.isErrored()` and decide if you want to
-allow or deny the request. See the Error Handling section in the SDK reference
-for an example. Our recommendation is to block requests without `User-Agent`
-headers because most clients always send this header.
+Requests without `User-Agent` headers can not be identified as any particular
+bot and will be marked as an errored decision. Check `decision.isErrored()` and
+decide if you want to allow or deny the request. Our recommendation is to block
+requests without `User-Agent` headers because most legitimate clients always
+send this header.
+
+See [an example of how to do this](/bot-protection/concepts#user-agent-header).
 :::
 
 ## Known bots

--- a/src/content/docs/bot-protection/reference/bun.mdx
+++ b/src/content/docs/bot-protection/reference/bun.mdx
@@ -170,11 +170,13 @@ If there is an error condition, Arcjet will return an
 accessing `decision.reason.message`.
 
 :::note
-Please be aware that requests without `User-Agent` headers can not be identified
-as any particular bot and will be marked as an errored decision. Developers
-should take caution to check `decision.isErrored()` and decide if you want to
-allow or deny the request. Our recommendation is to block requests without
-`User-Agent` headers because most clients always send this header.
+Requests without `User-Agent` headers can not be identified as any particular
+bot and will be marked as an errored decision. Check `decision.isErrored()` and
+decide if you want to allow or deny the request. Our recommendation is to block
+requests without `User-Agent` headers because most legitimate clients always
+send this header.
+
+See [an example of how to do this](/bot-protection/concepts#user-agent-header).
 :::
 
 <Tabs>

--- a/src/content/docs/bot-protection/reference/nextjs.mdx
+++ b/src/content/docs/bot-protection/reference/nextjs.mdx
@@ -390,11 +390,13 @@ If there is an error condition, Arcjet will return an
 accessing `decision.reason.message`.
 
 :::note
-Please be aware that requests without `User-Agent` headers can not be identified
-as any particular bot and will be marked as an errored decision. Developers
-should take caution to check `decision.isErrored()` and decide if you want to
-allow or deny the request. Our recommendation is to block requests without
-`User-Agent` headers because most clients always send this header.
+Requests without `User-Agent` headers can not be identified as any particular
+bot and will be marked as an errored decision. Check `decision.isErrored()` and
+decide if you want to allow or deny the request. Our recommendation is to block
+requests without `User-Agent` headers because most legitimate clients always
+send this header.
+
+See [an example of how to do this](/bot-protection/concepts#user-agent-header).
 :::
 
 <Tabs>

--- a/src/content/docs/bot-protection/reference/nodejs.mdx
+++ b/src/content/docs/bot-protection/reference/nodejs.mdx
@@ -170,11 +170,13 @@ If there is an error condition, Arcjet will return an
 accessing `decision.reason.message`.
 
 :::note
-Please be aware that requests without `User-Agent` headers can not be identified
-as any particular bot and will be marked as an errored decision. Developers
-should take caution to check `decision.isErrored()` and decide if you want to
-allow or deny the request. Our recommendation is to block requests without
-`User-Agent` headers because most clients always send this header.
+Requests without `User-Agent` headers can not be identified as any particular
+bot and will be marked as an errored decision. Check `decision.isErrored()` and
+decide if you want to allow or deny the request. Our recommendation is to block
+requests without `User-Agent` headers because most legitimate clients always
+send this header.
+
+See [an example of how to do this](/bot-protection/concepts#user-agent-header).
 :::
 
 <Tabs>

--- a/src/content/docs/bot-protection/reference/sveltekit.mdx
+++ b/src/content/docs/bot-protection/reference/sveltekit.mdx
@@ -246,11 +246,13 @@ If there is an error condition, Arcjet will return an
 accessing `decision.reason.message`.
 
 :::note
-Please be aware that requests without `User-Agent` headers can not be identified
-as any particular bot and will be marked as an errored decision. Developers
-should take caution to check `decision.isErrored()` and decide if you want to
-allow or deny the request. Our recommendation is to block requests without
-`User-Agent` headers because most clients always send this header.
+Requests without `User-Agent` headers can not be identified as any particular
+bot and will be marked as an errored decision. Check `decision.isErrored()` and
+decide if you want to allow or deny the request. Our recommendation is to block
+requests without `User-Agent` headers because most legitimate clients always
+send this header.
+
+See [an example of how to do this](/bot-protection/concepts#user-agent-header).
 :::
 
 <Tabs>


### PR DESCRIPTION
Extended example of how to detect the missing user agent error.
