### PR TITLE
chore: Refactor bot reference guide

### DIFF
--- a/src/content/docs/bot-protection/reference.mdx
+++ b/src/content/docs/bot-protection/reference.mdx
@@ -51,34 +51,38 @@ ajToc:
 ---
 
 import SlotByFramework from "@/components/SlotByFramework";
-import AllowingBotsBun from "@/snippets/bot-protection/reference/bun/AllowingBots.mdx";
-import DecisionLogBun from "@/snippets/bot-protection/reference/bun/DecisionLog.mdx";
-import DenyingBotsBun from "@/snippets/bot-protection/reference/bun/DenyingBots.mdx";
-import ErrorsBun from "@/snippets/bot-protection/reference/bun/Errors.mdx";
-import FilteringBun from "@/snippets/bot-protection/reference/bun/Filtering.mdx";
-import IdentifiedBotsBun from "@/snippets/bot-protection/reference/bun/IdentifiedBots.mdx";
-import AllowingBotsNextJs from "@/snippets/bot-protection/reference/nextjs/AllowingBots.mdx";
-import DecisionLogNextJs from "@/snippets/bot-protection/reference/nextjs/DecisionLog.mdx";
-import DenyingBotsNextJs from "@/snippets/bot-protection/reference/nextjs/DenyingBots.mdx";
-import ErrorsNextJs from "@/snippets/bot-protection/reference/nextjs/Errors.mdx";
-import ExamplesNextJs from "@/snippets/bot-protection/reference/nextjs/Examples.mdx";
-import FilteringNextJs from "@/snippets/bot-protection/reference/nextjs/Filtering.mdx";
-import IdentifiedBotsNextJs from "@/snippets/bot-protection/reference/nextjs/IdentifiedBots.mdx";
-import PerRouteVsMiddlewareNextJs from "@/snippets/bot-protection/reference/nextjs/PerRouteVsMiddleware.mdx";
-import AllowingBotsNodeJs from "@/snippets/bot-protection/reference/nodejs/AllowingBots.mdx";
-import DecisionLogNodeJs from "@/snippets/bot-protection/reference/nodejs/DecisionLog.mdx";
-import DenyingBotsNodeJs from "@/snippets/bot-protection/reference/nodejs/DenyingBots.mdx";
-import ErrorsNodeJs from "@/snippets/bot-protection/reference/nodejs/Errors.mdx";
-import FilteringNodeJs from "@/snippets/bot-protection/reference/nodejs/Filtering.mdx";
-import IdentifiedBotsNodeJs from "@/snippets/bot-protection/reference/nodejs/IdentifiedBots.mdx";
-import AllowingBotsSvelteKit from "@/snippets/bot-protection/reference/sveltekit/AllowingBots.mdx";
-import DecisionLogSvelteKit from "@/snippets/bot-protection/reference/sveltekit/DecisionLog.mdx";
-import DenyingBotsSvelteKit from "@/snippets/bot-protection/reference/sveltekit/DenyingBots.mdx";
-import ErrorsSvelteKit from "@/snippets/bot-protection/reference/sveltekit/Errors.mdx";
-import FilteringSvelteKit from "@/snippets/bot-protection/reference/sveltekit/Filtering.mdx";
-import IdentifiedBotsSvelteKit from "@/snippets/bot-protection/reference/sveltekit/IdentifiedBots.mdx";
-import PerRouteVsHooksSvelteKit from "@/snippets/bot-protection/reference/sveltekit/PerRouteVsHooks.mdx";
-import Comments from "/src/components/Comments.astro";
+import Comments from "@/components/Comments.astro";
+
+import BunAllowingBots from "@/snippets/bot-protection/reference/bun/AllowingBots.mdx";
+import BunDenyingBots from "@/snippets/bot-protection/reference/bun/DenyingBots.mdx";
+import BunDecisionLog from "@/snippets/bot-protection/reference/bun/DecisionLog.mdx";
+import BunIdentifiedBots from "@/snippets/bot-protection/reference/bun/IdentifiedBots.mdx";
+import BunErrors from "@/snippets/bot-protection/reference/bun/Errors.mdx";
+import BunFiltering from "@/snippets/bot-protection/reference/bun/Filtering.mdx";
+
+import NextJsAllowingBots from "@/snippets/bot-protection/reference/nextjs/AllowingBots.mdx";
+import NextJsDenyingBots from "@/snippets/bot-protection/reference/nextjs/DenyingBots.mdx";
+import NextJsPerRouteVsMiddleware from "@/snippets/bot-protection/reference/nextjs/PerRouteVsMiddleware.mdx";
+import NextJsDecisionLog from "@/snippets/bot-protection/reference/nextjs/DecisionLog.mdx";
+import NextJsIdentifiedBots from "@/snippets/bot-protection/reference/nextjs/IdentifiedBots.mdx";
+import NextJsErrors from "@/snippets/bot-protection/reference/nextjs/Errors.mdx";
+import NextJsFiltering from "@/snippets/bot-protection/reference/nextjs/Filtering.mdx";
+import NextJsExamples from "@/snippets/bot-protection/reference/nextjs/Examples.mdx";
+
+import NodeJsAllowingBots from "@/snippets/bot-protection/reference/nodejs/AllowingBots.mdx";
+import NodeJsDenyingBots from "@/snippets/bot-protection/reference/nodejs/DenyingBots.mdx";
+import NodeJsDecisionLog from "@/snippets/bot-protection/reference/nodejs/DecisionLog.mdx";
+import NodeJsIdentifiedBots from "@/snippets/bot-protection/reference/nodejs/IdentifiedBots.mdx";
+import NodeJsErrors from "@/snippets/bot-protection/reference/nodejs/Errors.mdx";
+import NodeJsFiltering from "@/snippets/bot-protection/reference/nodejs/Filtering.mdx";
+
+import SvelteKitAllowingBots from "@/snippets/bot-protection/reference/sveltekit/AllowingBots.mdx";
+import SvelteKitDenyingBots from "@/snippets/bot-protection/reference/sveltekit/DenyingBots.mdx";
+import SvelteKitPerRouteVsHooks from "@/snippets/bot-protection/reference/sveltekit/PerRouteVsHooks.mdx";
+import SvelteKitDecisionLog from "@/snippets/bot-protection/reference/sveltekit/DecisionLog.mdx";
+import SvelteKitIdentifiedBots from "@/snippets/bot-protection/reference/sveltekit/IdentifiedBots.mdx";
+import SvelteKitErrors from "@/snippets/bot-protection/reference/sveltekit/Errors.mdx";
+import SvelteKitFiltering from "@/snippets/bot-protection/reference/sveltekit/Filtering.mdx";
 
 Arcjet bot detection allows you to manage traffic by automated clients and bots.
 
@@ -126,10 +130,10 @@ bots](https://arcjet.com/bot-list) and/or [bot
 categories](/bot-protection/identifying-bots#bot-categories).
 
 <SlotByFramework client:load>
-  <AllowingBotsBun slot="bun" />
-  <AllowingBotsNextJs slot="next-js" />
-  <AllowingBotsNodeJs slot="node-js" />
-  <AllowingBotsSvelteKit slot="sveltekit" />
+  <BunAllowingBots slot="bun" />
+  <NextJsAllowingBots slot="next-js" />
+  <NodeJsAllowingBots slot="node-js" />
+  <SvelteKitAllowingBots slot="sveltekit" />
 </SlotByFramework>
 
 ### Denying specific bots
@@ -143,15 +147,15 @@ bots](https://arcjet.com/bot-list) and/or [bot
 categories](/bot-protection/identifying-bots#bot-categories).
 
 <SlotByFramework client:load>
-  <DenyingBotsBun slot="bun" />
-  <DenyingBotsNextJs slot="next-js" />
-  <DenyingBotsNodeJs slot="node-js" />
-  <DenyingBotsSvelteKit slot="sveltekit" />
+  <BunDenyingBots slot="bun" />
+  <NextJsDenyingBots slot="next-js" />
+  <NodeJsDenyingBots slot="node-js" />
+  <SvelteKitDenyingBots slot="sveltekit" />
 </SlotByFramework>
 
 <SlotByFramework client:load>
-  <PerRouteVsMiddlewareNextJs slot="next-js" />
-  <PerRouteVsHooksSvelteKit slot="sveltekit" />
+  <NextJsPerRouteVsMiddleware slot="next-js" />
+  <SvelteKitPerRouteVsHooks slot="sveltekit" />
 </SlotByFramework>
 
 ## Decision
@@ -195,10 +199,10 @@ for (const result of decision.results) {
 This example will log the full result as well as the bot protection rule:
 
 <SlotByFramework client:load>
-  <DecisionLogBun slot="bun" />
-  <DecisionLogNextJs slot="next-js" />
-  <DecisionLogNodeJs slot="node-js" />
-  <DecisionLogSvelteKit slot="sveltekit" />
+  <BunDecisionLog slot="bun" />
+  <NextJsDecisionLog slot="next-js" />
+  <NodeJsDecisionLog slot="node-js" />
+  <SvelteKitDecisionLog slot="sveltekit" />
 </SlotByFramework>
 
 ### Identified bots
@@ -210,10 +214,10 @@ of which will be available on the `decision.allowed` and `decision.denied`
 properties.
 
 <SlotByFramework client:load>
-  <IdentifiedBotsBun slot="bun" />
-  <IdentifiedBotsNextJs slot="next-js" />
-  <IdentifiedBotsNextJs slot="node-js" />
-  <IdentifiedBotsSvelteKit slot="sveltekit" />
+  <BunIdentifiedBots slot="bun" />
+  <NextJsIdentifiedBots slot="next-js" />
+  <NodeJsIdentifiedBots slot="node-js" />
+  <SvelteKitIdentifiedBots slot="sveltekit" />
 </SlotByFramework>
 
 ## Error handling
@@ -238,10 +242,10 @@ See [an example of how to do this](/bot-protection/concepts#user-agent-header).
 :::
 
 <SlotByFramework client:load>
-  <ErrorsBun slot="bun" />
-  <ErrorsNextJs slot="next-js" />
-  <ErrorsNodeJs slot="node-js" />
-  <ErrorsSvelteKit slot="sveltekit" />
+  <BunErrors slot="bun" />
+  <NextJsErrors slot="next-js" />
+  <NodeJsErrors slot="node-js" />
+  <SvelteKitErrors slot="sveltekit" />
 </SlotByFramework>
 
 ## Filtering categories
@@ -251,10 +255,10 @@ access. For example, you may want to allow most of `CATEGORY:GOOGLE` except
 their "advertising quality" bot.
 
 <SlotByFramework client:load>
-  <FilteringBun slot="bun" />
-  <FilteringNextJs slot="next-js" />
-  <FilteringNodeJs slot="node-js" />
-  <FilteringSvelteKit slot="sveltekit" />
+  <BunFiltering slot="bun" />
+  <NextJsFiltering slot="next-js" />
+  <NodeJsFiltering slot="node-js" />
+  <SvelteKitFiltering slot="sveltekit" />
 </SlotByFramework>
 
 ## Testing
@@ -269,7 +273,7 @@ Arcjet can also be triggered based using a sample of your traffic.
 See the [Testing](/testing) section of the docs for details.
 
 <SlotByFramework client:load>
-  <ExamplesNextJs slot="next-js" />
+  <NextJsExamples slot="next-js" />
 </SlotByFramework>
 
 <Comments />


### PR DESCRIPTION
This refactors the bot protection reference guide to prefix names with the framework and groups them for easier copy-paste.

This also helped me catch a bug where Next.js examples were being used for Identified Bots section.