### PR TITLE
feat: Add Deno Bot Protection Quick Start

### DIFF
--- a/src/content/docs/bot-protection/quick-start.mdx
+++ b/src/content/docs/bot-protection/quick-start.mdx
@@ -3,6 +3,7 @@ title: "Bot protection quick start"
 description: "Quick start guide for adding Arcjet bot protection to your Next.js, Node.js, Bun, or SvelteKit app."
 frameworks:
   - bun
+  - deno
   - next-js
   - node-js
   - sveltekit
@@ -44,6 +45,11 @@ import BunStep2 from "@/snippets/bot-protection/quick-start/bun/Step2.mdx";
 import BunStep3 from "@/snippets/bot-protection/quick-start/bun/Step3.mdx";
 import BunStep4 from "@/snippets/bot-protection/quick-start/bun/Step4.mdx";
 
+import DenoStep1 from "@/snippets/bot-protection/quick-start/deno/Step1.mdx";
+import DenoStep2 from "@/snippets/bot-protection/quick-start/deno/Step2.mdx";
+import DenoStep3 from "@/snippets/bot-protection/quick-start/deno/Step3.mdx";
+import DenoStep4 from "@/snippets/bot-protection/quick-start/deno/Step4.mdx";
+
 import NextJsStep1 from "@/snippets/bot-protection/quick-start/nextjs/Step1.mdx";
 import NextJsStep2 from "@/snippets/bot-protection/quick-start/nextjs/Step2.mdx";
 import NextJsStep3 from "@/snippets/bot-protection/quick-start/nextjs/Step3.mdx";
@@ -74,6 +80,7 @@ In your project root, run the following command to install the SDK:
 
 <SlotByFramework client:load>
   <BunStep1 slot="bun" />
+  <DenoStep1 slot="deno" />
   <NextJsStep1 slot="next-js" />
   <NodeJsStep1 slot="node-js" />
   <SvelteKitStep1 slot="sveltekit" />
@@ -86,6 +93,7 @@ instructions to add a site and get a key.
 
 <SlotByFramework client:load>
   <BunStep2 slot="bun" />
+  <DenoStep2 slot="deno" />
   <NextJsStep2 slot="next-js" />
   <NodeJsStep2 slot="node-js" />
   <SvelteKitStep2 slot="sveltekit" />
@@ -95,6 +103,7 @@ instructions to add a site and get a key.
 
 <SlotByFramework client:load>
   <BunStep3 slot="bun" />
+  <DenoStep3 slot="deno" />
   <NextJsStep3 slot="next-js" />
   <NodeJsStep3 slot="node-js" />
   <SvelteKitStep3 slot="sveltekit" />
@@ -102,6 +111,7 @@ instructions to add a site and get a key.
 
 <SlotByFramework client:load>
   <BunStep4 slot="bun" />
+  <DenoStep4 slot="deno" />
   <NextJsStep4 slot="next-js" />
   <NodeJsStep4 slot="node-js" />
   <SvelteKitStep4 slot="sveltekit" />

--- a/src/snippets/bot-protection/quick-start/deno/Step1.mdx
+++ b/src/snippets/bot-protection/quick-start/deno/Step1.mdx
@@ -1,0 +1,10 @@
+import SelectableContent from "@/components/SelectableContent";
+
+{/* prettier-ignore */}
+<SelectableContent client:load syncKey="packageManager" frameworkSwitcher>
+<div slot="deno" slotIdx="1">
+```bash
+deno add npm:@arcjet/deno
+```
+</div>
+</SelectableContent>

--- a/src/snippets/bot-protection/quick-start/deno/Step2.mdx
+++ b/src/snippets/bot-protection/quick-start/deno/Step2.mdx
@@ -1,0 +1,15 @@
+Add your key to a `.env` file in your project root.
+
+```ini title=".env"
+# NODE_ENV is not set automatically, so tell Arcjet we're in dev
+# You can leave this unset in prod
+ARCJET_ENV=development
+# Get your site key from https://app.arcjet.com
+ARCJET_KEY=ajkey_yourkey
+```
+
+:::caution[IP Address]
+Arcjet only accepts non-local IP addresses with a fallback to 127.0.0.1 in
+development mode. Since Deno doesn't set `NODE_ENV` for you, you also need to
+set `ARCJET_ENV` in your environment file.
+:::

--- a/src/snippets/bot-protection/quick-start/deno/Step3.mdx
+++ b/src/snippets/bot-protection/quick-start/deno/Step3.mdx
@@ -1,0 +1,13 @@
+import Step3TS from "./Step3.ts?raw";
+
+import { Code } from "@astrojs/starlight/components";
+import SelectableContent from "@/components/SelectableContent";
+
+The example below will return a 403 Forbidden response for all requests from
+clients we are sure are automated.
+
+<SelectableContent client:load syncKey="language" frameworkSwitcher>
+  <div slot="TS" slotIdx="1">
+    <Code code={Step3TS} lang="ts" title="index.ts" />
+  </div>
+</SelectableContent>

--- a/src/snippets/bot-protection/quick-start/deno/Step3.ts
+++ b/src/snippets/bot-protection/quick-start/deno/Step3.ts
@@ -1,0 +1,28 @@
+import "jsr:@std/dotenv/load";
+
+import arcjet, { detectBot } from "@arcjet/deno";
+
+const aj = arcjet({
+  key: Deno.env.get("ARCJET_KEY")!, // Get your site key from https://app.arcjet.com
+  rules: [
+    detectBot({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+      // Block all bots except search engine crawlers. See the full list of bots
+      // for other options: https://arcjet.com/bot-list
+      allow: ["CATEGORY:SEARCH_ENGINE"],
+    }),
+  ],
+});
+
+Deno.serve(
+  { port: 3000 },
+  aj.handler(async (req) => {
+    const decision = await aj.protect(req);
+
+    if (decision.isDenied()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    return new Response("Hello world");
+  }),
+);

--- a/src/snippets/bot-protection/quick-start/deno/Step4.mdx
+++ b/src/snippets/bot-protection/quick-start/deno/Step4.mdx
@@ -1,0 +1,30 @@
+import SelectableContent from "@/components/SelectableContent";
+
+### 4. Start server
+
+Start your Deno server:
+
+{/* prettier-ignore */}
+<SelectableContent client:load syncKey="language" frameworkSwitcher>
+<div slot="TS" slotIdx="1">
+  ```sh
+  deno run --watch index.ts
+  ```
+</div>
+</SelectableContent>
+
+:::note[Deno permissions]
+Deno will prompt you for various permissions. You can also start Deno with the
+appropriate permission flags (`--allow-read --allow-env --allow-net`) to skip
+the prompt.
+:::
+
+Make a `curl` request from your terminal. You should see a `403 Forbidden`
+response because `curl` is considered an automated client by default.
+
+```sh
+curl http://localhost:3000
+```
+
+The requests will also show up in the [Arcjet
+dashboard](https://app.arcjet.com).


### PR DESCRIPTION
I stacked this on top of #212 so adding the framework was easier with copy-paste.

This adds Deno as a framework in the Bot Protection quick start guide.

