### PR TITLE
fix: Redirect trailing slashes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -43,6 +43,241 @@
       "source": "/pricing",
       "destination": "https://arcjet.com/pricing",
       "permanent": true
+    },
+    {
+      "source": "/get-started/bun/",
+      "destination": "/get-started?f=bun",
+      "permanent": true
+    },
+    {
+      "source": "/get-started/nextjs/",
+      "destination": "/get-started?f=next-js",
+      "permanent": true
+    },
+    {
+      "source": "/get-started/nodejs/",
+      "destination": "/get-started?f=node-js",
+      "permanent": true
+    },
+    {
+      "source": "/get-started/sveltekit/",
+      "destination": "/get-started?f=sveltekit",
+      "permanent": true
+    },
+    {
+      "source": "/shield/",
+      "destination": "/shield/quick-start",
+      "permanent": true
+    },
+    {
+      "source": "/shield/quick-start/bun/",
+      "destination": "/shield/quick-start?f=bun",
+      "permanent": true
+    },
+    {
+      "source": "/shield/quick-start/nextjs/",
+      "destination": "/shield/quick-start?f=next-js",
+      "permanent": true
+    },
+    {
+      "source": "/shield/quick-start/nodejs/",
+      "destination": "/shield/quick-start?f=node-js",
+      "permanent": true
+    },
+    {
+      "source": "/shield/quick-start/sveltekit/",
+      "destination": "/shield/quick-start?f=sveltekit",
+      "permanent": true
+    },
+    {
+      "source": "/shield/reference/bun/",
+      "destination": "/shield/reference?f=bun",
+      "permanent": true
+    },
+    {
+      "source": "/shield/reference/nextjs/",
+      "destination": "/shield/reference?f=next-js",
+      "permanent": true
+    },
+    {
+      "source": "/shield/reference/nodejs/",
+      "destination": "/shield/reference?f=node-js",
+      "permanent": true
+    },
+    {
+      "source": "/shield/reference/sveltekit/",
+      "destination": "/shield/reference?f=sveltekit",
+      "permanent": true
+    },
+    {
+      "source": "/rate-limiting/",
+      "destination": "/rate-limiting/quick-start",
+      "permanent": true
+    },
+    {
+      "source": "/rate-limiting/quick-start/bun/",
+      "destination": "/rate-limiting/quick-start?f=bun",
+      "permanent": true
+    },
+    {
+      "source": "/rate-limiting/quick-start/nextjs/",
+      "destination": "/rate-limiting/quick-start?f=next-js",
+      "permanent": true
+    },
+    {
+      "source": "/rate-limiting/quick-start/nodejs/",
+      "destination": "/rate-limiting/quick-start?f=node-js",
+      "permanent": true
+    },
+    {
+      "source": "/rate-limiting/quick-start/sveltekit/",
+      "destination": "/rate-limiting/quick-start?f=sveltekit",
+      "permanent": true
+    },
+    {
+      "source": "/bot-protection/",
+      "destination": "/bot-protection/quick-start",
+      "permanent": true
+    },
+    {
+      "source": "/bot-protection/quick-start/bun/",
+      "destination": "/bot-protection/quick-start?f=bun",
+      "permanent": true
+    },
+    {
+      "source": "/bot-protection/quick-start/nextjs/",
+      "destination": "/bot-protection/quick-start?f=next-js",
+      "permanent": true
+    },
+    {
+      "source": "/bot-protection/quick-start/nodejs/",
+      "destination": "/bot-protection/quick-start?f=node-js",
+      "permanent": true
+    },
+    {
+      "source": "/bot-protection/quick-start/sveltekit/",
+      "destination": "/bot-protection/quick-start?f=sveltekit",
+      "permanent": true
+    },
+    {
+      "source": "/bot-protection/reference/bun/",
+      "destination": "/bot-protection/reference?f=bun",
+      "permanent": true
+    },
+    {
+      "source": "/bot-protection/reference/nextjs/",
+      "destination": "/bot-protection/reference?f=next-js",
+      "permanent": true
+    },
+    {
+      "source": "/bot-protection/reference/nodejs/",
+      "destination": "/bot-protection/reference?f=node-js",
+      "permanent": true
+    },
+    {
+      "source": "/bot-protection/reference/sveltekit/",
+      "destination": "/bot-protection/reference?f=sveltekit",
+      "permanent": true
+    },
+    {
+      "source": "/email-validation/",
+      "destination": "/email-validation/concepts",
+      "permanent": true
+    },
+    {
+      "source": "/email-validation/quick-start/bun/",
+      "destination": "/email-validation/quick-start?f=bun",
+      "permanent": true
+    },
+    {
+      "source": "/email-validation/quick-start/nextjs/",
+      "destination": "/email-validation/quick-start?f=next-js",
+      "permanent": true
+    },
+    {
+      "source": "/email-validation/quick-start/nodejs/",
+      "destination": "/email-validation/quick-start?f=node-js",
+      "permanent": true
+    },
+    {
+      "source": "/email-validation/quick-start/sveltekit/",
+      "destination": "/email-validation/quick-start?f=sveltekit",
+      "permanent": true
+    },
+    {
+      "source": "/email-validation/reference/bun/",
+      "destination": "/email-validation/reference?f=bun",
+      "permanent": true
+    },
+    {
+      "source": "/email-validation/reference/nextjs/",
+      "destination": "/email-validation/reference?f=next-js",
+      "permanent": true
+    },
+    {
+      "source": "/email-validation/reference/nodejs/",
+      "destination": "/email-validation/reference?f=node-js",
+      "permanent": true
+    },
+    {
+      "source": "/email-validation/reference/sveltekit/",
+      "destination": "/email-validation/reference?f=sveltekit",
+      "permanent": true
+    },
+    {
+      "source": "/signup-protection/",
+      "destination": "/signup-protection/quick-start",
+      "permanent": true
+    },
+    {
+      "source": "/signup-protection/quick-start/bun/",
+      "destination": "/signup-protection/quick-start?f=bun",
+      "permanent": true
+    },
+    {
+      "source": "/signup-protection/quick-start/nextjs/",
+      "destination": "/signup-protection/quick-start?f=next-js",
+      "permanent": true
+    },
+    {
+      "source": "/signup-protection/quick-start/nodejs/",
+      "destination": "/signup-protection/quick-start?f=node-js",
+      "permanent": true
+    },
+    {
+      "source": "/signup-protection/quick-start/sveltekit/",
+      "destination": "/signup-protection/quick-start?f=sveltekit",
+      "permanent": true
+    },
+    {
+      "source": "/signup-protection/reference/bun/",
+      "destination": "/signup-protection/reference?f=bun",
+      "permanent": true
+    },
+    {
+      "source": "/signup-protection/reference/nextjs/",
+      "destination": "/signup-protection/reference?f=next-js",
+      "permanent": true
+    },
+    {
+      "source": "/signup-protection/reference/nodejs/",
+      "destination": "/signup-protection/reference?f=node-js",
+      "permanent": true
+    },
+    {
+      "source": "/signup-protection/reference/sveltekit/",
+      "destination": "/signup-protection/reference?f=sveltekit",
+      "permanent": true
+    },
+    {
+      "source": "/reference/ts-js/",
+      "destination": "/reference/nodejs",
+      "permanent": true
+    },
+    {
+      "source": "/bot-protection/bot-types/",
+      "destination": "/bot-protection/identifying-bots",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
This needs to go in Vercel config as a redirect rather than Astro because we
already have redirects for non-trailing slash versions, and Astro thinks adding
a trailing slash redirect is the same.
