### PR TITLE
feat: Add Deno adapter in Bot Reference

### DIFF
--- a/src/content/docs/bot-protection/reference.mdx
+++ b/src/content/docs/bot-protection/reference.mdx
@@ -3,6 +3,7 @@ title: "Bot protection reference"
 description: "Reference guide for adding Arcjet bot protection to your Next.js, Node.js, Bun, or SvelteKit app."
 frameworks:
   - bun
+  - deno
   - next-js
   - node-js
   - sveltekit
@@ -59,6 +60,13 @@ import BunDecisionLog from "@/snippets/bot-protection/reference/bun/DecisionLog.
 import BunIdentifiedBots from "@/snippets/bot-protection/reference/bun/IdentifiedBots.mdx";
 import BunErrors from "@/snippets/bot-protection/reference/bun/Errors.mdx";
 import BunFiltering from "@/snippets/bot-protection/reference/bun/Filtering.mdx";
+
+import DenoAllowingBots from "@/snippets/bot-protection/reference/deno/AllowingBots.mdx";
+import DenoDenyingBots from "@/snippets/bot-protection/reference/deno/DenyingBots.mdx";
+import DenoDecisionLog from "@/snippets/bot-protection/reference/deno/DecisionLog.mdx";
+import DenoIdentifiedBots from "@/snippets/bot-protection/reference/deno/IdentifiedBots.mdx";
+import DenoErrors from "@/snippets/bot-protection/reference/deno/Errors.mdx";
+import DenoFiltering from "@/snippets/bot-protection/reference/deno/Filtering.mdx";
 
 import NextJsAllowingBots from "@/snippets/bot-protection/reference/nextjs/AllowingBots.mdx";
 import NextJsDenyingBots from "@/snippets/bot-protection/reference/nextjs/DenyingBots.mdx";
@@ -131,6 +139,7 @@ categories](/bot-protection/identifying-bots#bot-categories).
 
 <SlotByFramework client:load>
   <BunAllowingBots slot="bun" />
+  <DenoAllowingBots slot="deno" />
   <NextJsAllowingBots slot="next-js" />
   <NodeJsAllowingBots slot="node-js" />
   <SvelteKitAllowingBots slot="sveltekit" />
@@ -148,6 +157,7 @@ categories](/bot-protection/identifying-bots#bot-categories).
 
 <SlotByFramework client:load>
   <BunDenyingBots slot="bun" />
+  <DenoDenyingBots slot="deno" />
   <NextJsDenyingBots slot="next-js" />
   <NodeJsDenyingBots slot="node-js" />
   <SvelteKitDenyingBots slot="sveltekit" />
@@ -200,6 +210,7 @@ This example will log the full result as well as the bot protection rule:
 
 <SlotByFramework client:load>
   <BunDecisionLog slot="bun" />
+  <DenoDecisionLog slot="deno" />
   <NextJsDecisionLog slot="next-js" />
   <NodeJsDecisionLog slot="node-js" />
   <SvelteKitDecisionLog slot="sveltekit" />
@@ -215,6 +226,7 @@ properties.
 
 <SlotByFramework client:load>
   <BunIdentifiedBots slot="bun" />
+  <DenoIdentifiedBots slot="deno" />
   <NextJsIdentifiedBots slot="next-js" />
   <NodeJsIdentifiedBots slot="node-js" />
   <SvelteKitIdentifiedBots slot="sveltekit" />
@@ -243,6 +255,7 @@ See [an example of how to do this](/bot-protection/concepts#user-agent-header).
 
 <SlotByFramework client:load>
   <BunErrors slot="bun" />
+  <DenoErrors slot="deno" />
   <NextJsErrors slot="next-js" />
   <NodeJsErrors slot="node-js" />
   <SvelteKitErrors slot="sveltekit" />
@@ -256,6 +269,7 @@ their "advertising quality" bot.
 
 <SlotByFramework client:load>
   <BunFiltering slot="bun" />
+  <DenoFiltering slot="deno" />
   <NextJsFiltering slot="next-js" />
   <NodeJsFiltering slot="node-js" />
   <SvelteKitFiltering slot="sveltekit" />

--- a/src/snippets/bot-protection/reference/deno/AllowingBots.mdx
+++ b/src/snippets/bot-protection/reference/deno/AllowingBots.mdx
@@ -1,0 +1,9 @@
+import { Code } from "@astrojs/starlight/components";
+import SelectableContent from "@/components/SelectableContent";
+import AllowingBotsTS from "./AllowingBots.ts?raw";
+
+<SelectableContent client:load syncKey="language" frameworkSwitcher>
+  <div slot="TS" slotIdx="1">
+    <Code code={AllowingBotsTS} lang="ts" />
+  </div>
+</SelectableContent>

--- a/src/snippets/bot-protection/reference/deno/AllowingBots.ts
+++ b/src/snippets/bot-protection/reference/deno/AllowingBots.ts
@@ -1,0 +1,32 @@
+import arcjet, { detectBot } from "@arcjet/deno";
+
+const aj = arcjet({
+  key: Deno.env.get("ARCJET_KEY")!, // Get your site key from https://app.arcjet.com
+  rules: [
+    detectBot({
+      mode: "LIVE",
+      // configured with a list of bots to allow from
+      // https://arcjet.com/bot-list - all other detected bots will be blocked
+      allow: [
+        // Google has multiple crawlers, each with a different user-agent, so we
+        // allow the entire Google category
+        "CATEGORY:GOOGLE",
+        "CURL", // allows the default user-agent of the `curl` tool
+        "DISCORD_CRAWLER", // allows Discordbot
+      ],
+    }),
+  ],
+});
+
+Deno.serve(
+  { port: 3000 },
+  aj.handler(async (req) => {
+    const decision = await aj.protect(req);
+
+    if (decision.isDenied()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    return new Response("Hello world");
+  }),
+);

--- a/src/snippets/bot-protection/reference/deno/DecisionLog.mdx
+++ b/src/snippets/bot-protection/reference/deno/DecisionLog.mdx
@@ -1,0 +1,9 @@
+import SelectableContent from "@/components/SelectableContent";
+import { Code } from "@astrojs/starlight/components";
+import DecisionLogTS from "./DecisionLog.ts?raw";
+
+<SelectableContent client:load syncKey="language" frameworkSwitcher>
+  <div slot="TS" slotIdx="1">
+    <Code code={DecisionLogTS} lang="ts" />
+  </div>
+</SelectableContent>

--- a/src/snippets/bot-protection/reference/deno/DecisionLog.ts
+++ b/src/snippets/bot-protection/reference/deno/DecisionLog.ts
@@ -1,0 +1,42 @@
+import arcjet, { detectBot, fixedWindow } from "@arcjet/deno";
+
+const aj = arcjet({
+  key: Deno.env.get("ARCJET_KEY")!, // Get your site key from https://app.arcjet.com
+  rules: [
+    fixedWindow({
+      mode: "LIVE",
+      window: "1h",
+      max: 60,
+    }),
+    detectBot({
+      mode: "LIVE",
+      allow: [], // "allow none" will block all detected bots
+    }),
+  ],
+});
+
+Deno.serve(
+  { port: 3000 },
+  aj.handler(async (req) => {
+    const decision = await aj.protect(req);
+    console.log("Arcjet decision", decision);
+
+    for (const result of decision.results) {
+      console.log("Rule Result", result);
+
+      if (result.reason.isRateLimit()) {
+        console.log("Rate limit rule", result);
+      }
+
+      if (result.reason.isBot()) {
+        console.log("Bot protection rule", result);
+      }
+    }
+
+    if (decision.isDenied()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    return new Response("Hello world");
+  }),
+);

--- a/src/snippets/bot-protection/reference/deno/DenyingBots.mdx
+++ b/src/snippets/bot-protection/reference/deno/DenyingBots.mdx
@@ -1,0 +1,9 @@
+import { Code } from "@astrojs/starlight/components";
+import SelectableContent from "@/components/SelectableContent";
+import DenyingBotsTS from "./DenyingBots.ts?raw";
+
+<SelectableContent client:load syncKey="language" frameworkSwitcher>
+  <div slot="TS" slotIdx="1">
+    <Code code={DenyingBotsTS} lang="ts" />
+  </div>
+</SelectableContent>

--- a/src/snippets/bot-protection/reference/deno/DenyingBots.ts
+++ b/src/snippets/bot-protection/reference/deno/DenyingBots.ts
@@ -1,0 +1,29 @@
+import arcjet, { detectBot } from "@arcjet/deno";
+
+const aj = arcjet({
+  key: Deno.env.get("ARCJET_KEY")!, // Get your site key from https://app.arcjet.com
+  rules: [
+    detectBot({
+      mode: "LIVE",
+      // configured with a list of bots to deny from
+      // https://arcjet.com/bot-list - all other detected bots will be allowed
+      deny: [
+        "CATEGORY:AI", // denies all detected AI and LLM scrapers
+        "CURL", // denies the default user-agent of the `curl` tool
+      ],
+    }),
+  ],
+});
+
+Deno.serve(
+  { port: 3000 },
+  aj.handler(async (req) => {
+    const decision = await aj.protect(req);
+
+    if (decision.isDenied()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    return new Response("Hello world");
+  }),
+);

--- a/src/snippets/bot-protection/reference/deno/Errors.mdx
+++ b/src/snippets/bot-protection/reference/deno/Errors.mdx
@@ -1,0 +1,9 @@
+import SelectableContent from "@/components/SelectableContent";
+import { Code } from "@astrojs/starlight/components";
+import ErrorsTS from "./Errors.ts?raw";
+
+<SelectableContent client:load syncKey="language" frameworkSwitcher>
+  <div slot="TS" slotIdx="1">
+    <Code code={ErrorsTS} lang="ts" />
+  </div>
+</SelectableContent>

--- a/src/snippets/bot-protection/reference/deno/Errors.ts
+++ b/src/snippets/bot-protection/reference/deno/Errors.ts
@@ -1,0 +1,35 @@
+import arcjet, { detectBot } from "@arcjet/deno";
+
+const aj = arcjet({
+  key: Deno.env.get("ARCJET_KEY")!, // Get your site key from https://app.arcjet.com
+  rules: [
+    detectBot({
+      mode: "LIVE",
+      allow: [], // "allow none" will block all detected bots
+    }),
+  ],
+});
+
+Deno.serve(
+  { port: 3000 },
+  aj.handler(async (req) => {
+    const decision = await aj.protect(req);
+
+    // If the request is missing a User-Agent header, the decision will be
+    // marked as an error! You should check for this and make a decision about
+    // the request since requests without a User-Agent could indicate a crafted
+    // request from an automated client.
+    if (decision.isErrored()) {
+      // Fail open by logging the error and continuing
+      console.warn("Arcjet error", decision.reason.message);
+      // You could also fail closed here if the request is missing a User-Agent
+      //return new Response("Service unavailable", { status: 503 });
+    }
+
+    if (decision.isDenied()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    return new Response("Hello world");
+  }),
+);

--- a/src/snippets/bot-protection/reference/deno/Filtering.mdx
+++ b/src/snippets/bot-protection/reference/deno/Filtering.mdx
@@ -1,0 +1,9 @@
+import SelectableContent from "@/components/SelectableContent";
+import { Code } from "@astrojs/starlight/components";
+import FilteringTS from "./Filtering.ts?raw";
+
+<SelectableContent client:load syncKey="language" frameworkSwitcher>
+  <div slot="TS" slotIdx="1">
+    <Code code={FilteringTS} lang="ts" />
+  </div>
+</SelectableContent>

--- a/src/snippets/bot-protection/reference/deno/Filtering.ts
+++ b/src/snippets/bot-protection/reference/deno/Filtering.ts
@@ -1,0 +1,31 @@
+import arcjet, { botCategories, detectBot } from "@arcjet/deno";
+
+const aj = arcjet({
+  key: Deno.env.get("ARCJET_KEY")!, // Get your site key from https://app.arcjet.com
+  rules: [
+    detectBot({
+      mode: "LIVE",
+      // configured with a list of bots to allow from
+      // https://arcjet.com/bot-list - all other detected bots will be blocked
+      allow: [
+        // filter a category to remove individual bots from our provided lists
+        ...botCategories["CATEGORY:GOOGLE"].filter(
+          (bot) => bot !== "GOOGLE_ADSBOT" && bot !== "GOOGLE_ADSBOT_MOBILE",
+        ),
+      ],
+    }),
+  ],
+});
+
+Deno.serve(
+  { port: 3000 },
+  aj.handler(async (req) => {
+    const decision = await aj.protect(req);
+
+    if (decision.isDenied()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    return new Response("Hello world");
+  }),
+);

--- a/src/snippets/bot-protection/reference/deno/IdentifiedBots.mdx
+++ b/src/snippets/bot-protection/reference/deno/IdentifiedBots.mdx
@@ -1,0 +1,9 @@
+import SelectableContent from "@/components/SelectableContent";
+import { Code } from "@astrojs/starlight/components";
+import IdentifiedBotsTS from "./IdentifiedBots.ts?raw";
+
+<SelectableContent client:load syncKey="language" frameworkSwitcher>
+  <div slot="TS" slotIdx="1">
+    <Code code={IdentifiedBotsTS} lang="ts" />
+  </div>
+</SelectableContent>

--- a/src/snippets/bot-protection/reference/deno/IdentifiedBots.ts
+++ b/src/snippets/bot-protection/reference/deno/IdentifiedBots.ts
@@ -1,0 +1,29 @@
+import arcjet, { detectBot } from "@arcjet/deno";
+
+const aj = arcjet({
+  key: Deno.env.get("ARCJET_KEY")!, // Get your site key from https://app.arcjet.com
+  rules: [
+    detectBot({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+      allow: [], // "allow none" will block all detected bots
+    }),
+  ],
+});
+
+Deno.serve(
+  { port: 3000 },
+  aj.handler(async (req) => {
+    const decision = await aj.protect(req);
+
+    if (decision.reason.isBot()) {
+      console.log("detected + allowed bots", decision.reason.allowed);
+      console.log("detected + denied bots", decision.reason.denied);
+    }
+
+    if (decision.isDenied()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    return new Response("Hello world");
+  }),
+);


### PR DESCRIPTION
This builds upon #216 which made it easier to copy-paste snippets to add the new adapter.

This adds Deno as a framework into the Bot Reference.