### PR TITLE
chore: Add note about bun reload

### DIFF
--- a/src/snippets/get-started/bun-hono/Step4.mdx
+++ b/src/snippets/get-started/bun-hono/Step4.mdx
@@ -4,6 +4,12 @@
 bun run --hot index.ts
 ```
 
+:::note
+Bun's `--hot` flag will reload the runtime when changes are made to your `.ts`
+files, but not your `.env.local` file. If you change your `.env.local` file,
+you need to restart the command manually.
+:::
+
 Visit [`http://localhost:3000`](http://localhost:3000) in your browser and
 refresh a few times to hit the rate limit. You may see 2 requests - one for the
 page and one for a favicon.

--- a/src/snippets/get-started/bun/Step4.mdx
+++ b/src/snippets/get-started/bun/Step4.mdx
@@ -4,6 +4,12 @@
 bun run --hot index.ts
 ```
 
+:::note
+Bun's `--hot` flag will reload the runtime when changes are made to your `.ts`
+files, but not your `.env.local` file. If you change your `.env.local` file,
+you need to restart the command manually.
+:::
+
 Visit [`http://localhost:3000`](http://localhost:3000) in your browser and
 refresh a few times to hit the rate limit. You may see 2 requests - one for the
 page and one for a favicon.


### PR DESCRIPTION
Closes #195

If the `.env.local` file isn't set up correctly, the users might think their app will reload due to `--hot`.