### PR TITLE
fix: show aside for tsx too

### DIFF
--- a/src/snippets/bot-protection/quick-start/nodejs/Step4.mdx
+++ b/src/snippets/bot-protection/quick-start/nodejs/Step4.mdx
@@ -5,13 +5,6 @@ import SelectableContent from "@/components/SelectableContent";
 
 Start your Node.js server:
 
-<Aside type="note" title="env files">
-  Node 20+ supports loading environment variables from a local file with
-  `--env-file`. If you're using an older version of Node, you can use a package
-  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
-  variables from a `.env.local` file.
-</Aside>
-
 {/* prettier-ignore */}
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
@@ -25,6 +18,13 @@ Start your Node.js server:
   ```
   </div>
 </SelectableContent>
+
+<Aside type="note" title="env files">
+  Node 20+ supports loading environment variables from a local file with
+  `--env-file`. If you're using an older version of Node, you can use a package
+  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
+  variables from a `.env.local` file.
+</Aside>
 
 Make a `curl` request from your terminal to your application. You should see a
 `403 Forbidden` response because `curl` is considered an automated client by

--- a/src/snippets/email-validation/quick-start/nodejs/Step4.mdx
+++ b/src/snippets/email-validation/quick-start/nodejs/Step4.mdx
@@ -3,13 +3,6 @@ import SelectableContent from "@/components/SelectableContent";
 
 ### 4. Start server
 
-<Aside type="note" title="env files">
-  Node 20+ supports loading environment variables from a local file with
-  `--env-file`. If you're using an older version of Node, you can use a package
-  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
-  variables from a `.env.local` file.
-</Aside>
-
 {/* prettier-ignore */}
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
@@ -27,6 +20,13 @@ node --env-file .env.local index.js
 
   </div>
 </SelectableContent>
+
+<Aside type="note" title="env files">
+  Node 20+ supports loading environment variables from a local file with
+  `--env-file`. If you're using an older version of Node, you can use a package
+  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
+  variables from a `.env.local` file.
+</Aside>
 
 Make a `curl` `POST` request from your terminal to your application with various
 emails to test the result.

--- a/src/snippets/get-started/node-js-express/Step4.mdx
+++ b/src/snippets/get-started/node-js-express/Step4.mdx
@@ -2,17 +2,17 @@ import { Aside } from "@astrojs/starlight/components";
 
 ## 4. Start app
 
+{/* prettier-ignore */}
+```sh
+node --env-file .env.local index.js
+```
+
 <Aside type="note" title="env files">
   Node 20+ supports loading environment variables from a local file with
   `--env-file`. If you're using an older version of Node, you can use a package
   like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
   variables from a `.env.local` file.
 </Aside>
-
-{/* prettier-ignore */}
-```sh
-node --env-file .env.local index.js
-```
 
 Visit [`http://localhost:3000`](http://localhost:3000) in your browser and
 refresh a few times to hit the rate limit.

--- a/src/snippets/get-started/node-js/Step4.mdx
+++ b/src/snippets/get-started/node-js/Step4.mdx
@@ -4,24 +4,22 @@ import { Aside } from "@astrojs/starlight/components";
 ## 4. Start app
 
 {/* prettier-ignore */}
-<SelectableContent client:load syncKey="language" frameworkSwitcher>
-  <div slot="TS" slotIdx="1">
-  ```sh
-  npx tsx --env-file .env.local index.ts
-  ```
-  </div>
-  <div slot="JS" slotIdx="2">
-  <Aside type="note" title="env files">
+<Aside type="note" title="env files">
   Node 20+ supports loading environment variables from a local file with
   `--env-file`. If you're using an older version of Node, you can use a package
   like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
   variables from a `.env.local` file.
 </Aside>
-
-```sh
-node --env-file .env.local index.js
-```
-
+<SelectableContent client:load syncKey="language" frameworkSwitcher>
+  <div slot="TS" slotIdx="1">
+    ```sh
+    npx tsx --env-file .env.local index.ts
+    ```
+  </div>
+  <div slot="JS" slotIdx="2">
+    ```sh
+    node --env-file .env.local index.js
+    ```
   </div>
 </SelectableContent>
 

--- a/src/snippets/get-started/node-js/Step4.mdx
+++ b/src/snippets/get-started/node-js/Step4.mdx
@@ -4,12 +4,6 @@ import { Aside } from "@astrojs/starlight/components";
 ## 4. Start app
 
 {/* prettier-ignore */}
-<Aside type="note" title="env files">
-  Node 20+ supports loading environment variables from a local file with
-  `--env-file`. If you're using an older version of Node, you can use a package
-  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
-  variables from a `.env.local` file.
-</Aside>
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
     ```sh
@@ -22,6 +16,13 @@ import { Aside } from "@astrojs/starlight/components";
     ```
   </div>
 </SelectableContent>
+
+<Aside type="note" title="env files">
+  Node 20+ supports loading environment variables from a local file with
+  `--env-file`. If you're using an older version of Node, you can use a package
+  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
+  variables from a `.env.local` file.
+</Aside>
 
 Visit [`http://localhost:8000`](http://localhost:8000) in your browser and
 refresh a few times to hit the rate limit.

--- a/src/snippets/rate-limiting/quick-start/nodejs/Step4.mdx
+++ b/src/snippets/rate-limiting/quick-start/nodejs/Step4.mdx
@@ -3,13 +3,6 @@ import SelectableContent from "@/components/SelectableContent";
 
 ### 4. Start server
 
-<Aside type="note" title="env files">
-  Node 20+ supports loading environment variables from a local file with
-  `--env-file`. If you're using an older version of Node, you can use a package
-  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
-  variables from a `.env.local` file.
-</Aside>
-
 {/* prettier-ignore */}
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
@@ -27,6 +20,13 @@ node --env-file .env.local index.js
 
   </div>
 </SelectableContent>
+
+<Aside type="note" title="env files">
+  Node 20+ supports loading environment variables from a local file with
+  `--env-file`. If you're using an older version of Node, you can use a package
+  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
+  variables from a `.env.local` file.
+</Aside>
 
 Then make some requests to hit the rate limit:
 

--- a/src/snippets/shield/quick-start/nodejs/Step4.mdx
+++ b/src/snippets/shield/quick-start/nodejs/Step4.mdx
@@ -3,13 +3,6 @@ import SelectableContent from "@/components/SelectableContent";
 
 ### 4. Start server
 
-<Aside type="note" title="env files">
-  Node 20+ supports loading environment variables from a local file with
-  `--env-file`. If you're using an older version of Node, you can use a package
-  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
-  variables from a `.env.local` file.
-</Aside>
-
 {/* prettier-ignore */}
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
@@ -27,3 +20,10 @@ node --env-file .env.local index.js
 
   </div>
 </SelectableContent>
+
+<Aside type="note" title="env files">
+  Node 20+ supports loading environment variables from a local file with
+  `--env-file`. If you're using an older version of Node, you can use a package
+  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
+  variables from a `.env.local` file.
+</Aside>

--- a/src/snippets/signup-protection/quick-start/nodejs/Step4.mdx
+++ b/src/snippets/signup-protection/quick-start/nodejs/Step4.mdx
@@ -3,13 +3,6 @@ import SelectableContent from "@/components/SelectableContent";
 
 ### 4. Start server
 
-<Aside type="note" title="env files">
-  Node 20+ supports loading environment variables from a local file with
-  `--env-file`. If you're using an older version of Node, you can use a package
-  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
-  variables from a `.env.local` file.
-</Aside>
-
 {/* prettier-ignore */}
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <Fragment slot="TS">
@@ -23,6 +16,13 @@ import SelectableContent from "@/components/SelectableContent";
   ```
   </Fragment>
 </SelectableContent>
+
+<Aside type="note" title="env files">
+  Node 20+ supports loading environment variables from a local file with
+  `--env-file`. If you're using an older version of Node, you can use a package
+  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
+  variables from a `.env.local` file.
+</Aside>
 
 Make a `curl` `POST` request from your terminal to your application with various
 emails to test the result.


### PR DESCRIPTION
The content in the aside is relevant for `npx tsx` as well as `node` so we should show it to both.
