### PR TITLE
chore: Add instruction to create file for all getting started guides

### DIFF
--- a/src/snippets/get-started/bun-hono/Step3.mdx
+++ b/src/snippets/get-started/bun-hono/Step3.mdx
@@ -4,8 +4,9 @@ import SelectableContent from "@/components/SelectableContent";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
+    Create a new file at `index.ts` with the contents:
 
-    <Code code={Step3TS} lang="ts" title="/index.ts" />
+    <Code code={Step3TS} lang="ts" title="index.ts" />
 
   </div>
 </SelectableContent>

--- a/src/snippets/get-started/bun/Step3.mdx
+++ b/src/snippets/get-started/bun/Step3.mdx
@@ -5,13 +5,15 @@ import SelectableContent from "@/components/SelectableContent";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
+    Create a new file at `index.ts` with the contents:
 
     <Code code={Step3TS} lang="ts" title="index.ts" />
 
   </div>
   <div slot="JS" slotIdx="2">
+    Create a new file at `index.js` with the contents:
 
-    <Code code={Step3JS} lang="ts" title="index.js" />
+    <Code code={Step3JS} lang="js" title="index.js" />
 
   </div>
 </SelectableContent>

--- a/src/snippets/get-started/nest-js/Step3.mdx
+++ b/src/snippets/get-started/nest-js/Step3.mdx
@@ -3,7 +3,9 @@ import { Code } from "@astrojs/starlight/components";
 import GlobalGuard from "/src/snippets/get-started/nest-js/GlobalGuard.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
-  <Code code={GlobalGuard} lang="ts" title="src/main.ts" />
+Update your `src/main.ts` file with the contents:
+
+<Code code={GlobalGuard} lang="ts" title="src/main.ts" />
 
 This creates a global guard that will be applied to all routes. In a real
 application, implementing guards or per-route protections would give you more

--- a/src/snippets/get-started/node-js-express/Step3.mdx
+++ b/src/snippets/get-started/node-js-express/Step3.mdx
@@ -4,6 +4,9 @@ import Express from "/src/snippets/get-started/node-js-express/Express.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="JS" slotIdx="1">
+    Create a new route at `index.js` with the contents:
+
     <Code code={Express} lang="js" title="index.js" />
+
   </div>
 </SelectableContent>

--- a/src/snippets/get-started/node-js-hono/Step3.mdx
+++ b/src/snippets/get-started/node-js-hono/Step3.mdx
@@ -3,7 +3,10 @@ import { Code } from "@astrojs/starlight/components";
 import Step3 from "/src/snippets/get-started/node-js-hono/Step3.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
-  <div slot="JS" slotIdx="1">
+  <div slot="TS" slotIdx="1">
+    Create a new route at `index.ts` with the contents:
+
     <Code code={Step3} lang="ts" title="src/index.ts" />
+
   </div>
 </SelectableContent>

--- a/src/snippets/get-started/node-js/Step3.mdx
+++ b/src/snippets/get-started/node-js/Step3.mdx
@@ -5,9 +5,15 @@ import Step3TS from "/src/snippets/get-started/node-js/Step3.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
+    Create a new route at `index.ts` with the contents:
+
     <Code code={Step3TS} lang="ts" title="index.ts" />
+
   </div>
   <div slot="JS" slotIdx="2">
-    <Code code={Step3JS} lang="ts" title="index.js" />
+    Create a new route at `index.js` with the contents:
+
+    <Code code={Step3JS} lang="js" title="index.js" />
+
   </div>
 </SelectableContent>

--- a/src/snippets/get-started/remix/Step3.mdx
+++ b/src/snippets/get-started/remix/Step3.mdx
@@ -1,9 +1,12 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import Step3 from "/src/snippets/get-started/remix/Step3.tsx?raw";
+import Step3 from "@/snippets/get-started/remix/Step3.tsx?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
+    Create a new route at `app/routes/arcjet.ts` with the contents:
+
     <Code code={Step3} lang="ts" title="app/routes/arcjet.tsx" />
+
   </div>
 </SelectableContent>


### PR DESCRIPTION
I think we should instruct the user to create a file where the contents will be in all examples. We currently do this in next and svelte but not in others.

Replaces #185