### PR TITLE
chore: Remove unused import in Remix docs

### DIFF
--- a/src/snippets/get-started/remix/Step3.tsx
+++ b/src/snippets/get-started/remix/Step3.tsx
@@ -1,6 +1,5 @@
 import arcjet, { detectBot, shield, tokenBucket } from "@arcjet/remix";
 import type { LoaderFunctionArgs } from "@remix-run/node";
-import { json } from "@remix-run/node";
 
 const aj = arcjet({
   key: process.env.ARCJET_KEY!,


### PR DESCRIPTION
This import is unused in our example.