### PR TITLE
fix: improve and differentiate heading style

### DIFF
--- a/src/styles/docs/index.scss
+++ b/src/styles/docs/index.scss
@@ -2,5 +2,11 @@
   h4 {
     margin-top: 0 !important;
     margin-bottom: calc(var(--sp) * 2);
+
+    font-size: 20px;
+    text-transform: none;
+    line-height: 1.3em;
+
+    color: var(--aj-palette-txt-primary);
   }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -254,21 +254,28 @@ h3,
   line-height: 1.5em;
 }
 
-h4 {
+h4,
+.sl-markdown-content h4 {
   font-size: 20px;
+  text-transform: uppercase;
   line-height: 1.3em;
 
   color: var(--aj-palette-txt-secondary);
 }
 
-h5 {
+h5,
+.sl-markdown-content h5 {
   font-size: 18px;
   line-height: 1.3em;
 }
 
-h6 {
-  font-size: 16px;
+h6,
+.sl-markdown-content h6 {
+  font-size: 14px;
   line-height: 1.3em;
+  text-transform: uppercase;
+
+  color: var(--aj-palette-txt-secondary);
 }
 
 .sl-markdown-content


### PR DESCRIPTION
Improved heading styling for h4 and below, eg:

Turns this:
<img width="784" alt="image" src="https://github.com/user-attachments/assets/b0269227-4bd4-4538-bf99-66f2d153d36a">

To this:
<img width="789" alt="image" src="https://github.com/user-attachments/assets/3cebf8e5-75df-443b-b06c-4d066bf553ee">
