### PR TITLE
fix: sync bot protection step4

### DIFF
--- a/src/snippets/bot-protection/quick-start/bun/Step4.mdx
+++ b/src/snippets/bot-protection/quick-start/bun/Step4.mdx
@@ -5,7 +5,7 @@ import SelectableContent from "@/components/SelectableContent";
 Start your Bun server:
 
 {/* prettier-ignore */}
-<SelectableContent client:load syncKey="language" frameworkSwitcher>
+<SelectableContent client:load syncKey="packageManager" frameworkSwitcher>
 <div slot="TS" slotIdx="1">
   ```sh
   bun run --hot index.ts
@@ -22,7 +22,8 @@ Make a `curl` request from your terminal. You should see a `403 Forbidden`
 response because `curl` is considered an automated client by default.
 
 ```sh
-curl http://localhost:3000
+# Will show the response status, which should be 403 forbidden
+curl -i http://localhost:3000
 ```
 
 The requests will also show up in the [Arcjet

--- a/src/snippets/bot-protection/quick-start/nextjs/Step4.mdx
+++ b/src/snippets/bot-protection/quick-start/nextjs/Step4.mdx
@@ -5,7 +5,7 @@ import SelectableContent from "@/components/SelectableContent";
 Start your Next.js app:
 
 {/* prettier-ignore */}
-<SelectableContent client:load syncKey="packageManager">
+<SelectableContent client:load syncKey="packageManager" frameworkSwitcher>
 <div slot="npm" slotIdx="1">
 ```sh
 npm run dev
@@ -29,8 +29,8 @@ default. See [the reference guide](/bot-protection/reference) to learn about
 configuring this.
 
 ```shell
-# Will show just the response headers, which should be 403 forbidden
-curl -I http://localhost:3000
+# Will show the response headers, which should be 403 forbidden
+curl -i http://localhost:3000
 ```
 
 The requests will also show up in the [Arcjet

--- a/src/snippets/bot-protection/quick-start/nodejs/Step4.mdx
+++ b/src/snippets/bot-protection/quick-start/nodejs/Step4.mdx
@@ -6,7 +6,7 @@ import SelectableContent from "@/components/SelectableContent";
 Start your Node.js server:
 
 {/* prettier-ignore */}
-<SelectableContent client:load syncKey="language" frameworkSwitcher>
+<SelectableContent client:load syncKey="packageManager" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
   ```sh
   npx tsx --env-file .env.local index.ts
@@ -32,7 +32,8 @@ default. See [the reference guide](/bot-protection/reference) to learn about
 configuring this.
 
 ```shell
-curl http://localhost:8000
+# Will show the response headers, which should be 403 forbidden
+curl -i http://localhost:8000
 ```
 
 The requests will also show up in the [Arcjet

--- a/src/snippets/bot-protection/quick-start/sveltekit/Step4.mdx
+++ b/src/snippets/bot-protection/quick-start/sveltekit/Step4.mdx
@@ -5,7 +5,7 @@ import SelectableContent from "@/components/SelectableContent";
 Start your SvelteKit app:
 
 {/* prettier-ignore */}
-<SelectableContent client:load syncKey="packageManager">
+<SelectableContent client:load syncKey="packageManager" frameworkSwitcher>
 <div slot="npm" slotIdx="1">
 ```sh
 npm run dev
@@ -29,8 +29,8 @@ default. See [the reference guide](/bot-protection/reference) to learn about
 configuring this.
 
 ```shell
-# Will show just the response headers, which should be 403 forbidden
-curl -I http://localhost:5173
+# Will show the response status, which should be 403 forbidden
+curl -i http://localhost:5173
 ```
 
 The requests will also show up in the [Arcjet


### PR DESCRIPTION
The Step 4 for bot detection is different based on the framework.
We either show the framework switcher or don't depending on the framework.
In some examples we don't use a `-i` flag so users won't see the response status.
I also switched some from `-I` to `-i` because `-I` sends a head request.
