### PR TITLE
fix: Move env file name to framework snippets for getting started

### DIFF
--- a/src/content/docs/get-started.mdx
+++ b/src/content/docs/get-started.mdx
@@ -179,8 +179,7 @@ In your project root, run the following command:
 ## 2. Set your key
 
 [Create a free Arcjet account](https://app.arcjet.com) then follow the
-instructions to add a site and get a key. Add it to a `.env.local` file the
-project root.
+instructions to add a site and get a key.
 
 <SlotByFramework client:load>
   <BunStep2 slot="bun" />

--- a/src/snippets/get-started/bun-hono/Step2.mdx
+++ b/src/snippets/get-started/bun-hono/Step2.mdx
@@ -1,4 +1,4 @@
-Add your key to a `.env.local` file your project root.
+Add your key to a `.env.local` file in your project root.
 
 ```ini title=".env.local"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev

--- a/src/snippets/get-started/bun-hono/Step2.mdx
+++ b/src/snippets/get-started/bun-hono/Step2.mdx
@@ -1,3 +1,5 @@
+Add your key to a `.env.local` file your project root.
+
 ```ini title=".env.local"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev
 # You can leave this unset in prod
@@ -5,3 +7,9 @@ ARCJET_ENV=development
 # Get your site key from https://app.arcjet.com
 ARCJET_KEY=ajkey_yourkey
 ```
+
+:::caution[IP Address]
+Arcjet only accepts non-local IP addresses with a fallback to 127.0.0.1 in
+development mode. Since Bun doesn't set `NODE_ENV` for you, you also need to
+set `ARCJET_ENV` in your environment file.
+:::

--- a/src/snippets/get-started/bun/Step2.mdx
+++ b/src/snippets/get-started/bun/Step2.mdx
@@ -1,4 +1,4 @@
-Add your key to a `.env.local` file your project root.
+Add your key to a `.env.local` file in your project root.
 
 ```ini title=".env.local"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev

--- a/src/snippets/get-started/bun/Step2.mdx
+++ b/src/snippets/get-started/bun/Step2.mdx
@@ -1,3 +1,5 @@
+Add your key to a `.env.local` file your project root.
+
 ```ini title=".env.local"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev
 # You can leave this unset in prod
@@ -5,3 +7,9 @@ ARCJET_ENV=development
 # Get your site key from https://app.arcjet.com
 ARCJET_KEY=ajkey_yourkey
 ```
+
+:::caution[IP Address]
+Arcjet only accepts non-local IP addresses with a fallback to 127.0.0.1 in
+development mode. Since Bun doesn't set `NODE_ENV` for you, you also need to
+set `ARCJET_ENV` in your environment file.
+:::

--- a/src/snippets/get-started/deno/Step2.mdx
+++ b/src/snippets/get-started/deno/Step2.mdx
@@ -1,11 +1,15 @@
-Arcjet only accepts non-local IP addresses with a fallback to 127.0.0.1 in
-development mode. Since Deno doesn't set `NODE_ENV` for you, you also need to
-set `ARCJET_ENV` in your environment file.
+Add your key to a `.env` file your project root.
 
-```ini title=".env.local"
+```ini title=".env"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev
 # You can leave this unset in prod
 ARCJET_ENV=development
 # Get your site key from https://app.arcjet.com
 ARCJET_KEY=ajkey_yourkey
 ```
+
+:::caution[IP Address]
+Arcjet only accepts non-local IP addresses with a fallback to 127.0.0.1 in
+development mode. Since Deno doesn't set `NODE_ENV` for you, you also need to
+set `ARCJET_ENV` in your environment file.
+:::

--- a/src/snippets/get-started/deno/Step2.mdx
+++ b/src/snippets/get-started/deno/Step2.mdx
@@ -1,4 +1,4 @@
-Add your key to a `.env` file your project root.
+Add your key to a `.env` file in your project root.
 
 ```ini title=".env"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev

--- a/src/snippets/get-started/nest-js/GlobalGuard.ts
+++ b/src/snippets/get-started/nest-js/GlobalGuard.ts
@@ -13,7 +13,6 @@ import { APP_GUARD, NestFactory } from "@nestjs/core";
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      envFilePath: ".env.local",
     }),
     ArcjetModule.forRoot({
       isGlobal: true,

--- a/src/snippets/get-started/nest-js/Step2.mdx
+++ b/src/snippets/get-started/nest-js/Step2.mdx
@@ -1,4 +1,4 @@
-Add your key to a `.env` file your project root.
+Add your key to a `.env` file in your project root.
 
 ```ini title=".env"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev

--- a/src/snippets/get-started/nest-js/Step2.mdx
+++ b/src/snippets/get-started/nest-js/Step2.mdx
@@ -1,7 +1,15 @@
-```ini title=".env.local"
+Add your key to a `.env` file your project root.
+
+```ini title=".env"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev
 # You can leave this unset in prod
 ARCJET_ENV=development
 # Get your site key from https://app.arcjet.com
 ARCJET_KEY=ajkey_yourkey
 ```
+
+:::caution[IP Address]
+Arcjet only accepts non-local IP addresses with a fallback to 127.0.0.1 in
+development mode. Since NestJS doesn't set `NODE_ENV` for you, you also need to
+set `ARCJET_ENV` in your environment file.
+:::

--- a/src/snippets/get-started/next-js/Step2.mdx
+++ b/src/snippets/get-started/next-js/Step2.mdx
@@ -1,3 +1,5 @@
+Add your key to a `.env.local` file your project root.
+
 ```ini title=".env.local"
 ARCJET_KEY=ajkey_yourkey
 ```

--- a/src/snippets/get-started/next-js/Step2.mdx
+++ b/src/snippets/get-started/next-js/Step2.mdx
@@ -1,4 +1,4 @@
-Add your key to a `.env.local` file your project root.
+Add your key to a `.env.local` file in your project root.
 
 ```ini title=".env.local"
 ARCJET_KEY=ajkey_yourkey

--- a/src/snippets/get-started/node-js-express/Step2.mdx
+++ b/src/snippets/get-started/node-js-express/Step2.mdx
@@ -1,4 +1,4 @@
-Add your key to a `.env.local` file your project root.
+Add your key to a `.env.local` file in your project root.
 
 ```ini title=".env.local"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev

--- a/src/snippets/get-started/node-js-express/Step2.mdx
+++ b/src/snippets/get-started/node-js-express/Step2.mdx
@@ -1,3 +1,5 @@
+Add your key to a `.env.local` file your project root.
+
 ```ini title=".env.local"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev
 # You can leave this unset in prod
@@ -5,3 +7,9 @@ ARCJET_ENV=development
 # Get your site key from https://app.arcjet.com
 ARCJET_KEY=ajkey_yourkey
 ```
+
+:::caution[IP Address]
+Arcjet only accepts non-local IP addresses with a fallback to 127.0.0.1 in
+development mode. Since Node.js doesn't set `NODE_ENV` for you, you also need to
+set `ARCJET_ENV` in your environment file.
+:::

--- a/src/snippets/get-started/node-js-hono/Step2.mdx
+++ b/src/snippets/get-started/node-js-hono/Step2.mdx
@@ -1,6 +1,6 @@
 import { Aside } from "@astrojs/starlight/components";
 
-Add your key to a `.env.local` file your project root.
+Add your key to a `.env.local` file in your project root.
 
 ```ini title=".env.local"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev

--- a/src/snippets/get-started/node-js-hono/Step2.mdx
+++ b/src/snippets/get-started/node-js-hono/Step2.mdx
@@ -1,5 +1,7 @@
 import { Aside } from "@astrojs/starlight/components";
 
+Add your key to a `.env.local` file your project root.
+
 ```ini title=".env.local"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev
 # You can leave this unset in prod
@@ -7,6 +9,12 @@ ARCJET_ENV=development
 # Get your site key from https://app.arcjet.com
 ARCJET_KEY=ajkey_yourkey
 ```
+
+:::caution[IP Address]
+Arcjet only accepts non-local IP addresses with a fallback to 127.0.0.1 in
+development mode. Since Node.js doesn't set `NODE_ENV` for you, you also need to
+set `ARCJET_ENV` in your environment file.
+:::
 
 Next you need to update the dev command in your `package.json` to use the
 `.env.local` file.

--- a/src/snippets/get-started/node-js/Step2.mdx
+++ b/src/snippets/get-started/node-js/Step2.mdx
@@ -1,4 +1,4 @@
-Add your key to a `.env.local` file your project root.
+Add your key to a `.env.local` file in your project root.
 
 ```ini title=".env.local"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev

--- a/src/snippets/get-started/node-js/Step2.mdx
+++ b/src/snippets/get-started/node-js/Step2.mdx
@@ -1,3 +1,5 @@
+Add your key to a `.env.local` file your project root.
+
 ```ini title=".env.local"
 # NODE_ENV is not set automatically, so tell Arcjet we're in dev
 # You can leave this unset in prod
@@ -5,3 +7,9 @@ ARCJET_ENV=development
 # Get your site key from https://app.arcjet.com
 ARCJET_KEY=ajkey_yourkey
 ```
+
+:::caution[IP Address]
+Arcjet only accepts non-local IP addresses with a fallback to 127.0.0.1 in
+development mode. Since Node.js doesn't set `NODE_ENV` for you, you also need to
+set `ARCJET_ENV` in your environment file.
+:::

--- a/src/snippets/get-started/remix/Step2.mdx
+++ b/src/snippets/get-started/remix/Step2.mdx
@@ -1,4 +1,4 @@
-Add your key to a `.env` file your project root.
+Add your key to a `.env` file in your project root.
 
 ```ini title=".env"
 ARCJET_KEY=ajkey_yourkey

--- a/src/snippets/get-started/remix/Step2.mdx
+++ b/src/snippets/get-started/remix/Step2.mdx
@@ -1,3 +1,5 @@
-```ini title=".env.local"
+Add your key to a `.env` file your project root.
+
+```ini title=".env"
 ARCJET_KEY=ajkey_yourkey
 ```

--- a/src/snippets/get-started/sveltekit/Step2.mdx
+++ b/src/snippets/get-started/sveltekit/Step2.mdx
@@ -1,4 +1,4 @@
-Add your key to a `.env` file your project root.
+Add your key to a `.env` file in your project root.
 
 ```ini title=".env"
 ARCJET_KEY=ajkey_yourkey

--- a/src/snippets/get-started/sveltekit/Step2.mdx
+++ b/src/snippets/get-started/sveltekit/Step2.mdx
@@ -1,3 +1,5 @@
-```ini title=".env.local"
+Add your key to a `.env` file your project root.
+
+```ini title=".env"
 ARCJET_KEY=ajkey_yourkey
 ```


### PR DESCRIPTION
Some frameworks need `.env` instead of `.env.local` (specifically, Deno and anything that uses Vite) so I've moved that sentence into the snippets themselves.

I also re-added the note about non-local IPs since @danni-popova ran into the issue earlier in the week.