### PR TITLE
fix: correct method name

### DIFF
--- a/src/content/docs/reference/bun.mdx
+++ b/src/content/docs/reference/bun.mdx
@@ -265,7 +265,7 @@ which rule caused the conclusion:
   and the request is suspicious based on analysis by Arcjet Shield.
 - `isEmail()` (`bool`) - Returns `true` if the email validation rules have been
   applied and the email address has a problem.
-- `isErrored()` (`bool`) - Returns `true` if there was an error processing the
+- `isError()` (`bool`) - Returns `true` if there was an error processing the
   request.
 
 ### Results

--- a/src/content/docs/reference/nextjs.mdx
+++ b/src/content/docs/reference/nextjs.mdx
@@ -358,7 +358,7 @@ which rule caused the conclusion:
   and the request is suspicious based on analysis by Arcjet Shield.
 - `isEmail()` (`bool`) - Returns `true` if the email validation rules have been
   applied and the email address has a problem.
-- `isErrored()` (`bool`) - Returns `true` if there was an error processing the
+- `isError()` (`bool`) - Returns `true` if there was an error processing the
   request.
 
 ### Results

--- a/src/content/docs/reference/nodejs.mdx
+++ b/src/content/docs/reference/nodejs.mdx
@@ -235,7 +235,7 @@ which rule caused the conclusion:
   and the request is suspicious based on analysis by Arcjet Shield.
 - `isEmail()` (`bool`) - Returns `true` if the email rules have been applied and
   the email address has a problem.
-- `isErrored()` (`bool`) - Returns `true` if there was an error processing the
+- `isError()` (`bool`) - Returns `true` if there was an error processing the
   request.
 
 ### Results

--- a/src/content/docs/reference/sveltekit.mdx
+++ b/src/content/docs/reference/sveltekit.mdx
@@ -274,7 +274,7 @@ which rule caused the conclusion:
   and the request is suspicious based on analysis by Arcjet Shield.
 - `isEmail()` (`bool`) - Returns `true` if the email validation rules have been
   applied and the email address has a problem.
-- `isErrored()` (`bool`) - Returns `true` if there was an error processing the
+- `isError()` (`bool`) - Returns `true` if there was an error processing the
   request.
 
 ### Results


### PR DESCRIPTION
The correct method name on the Reason object is `.isError()`, not `.isErrored()`
