### PR TITLE
fix: Populate code switcher for NestJS

### DIFF
--- a/src/snippets/get-started/nest-js/Step3.mdx
+++ b/src/snippets/get-started/nest-js/Step3.mdx
@@ -3,13 +3,15 @@ import { Code } from "@astrojs/starlight/components";
 import GlobalGuard from "/src/snippets/get-started/nest-js/GlobalGuard.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
-Update your `src/main.ts` file with the contents:
+<div slot="TS" slotIdx="1">
+  Update your `src/main.ts` file with the contents:
 
-<Code code={GlobalGuard} lang="ts" title="src/main.ts" />
+  <Code code={GlobalGuard} lang="ts" title="src/main.ts" />
 
-This creates a global guard that will be applied to all routes. In a real
-application, implementing guards or per-route protections would give you more
-flexibility. See [our example app](https://github.com/arcjet/example-nestjs) for
-how to do this.
+  This creates a global guard that will be applied to all routes. In a real
+  application, implementing guards or per-route protections would give you more
+  flexibility. See [our example app](https://github.com/arcjet/example-nestjs) for
+  how to do this.
 
+</div>
 </SelectableContent>


### PR DESCRIPTION
Closes #187

No slots were specified for the NestJS switcher.