### PR TITLE
fix: sensitive info and bot detection per route examples

### DIFF
--- a/src/snippets/bot-protection/reference/nextjs/PerRoute.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/PerRoute.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import PerRouteAppTS from "/src/snippets/sensitive-info/reference/nextjs/PerRouteApp.ts?raw";
-import PerRoutePagesTS from "/src/snippets/sensitive-info/reference/nextjs/PerRoutePages.ts?raw";
-import PerRouteAppJS from "/src/snippets/sensitive-info/reference/nextjs/PerRouteApp.js?raw";
-import PerRoutePagesJS from "/src/snippets/sensitive-info/reference/nextjs/PerRoutePages.js?raw";
+import PerRouteAppTS from "/src/snippets/bot-protection/reference/nextjs/PerRouteApp.ts?raw";
+import PerRoutePagesTS from "/src/snippets/bot-protection/reference/nextjs/PerRoutePages.ts?raw";
+import PerRouteAppJS from "/src/snippets/bot-protection/reference/nextjs/PerRouteApp.js?raw";
+import PerRoutePagesJS from "/src/snippets/bot-protection/reference/nextjs/PerRoutePages.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/nextjs/PerRoute.mdx
+++ b/src/snippets/sensitive-info/reference/nextjs/PerRoute.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import PerRouteAppJS from "/src/snippets/shield/reference/nextjs/PerRouteApp.js?raw";
-import PerRouteAppTS from "/src/snippets/shield/reference/nextjs/PerRouteApp.ts?raw";
-import PerRoutePagesJS from "/src/snippets/shield/reference/nextjs/PerRoutePages.js?raw";
-import PerRoutePagesTS from "/src/snippets/shield/reference/nextjs/PerRoutePages.ts?raw";
+import PerRouteAppJS from "/src/snippets/sensitive-info/reference/nextjs/PerRouteApp.js?raw";
+import PerRouteAppTS from "/src/snippets/sensitive-info/reference/nextjs/PerRouteApp.ts?raw";
+import PerRoutePagesJS from "/src/snippets/sensitive-info/reference/nextjs/PerRoutePages.js?raw";
+import PerRoutePagesTS from "/src/snippets/sensitive-info/reference/nextjs/PerRoutePages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/nextjs/PerRouteApp.js
+++ b/src/snippets/sensitive-info/reference/nextjs/PerRouteApp.js
@@ -20,7 +20,7 @@ export async function POST(req) {
         error: "Unexpected sensitive info received",
         // Useful for debugging, but don't return it to the client in
         // production
-        //reason: decision.reason,
+        // reason: decision.reason,
       },
       { status: 400 },
     );

--- a/src/snippets/sensitive-info/reference/nextjs/PerRouteApp.ts
+++ b/src/snippets/sensitive-info/reference/nextjs/PerRouteApp.ts
@@ -20,7 +20,7 @@ export async function POST(req: Request) {
         error: "Unexpected sensitive info received",
         // Useful for debugging, but don't return it to the client in
         // production
-        //reason: decision.reason,
+        // reason: decision.reason,
       },
       { status: 400 },
     );


### PR DESCRIPTION
The "Per route" code examples were swapped on sensitive info and bot detection. 