### PR TITLE
fix: imports for node quickstart

### DIFF
--- a/src/snippets/get-started/node-js-express/Express.js
+++ b/src/snippets/get-started/node-js-express/Express.js
@@ -1,4 +1,4 @@
-import arcjet, { fixedWindow } from "@arcjet/node";
+import arcjet, { shield, detectBot, tokenBucket } from "@arcjet/node";
 import express from "express";
 
 const app = express();


### PR DESCRIPTION
Node + express quickstart doesn't import the rules that will be used.
