### PR TITLE
fix: Convert all snippet imports to relative paths & resolve incorrect imports

### DIFF
--- a/src/snippets/bot-protection/quick-start/bun/Step3.mdx
+++ b/src/snippets/bot-protection/quick-start/bun/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/bot-protection/quick-start/bun/Step3.ts?raw";
-import Step3JS from "/src/snippets/bot-protection/quick-start/bun/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/bot-protection/quick-start/nextjs/Step3.mdx
+++ b/src/snippets/bot-protection/quick-start/nextjs/Step3.mdx
@@ -1,7 +1,7 @@
-import Step3JS from "/src/snippets/bot-protection/quick-start/nextjs/Step3.js?raw";
-import Step3AdvancedJS from "/src/snippets/bot-protection/quick-start/nextjs/Step3Advanced.js?raw";
-import Step3TS from "/src/snippets/bot-protection/quick-start/nextjs/Step3.ts?raw";
-import Step3AdvancedTS from "/src/snippets/bot-protection/quick-start/nextjs/Step3Advanced.ts?raw";
+import Step3JS from "./Step3.js?raw";
+import Step3AdvancedJS from "./Step3Advanced.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3AdvancedTS from "./Step3Advanced.ts?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/bot-protection/quick-start/nodejs/Step3.mdx
+++ b/src/snippets/bot-protection/quick-start/nodejs/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/bot-protection/quick-start/nodejs/Step3.ts?raw";
-import Step3JS from "/src/snippets/bot-protection/quick-start/nodejs/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/bot-protection/quick-start/sveltekit/Step3.mdx
+++ b/src/snippets/bot-protection/quick-start/sveltekit/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/bot-protection/quick-start/sveltekit/Step3.ts?raw";
-import Step3JS from "/src/snippets/bot-protection/quick-start/sveltekit/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/bot-protection/reference/bun/AllowingBots.mdx
+++ b/src/snippets/bot-protection/reference/bun/AllowingBots.mdx
@@ -1,7 +1,7 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import AllowingBotsTS from "/src/snippets/bot-protection/reference/bun/AllowingBots.ts?raw";
-import AllowingBotsJS from "/src/snippets/bot-protection/reference/bun/AllowingBots.js?raw";
+import AllowingBotsTS from "./AllowingBots.ts?raw";
+import AllowingBotsJS from "./AllowingBots.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/bun/DecisionLog.mdx
+++ b/src/snippets/bot-protection/reference/bun/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/bot-protection/reference/bun/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/bot-protection/reference/bun/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/bun/DenyingBots.mdx
+++ b/src/snippets/bot-protection/reference/bun/DenyingBots.mdx
@@ -1,7 +1,7 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import DenyingBotsTS from "/src/snippets/bot-protection/reference/bun/DenyingBots.ts?raw";
-import DenyingBotsJS from "/src/snippets/bot-protection/reference/bun/DenyingBots.js?raw";
+import DenyingBotsTS from "./DenyingBots.ts?raw";
+import DenyingBotsJS from "./DenyingBots.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/bun/Errors.mdx
+++ b/src/snippets/bot-protection/reference/bun/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/bot-protection/reference/bun/Errors.js?raw";
-import ErrorsTS from "/src/snippets/bot-protection/reference/bun/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/bun/Filtering.mdx
+++ b/src/snippets/bot-protection/reference/bun/Filtering.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import FilteringTS from "/src/snippets/bot-protection/reference/bun/Filtering.ts?raw";
-import FilteringJS from "/src/snippets/bot-protection/reference/bun/Filtering.js?raw";
+import FilteringTS from "./Filtering.ts?raw";
+import FilteringJS from "./Filtering.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/bun/IdentifiedBots.mdx
+++ b/src/snippets/bot-protection/reference/bun/IdentifiedBots.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import IdentifiedBotsTS from "/src/snippets/bot-protection/reference/bun/IdentifiedBots.ts?raw";
-import IdentifiedBotsJS from "/src/snippets/bot-protection/reference/bun/IdentifiedBots.js?raw";
+import IdentifiedBotsTS from "./IdentifiedBots.ts?raw";
+import IdentifiedBotsJS from "./IdentifiedBots.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nextjs/AllowingBots.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/AllowingBots.mdx
@@ -1,9 +1,9 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import AllowingBotsAppTS from "/src/snippets/bot-protection/reference/nextjs/AllowingBotsApp.ts?raw";
-import AllowingBotsPagesTS from "/src/snippets/bot-protection/reference/nextjs/AllowingBotsPages.ts?raw";
-import AllowingBotsAppJS from "/src/snippets/bot-protection/reference/nextjs/AllowingBotsPages.js?raw";
-import AllowingBotsPagesJS from "/src/snippets/bot-protection/reference/nextjs/AllowingBotsPages.js?raw";
+import AllowingBotsAppTS from "./AllowingBotsApp.ts?raw";
+import AllowingBotsPagesTS from "./AllowingBotsPages.ts?raw";
+import AllowingBotsAppJS from "./AllowingBotsPages.js?raw";
+import AllowingBotsPagesJS from "./AllowingBotsPages.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nextjs/DecisionLog.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/DecisionLog.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogAppJS from "/src/snippets/bot-protection/reference/nextjs/DecisionLogApp.js?raw";
-import DecisionLogAppTS from "/src/snippets/bot-protection/reference/nextjs/DecisionLogApp.ts?raw";
-import DecisionLogPagesJS from "/src/snippets/bot-protection/reference/nextjs/DecisionLogPages.js?raw";
-import DecisionLogPagesTS from "/src/snippets/bot-protection/reference/nextjs/DecisionLogPages.ts?raw";
+import DecisionLogAppJS from "./DecisionLogApp.js?raw";
+import DecisionLogAppTS from "./DecisionLogApp.ts?raw";
+import DecisionLogPagesJS from "./DecisionLogPages.js?raw";
+import DecisionLogPagesTS from "./DecisionLogPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nextjs/DenyingBots.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/DenyingBots.mdx
@@ -1,9 +1,9 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import DenyingBotsAppTS from "/src/snippets/bot-protection/reference/nextjs/DenyingBotsApp.ts?raw";
-import DenyingBotsPagesTS from "/src/snippets/bot-protection/reference/nextjs/DenyingBotsPages.ts?raw";
-import DenyingBotsAppJS from "/src/snippets/bot-protection/reference/nextjs/DenyingBotsApp.js?raw";
-import DenyingBotsPagesJS from "/src/snippets/bot-protection/reference/nextjs/DenyingBotsPages.js?raw";
+import DenyingBotsAppTS from "./DenyingBotsApp.ts?raw";
+import DenyingBotsPagesTS from "./DenyingBotsPages.ts?raw";
+import DenyingBotsAppJS from "./DenyingBotsApp.js?raw";
+import DenyingBotsPagesJS from "./DenyingBotsPages.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nextjs/Errors.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/Errors.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsAppJS from "/src/snippets/bot-protection/reference/nextjs/ErrorsApp.js?raw";
-import ErrorsAppTS from "/src/snippets/bot-protection/reference/nextjs/ErrorsApp.ts?raw";
-import ErrorsPagesJS from "/src/snippets/bot-protection/reference/nextjs/ErrorsPages.js?raw";
-import ErrorsPagesTS from "/src/snippets/bot-protection/reference/nextjs/ErrorsPages.ts?raw";
+import ErrorsAppJS from "./ErrorsApp.js?raw";
+import ErrorsAppTS from "./ErrorsApp.ts?raw";
+import ErrorsPagesJS from "./ErrorsPages.js?raw";
+import ErrorsPagesTS from "./ErrorsPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nextjs/Examples.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/Examples.mdx
@@ -1,19 +1,19 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import EdgeAppJS from "/src/snippets/bot-protection/reference/nextjs/EdgeApp.js?raw";
-import EdgeAppTS from "/src/snippets/bot-protection/reference/nextjs/EdgeApp.ts?raw";
-import EdgePagesJS from "/src/snippets/bot-protection/reference/nextjs/EdgePages.js?raw";
-import EdgePagesTS from "/src/snippets/bot-protection/reference/nextjs/EdgePages.ts?raw";
-import ProtectPageMiddlewareJS from "/src/snippets/bot-protection/reference/nextjs/ProtectPageMiddleware.js?raw";
-import ProtectPageMiddlewareTS from "/src/snippets/bot-protection/reference/nextjs/ProtectPageMiddleware.ts?raw";
-import ProtectPagePagesJS from "/src/snippets/bot-protection/reference/nextjs/ProtectPagePages.jsx?raw";
-import ProtectPagePagesTS from "/src/snippets/bot-protection/reference/nextjs/ProtectPagePages.tsx?raw";
-import WrapAppJS from "/src/snippets/bot-protection/reference/nextjs/WrapApp.js?raw";
-import WrapAppTS from "/src/snippets/bot-protection/reference/nextjs/WrapApp.ts?raw";
-import WrapPagesEdgeJS from "/src/snippets/bot-protection/reference/nextjs/WrapPagesEdge.js?raw";
-import WrapPagesEdgeTS from "/src/snippets/bot-protection/reference/nextjs/WrapPagesEdge.ts?raw";
-import WrapPagesNodeJS from "/src/snippets/bot-protection/reference/nextjs/WrapPagesNode.js?raw";
-import WrapPagesNodeTS from "/src/snippets/bot-protection/reference/nextjs/WrapPagesNode.ts?raw";
+import EdgeAppJS from "./EdgeApp.js?raw";
+import EdgeAppTS from "./EdgeApp.ts?raw";
+import EdgePagesJS from "./EdgePages.js?raw";
+import EdgePagesTS from "./EdgePages.ts?raw";
+import ProtectPageMiddlewareJS from "./ProtectPageMiddleware.js?raw";
+import ProtectPageMiddlewareTS from "./ProtectPageMiddleware.ts?raw";
+import ProtectPagePagesJS from "./ProtectPagePages.jsx?raw";
+import ProtectPagePagesTS from "./ProtectPagePages.tsx?raw";
+import WrapAppJS from "./WrapApp.js?raw";
+import WrapAppTS from "./WrapApp.ts?raw";
+import WrapPagesEdgeJS from "./WrapPagesEdge.js?raw";
+import WrapPagesEdgeTS from "./WrapPagesEdge.ts?raw";
+import WrapPagesNodeJS from "./WrapPagesNode.js?raw";
+import WrapPagesNodeTS from "./WrapPagesNode.ts?raw";
 
 ## Examples
 

--- a/src/snippets/bot-protection/reference/nextjs/Filtering.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/Filtering.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import FilteringAppJS from "/src/snippets/bot-protection/reference/nextjs/FilteringApp.js?raw";
-import FilteringAppTS from "/src/snippets/bot-protection/reference/nextjs/FilteringApp.ts?raw";
-import FilteringPagesJS from "/src/snippets/bot-protection/reference/nextjs/FilteringPages.js?raw";
-import FilteringPagesTS from "/src/snippets/bot-protection/reference/nextjs/FilteringPages.ts?raw";
+import FilteringAppJS from "./FilteringApp.js?raw";
+import FilteringAppTS from "./FilteringApp.ts?raw";
+import FilteringPagesJS from "./FilteringPages.js?raw";
+import FilteringPagesTS from "./FilteringPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nextjs/IdentifiedBots.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/IdentifiedBots.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import IdentifiedBotsAppJS from "/src/snippets/bot-protection/reference/nextjs/IdentifiedBotsApp.js?raw";
-import IdentifiedBotsAppTS from "/src/snippets/bot-protection/reference/nextjs/IdentifiedBotsApp.ts?raw";
-import IdentifiedBotsPagesJS from "/src/snippets/bot-protection/reference/nextjs/IdentifiedBotsPages.js?raw";
-import IdentifiedBotsPagesTS from "/src/snippets/bot-protection/reference/nextjs/IdentifiedBotsPages.ts?raw";
+import IdentifiedBotsAppJS from "./IdentifiedBotsApp.js?raw";
+import IdentifiedBotsAppTS from "./IdentifiedBotsApp.ts?raw";
+import IdentifiedBotsPagesJS from "./IdentifiedBotsPages.js?raw";
+import IdentifiedBotsPagesTS from "./IdentifiedBotsPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nextjs/Middleware.js
+++ b/src/snippets/bot-protection/reference/nextjs/Middleware.js
@@ -1,0 +1,19 @@
+import arcjet, { createMiddleware, detectBot } from "@arcjet/next";
+export const config = {
+  // matcher tells Next.js which routes to run the middleware on.
+  // This runs the middleware on all routes except for static assets.
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};
+const aj = arcjet({
+  key: process.env.ARCJET_KEY, // Get your site key from https://app.arcjet.com
+  rules: [
+    detectBot({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+      // Block all bots except search engine crawlers. See the full list of bots
+      // for other options: https://arcjet.com/bot-list
+      allow: ["CATEGORY:SEARCH_ENGINE"],
+    }),
+  ],
+});
+// Pass any existing middleware with the optional existingMiddleware prop
+export default createMiddleware(aj);

--- a/src/snippets/bot-protection/reference/nextjs/Middleware.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/Middleware.mdx
@@ -1,10 +1,10 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import Step3JS from "/src/snippets/bot-protection/quick-start/nextjs/Step3.js?raw";
-import Step3TS from "/src/snippets/bot-protection/quick-start/nextjs/Step3.ts?raw";
-import CustomizedMiddlewareJS from "/src/snippets/bot-protection/reference/nextjs/CustomizedMiddleware.js?raw";
-import CustomizedMiddlewareTS from "/src/snippets/bot-protection/reference/nextjs/CustomizedMiddleware.ts?raw";
-import MiddlewareMatcher from "/src/snippets/bot-protection/reference/nextjs/MiddlewareMatcher.ts?raw";
+import MiddlewareJS from "./Middleware.js?raw";
+import MiddlewareTS from "./Middleware.ts?raw";
+import CustomizedMiddlewareJS from "./CustomizedMiddleware.js?raw";
+import CustomizedMiddlewareTS from "./CustomizedMiddleware.ts?raw";
+import MiddlewareMatcher from "./MiddlewareMatcher.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   This will run on every request to your Next.js app, except for static assets
@@ -16,7 +16,12 @@ for details).
     Create a file called `middleware.ts` in your project root (at the same level as
 `pages` or `app` or inside `src`):
 
-<Code code={Step3TS} lang="ts" title="/middleware.ts" mark={["ARCJET_KEY"]} />
+<Code
+  code={MiddlewareTS}
+  lang="ts"
+  title="/middleware.ts"
+  mark={["ARCJET_KEY"]}
+/>
 
 You can also customize the response depending on the decision. In this case we
 will return a 403 Forbidden response only if we detect a hosting provider IP
@@ -28,7 +33,12 @@ address for the bot detection rule result:
     Create a file called `middleware.js` in your project root (at the same level as
 `pages` or `app` or inside `src`):
 
-<Code code={Step3JS} lang="js" title="/middleware.js" mark={["ARCJET_KEY"]} />
+<Code
+  code={MiddlewareJS}
+  lang="js"
+  title="/middleware.js"
+  mark={["ARCJET_KEY"]}
+/>
 
 You can also customize the response depending on the decision. In this case we
 will return a 403 Forbidden response only if we detect a hosting provider IP

--- a/src/snippets/bot-protection/reference/nextjs/Middleware.ts
+++ b/src/snippets/bot-protection/reference/nextjs/Middleware.ts
@@ -1,0 +1,19 @@
+import arcjet, { createMiddleware, detectBot } from "@arcjet/next";
+export const config = {
+  // matcher tells Next.js which routes to run the middleware on.
+  // This runs the middleware on all routes except for static assets.
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};
+const aj = arcjet({
+  key: process.env.ARCJET_KEY!, // Get your site key from https://app.arcjet.com
+  rules: [
+    detectBot({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+      // Block all bots except search engine crawlers. See the full list of bots
+      // for other options: https://arcjet.com/bot-list
+      allow: ["CATEGORY:SEARCH_ENGINE"],
+    }),
+  ],
+});
+// Pass any existing middleware with the optional existingMiddleware prop
+export default createMiddleware(aj);

--- a/src/snippets/bot-protection/reference/nextjs/PerRoute.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/PerRoute.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import PerRouteAppTS from "/src/snippets/bot-protection/reference/nextjs/PerRouteApp.ts?raw";
-import PerRoutePagesTS from "/src/snippets/bot-protection/reference/nextjs/PerRoutePages.ts?raw";
-import PerRouteAppJS from "/src/snippets/bot-protection/reference/nextjs/PerRouteApp.js?raw";
-import PerRoutePagesJS from "/src/snippets/bot-protection/reference/nextjs/PerRoutePages.js?raw";
+import PerRouteAppTS from "./PerRouteApp.ts?raw";
+import PerRoutePagesTS from "./PerRoutePages.ts?raw";
+import PerRouteAppJS from "./PerRouteApp.js?raw";
+import PerRoutePagesJS from "./PerRoutePages.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nextjs/PerRouteVsMiddleware.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/PerRouteVsMiddleware.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import SlotByFramework from "@/components/SlotByFramework";
-import MiddlewareNextJs from "@/snippets/bot-protection/reference/nextjs/Middleware.mdx";
-import PerRouteNextJs from "@/snippets/bot-protection/reference/nextjs/PerRoute.mdx";
+import MiddlewareNextJs from "./Middleware.mdx";
+import PerRouteNextJs from "./PerRoute.mdx";
 
 ## Per route vs middleware
 

--- a/src/snippets/bot-protection/reference/nodejs/AllowingBots.mdx
+++ b/src/snippets/bot-protection/reference/nodejs/AllowingBots.mdx
@@ -1,7 +1,7 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import AllowingBotsTS from "/src/snippets/bot-protection/reference/nodejs/AllowingBots.ts?raw";
-import AllowingBotsJS from "/src/snippets/bot-protection/reference/nodejs/AllowingBots.js?raw";
+import AllowingBotsTS from "./AllowingBots.ts?raw";
+import AllowingBotsJS from "./AllowingBots.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nodejs/DecisionLog.mdx
+++ b/src/snippets/bot-protection/reference/nodejs/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/bot-protection/reference/nodejs/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/bot-protection/reference/nodejs/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nodejs/DenyingBots.mdx
+++ b/src/snippets/bot-protection/reference/nodejs/DenyingBots.mdx
@@ -1,7 +1,7 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import DenyingBotsTS from "/src/snippets/bot-protection/reference/nodejs/DenyingBots.ts?raw";
-import DenyingBotsJS from "/src/snippets/bot-protection/reference/nodejs/DenyingBots.js?raw";
+import DenyingBotsTS from "./DenyingBots.ts?raw";
+import DenyingBotsJS from "./DenyingBots.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nodejs/Errors.mdx
+++ b/src/snippets/bot-protection/reference/nodejs/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/bot-protection/reference/nodejs/Errors.js?raw";
-import ErrorsTS from "/src/snippets/bot-protection/reference/nodejs/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nodejs/Filtering.mdx
+++ b/src/snippets/bot-protection/reference/nodejs/Filtering.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import FilteringTS from "/src/snippets/bot-protection/reference/nodejs/Filtering.ts?raw";
-import FilteringJS from "/src/snippets/bot-protection/reference/nodejs/Filtering.js?raw";
+import FilteringTS from "./Filtering.ts?raw";
+import FilteringJS from "./Filtering.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nodejs/IdentifiedBots.mdx
+++ b/src/snippets/bot-protection/reference/nodejs/IdentifiedBots.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import IdentifiedBotsTS from "/src/snippets/bot-protection/reference/nodejs/IdentifiedBots.ts?raw";
-import IdentifiedBotsJS from "/src/snippets/bot-protection/reference/nodejs/IdentifiedBots.js?raw";
+import IdentifiedBotsTS from "./IdentifiedBots.ts?raw";
+import IdentifiedBotsJS from "./IdentifiedBots.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/sveltekit/AllowingBots.mdx
+++ b/src/snippets/bot-protection/reference/sveltekit/AllowingBots.mdx
@@ -1,7 +1,7 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import AllowingBotsTS from "/src/snippets/bot-protection/reference/sveltekit/AllowingBots.ts?raw";
-import AllowingBotsJS from "/src/snippets/bot-protection/reference/sveltekit/AllowingBots.js?raw";
+import AllowingBotsTS from "./AllowingBots.ts?raw";
+import AllowingBotsJS from "./AllowingBots.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/sveltekit/DecisionLog.mdx
+++ b/src/snippets/bot-protection/reference/sveltekit/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/bot-protection/reference/sveltekit/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/bot-protection/reference/sveltekit/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/sveltekit/DenyingBots.mdx
+++ b/src/snippets/bot-protection/reference/sveltekit/DenyingBots.mdx
@@ -1,7 +1,7 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import DenyingBotsTS from "/src/snippets/bot-protection/reference/sveltekit/DenyingBots.ts?raw";
-import DenyingBotsJS from "/src/snippets/bot-protection/reference/sveltekit/DenyingBots.js?raw";
+import DenyingBotsTS from "./DenyingBots.ts?raw";
+import DenyingBotsJS from "./DenyingBots.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/sveltekit/Errors.mdx
+++ b/src/snippets/bot-protection/reference/sveltekit/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/bot-protection/reference/sveltekit/Errors.js?raw";
-import ErrorsTS from "/src/snippets/bot-protection/reference/sveltekit/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/sveltekit/Filtering.mdx
+++ b/src/snippets/bot-protection/reference/sveltekit/Filtering.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import FilteringTS from "/src/snippets/bot-protection/reference/sveltekit/Filtering.ts?raw";
-import FilteringJS from "/src/snippets/bot-protection/reference/sveltekit/Filtering.js?raw";
+import FilteringTS from "./Filtering.ts?raw";
+import FilteringJS from "./Filtering.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/sveltekit/Hooks.js
+++ b/src/snippets/bot-protection/reference/sveltekit/Hooks.js
@@ -1,0 +1,25 @@
+import { env } from "$env/dynamic/private";
+import arcjet, { detectBot } from "@arcjet/sveltekit";
+import { error } from "@sveltejs/kit";
+
+const aj = arcjet({
+  key: env.ARCJET_KEY, // Get your site key from https://app.arcjet.com
+  rules: [
+    detectBot({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+      // Block all bots except search engine crawlers. See the full list of bots
+      // for other options: https://arcjet.com/bot-list
+      allow: ["CATEGORY:SEARCH_ENGINE"],
+    }),
+  ],
+});
+
+export async function handle({ event, resolve }) {
+  const decision = await aj.protect(event);
+
+  if (decision.isDenied()) {
+    return error(403, "Forbidden");
+  }
+
+  return resolve(event);
+}

--- a/src/snippets/bot-protection/reference/sveltekit/Hooks.mdx
+++ b/src/snippets/bot-protection/reference/sveltekit/Hooks.mdx
@@ -1,15 +1,13 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import PerRouteTS from "/src/snippets/bot-protection/reference/sveltekit/PerRoute.ts?raw";
-import PerRouteJS from "/src/snippets/bot-protection/reference/sveltekit/PerRoute.js?raw";
-import Step3TS from "/src/snippets/bot-protection/quick-start/sveltekit/Step3.ts?raw";
-import Step3JS from "/src/snippets/bot-protection/quick-start/sveltekit/Step3.js?raw";
+import HooksTS from "./Hooks.ts?raw";
+import HooksJS from "./Hooks.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
-    <Code code={Step3TS} lang="ts" title="/src/hooks.server.ts" />
+    <Code code={HooksTS} lang="ts" title="/src/hooks.server.ts" />
   </div>
   <div slot="JS" slotIdx="2">
-    <Code code={Step3JS} lang="js" title="/src/hooks.server.js" />
+    <Code code={HooksJS} lang="js" title="/src/hooks.server.js" />
   </div>
 </SelectableContent>

--- a/src/snippets/bot-protection/reference/sveltekit/Hooks.ts
+++ b/src/snippets/bot-protection/reference/sveltekit/Hooks.ts
@@ -1,0 +1,31 @@
+import { env } from "$env/dynamic/private";
+import arcjet, { detectBot } from "@arcjet/sveltekit";
+import { error, type RequestEvent } from "@sveltejs/kit";
+
+const aj = arcjet({
+  key: env.ARCJET_KEY!, // Get your site key from https://app.arcjet.com
+  rules: [
+    detectBot({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+      // Block all bots except search engine crawlers. See the full list of bots
+      // for other options: https://arcjet.com/bot-list
+      allow: ["CATEGORY:SEARCH_ENGINE"],
+    }),
+  ],
+});
+
+export async function handle({
+  event,
+  resolve,
+}: {
+  event: RequestEvent;
+  resolve: (event: RequestEvent) => Response | Promise<Response>;
+}): Promise<Response> {
+  const decision = await aj.protect(event);
+
+  if (decision.isDenied()) {
+    return error(403, "Forbidden");
+  }
+
+  return resolve(event);
+}

--- a/src/snippets/bot-protection/reference/sveltekit/IdentifiedBots.mdx
+++ b/src/snippets/bot-protection/reference/sveltekit/IdentifiedBots.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import IdentifiedBotsTS from "/src/snippets/bot-protection/reference/sveltekit/IdentifiedBots.ts?raw";
-import IdentifiedBotsJS from "/src/snippets/bot-protection/reference/sveltekit/IdentifiedBots.js?raw";
+import IdentifiedBotsTS from "./IdentifiedBots.ts?raw";
+import IdentifiedBotsJS from "./IdentifiedBots.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/sveltekit/PerRoute.mdx
+++ b/src/snippets/bot-protection/reference/sveltekit/PerRoute.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import PerRouteTS from "/src/snippets/bot-protection/reference/sveltekit/PerRoute.ts?raw";
-import PerRouteJS from "/src/snippets/bot-protection/reference/sveltekit/PerRoute.js?raw";
+import PerRouteTS from "./PerRoute.ts?raw";
+import PerRouteJS from "./PerRoute.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/sveltekit/PerRouteVsHooks.mdx
+++ b/src/snippets/bot-protection/reference/sveltekit/PerRouteVsHooks.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import SlotByFramework from "@/components/SlotByFramework";
-import Hooks from "@/snippets/bot-protection/reference/sveltekit/Hooks.mdx";
-import PerRoute from "@/snippets/bot-protection/reference/sveltekit/PerRoute.mdx";
+import Hooks from "./Hooks.mdx";
+import PerRoute from "./PerRoute.mdx";
 import { Code } from "@astrojs/starlight/components";
-import HookMatcher from "/src/snippets/bot-protection/reference/sveltekit/HookMatcher.ts?raw";
+import HookMatcher from "./HookMatcher.ts?raw";
 
 ## Per route vs hooks
 

--- a/src/snippets/email-validation/quick-start/bun/Step3.mdx
+++ b/src/snippets/email-validation/quick-start/bun/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/email-validation/quick-start/bun/Step3.ts?raw";
-import Step3JS from "/src/snippets/email-validation/quick-start/bun/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/email-validation/quick-start/nextjs/Step3.mdx
+++ b/src/snippets/email-validation/quick-start/nextjs/Step3.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import Step3AppJS from "/src/snippets/email-validation/quick-start/nextjs/Step3App.js?raw";
-import Step3AppTS from "/src/snippets/email-validation/quick-start/nextjs/Step3App.ts?raw";
-import Step3PagesJS from "/src/snippets/email-validation/quick-start/nextjs/Step3Pages.js?raw";
-import Step3PagesTS from "/src/snippets/email-validation/quick-start/nextjs/Step3Pages.ts?raw";
+import Step3AppJS from "./Step3App.js?raw";
+import Step3AppTS from "./Step3App.ts?raw";
+import Step3PagesJS from "./Step3Pages.js?raw";
+import Step3PagesTS from "./Step3Pages.ts?raw";
 
 If you are using server actions, see the [example in the SDK
 reference](/reference/nextjs#server-actions).

--- a/src/snippets/email-validation/quick-start/nodejs/Step3.mdx
+++ b/src/snippets/email-validation/quick-start/nodejs/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/email-validation/quick-start/nodejs/Step3.ts?raw";
-import Step3JS from "/src/snippets/email-validation/quick-start/nodejs/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/email-validation/quick-start/sveltekit/Step3.mdx
+++ b/src/snippets/email-validation/quick-start/sveltekit/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/email-validation/quick-start/sveltekit/Step3.ts?raw";
-import Step3JS from "/src/snippets/email-validation/quick-start/sveltekit/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/email-validation/reference/bun/DecisionLog.mdx
+++ b/src/snippets/email-validation/reference/bun/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/email-validation/reference/bun/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/email-validation/reference/bun/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/email-validation/reference/bun/Errors.mdx
+++ b/src/snippets/email-validation/reference/bun/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/email-validation/reference/bun/Errors.js?raw";
-import ErrorsTS from "/src/snippets/email-validation/reference/bun/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/email-validation/reference/nextjs/DecisionLog.mdx
+++ b/src/snippets/email-validation/reference/nextjs/DecisionLog.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogAppJS from "/src/snippets/email-validation/reference/nextjs/DecisionLogApp.js?raw";
-import DecisionLogAppTS from "/src/snippets/email-validation/reference/nextjs/DecisionLogApp.ts?raw";
-import DecisionLogPagesJS from "/src/snippets/email-validation/reference/nextjs/DecisionLogPages.js?raw";
-import DecisionLogPagesTS from "/src/snippets/email-validation/reference/nextjs/DecisionLogPages.ts?raw";
+import DecisionLogAppJS from "./DecisionLogApp.js?raw";
+import DecisionLogAppTS from "./DecisionLogApp.ts?raw";
+import DecisionLogPagesJS from "./DecisionLogPages.js?raw";
+import DecisionLogPagesTS from "./DecisionLogPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/email-validation/reference/nextjs/Errors.mdx
+++ b/src/snippets/email-validation/reference/nextjs/Errors.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsAppJS from "/src/snippets/email-validation/reference/nextjs/ErrorsApp.js?raw";
-import ErrorsAppTS from "/src/snippets/email-validation/reference/nextjs/ErrorsApp.ts?raw";
-import ErrorsPagesJS from "/src/snippets/email-validation/reference/nextjs/ErrorsPages.js?raw";
-import ErrorsPagesTS from "/src/snippets/email-validation/reference/nextjs/ErrorsPages.ts?raw";
+import ErrorsAppJS from "./ErrorsApp.js?raw";
+import ErrorsAppTS from "./ErrorsApp.ts?raw";
+import ErrorsPagesJS from "./ErrorsPages.js?raw";
+import ErrorsPagesTS from "./ErrorsPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/email-validation/reference/nodejs/DecisionLog.mdx
+++ b/src/snippets/email-validation/reference/nodejs/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/email-validation/reference/nodejs/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/email-validation/reference/nodejs/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/email-validation/reference/nodejs/Errors.mdx
+++ b/src/snippets/email-validation/reference/nodejs/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/bot-protection/reference/nodejs/Errors.js?raw";
-import ErrorsTS from "/src/snippets/bot-protection/reference/nodejs/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/email-validation/reference/sveltekit/DecisionLog.mdx
+++ b/src/snippets/email-validation/reference/sveltekit/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/email-validation/reference/sveltekit/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/email-validation/reference/sveltekit/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/email-validation/reference/sveltekit/Errors.mdx
+++ b/src/snippets/email-validation/reference/sveltekit/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/email-validation/reference/sveltekit/Errors.js?raw";
-import ErrorsTS from "/src/snippets/email-validation/reference/sveltekit/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/get-started/bun-hono/Step3.mdx
+++ b/src/snippets/get-started/bun-hono/Step3.mdx
@@ -1,4 +1,4 @@
-import Step3TS from "/src/snippets/get-started/bun-hono/Step3.ts?raw";
+import Step3TS from "./Step3.ts?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/get-started/bun/Step3.mdx
+++ b/src/snippets/get-started/bun/Step3.mdx
@@ -1,6 +1,6 @@
-import Step3TS from "/src/snippets/get-started/bun/Step3.ts?raw";
-import Step3JS from "/src/snippets/get-started/bun/Step3.js?raw";
-import Step3ServeTS from "/src/snippets/get-started/bun/BunServe.ts?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
+import Step3ServeTS from "./BunServe.ts?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/get-started/nest-js/Step3.mdx
+++ b/src/snippets/get-started/nest-js/Step3.mdx
@@ -1,17 +1,18 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import GlobalGuard from "/src/snippets/get-started/nest-js/GlobalGuard.ts?raw";
+import GlobalGuard from "./GlobalGuard.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
 <div slot="TS" slotIdx="1">
   Update your `src/main.ts` file with the contents:
 
-  <Code code={GlobalGuard} lang="ts" title="src/main.ts" />
+{" "}
+<Code code={GlobalGuard} lang="ts" title="src/main.ts" />
 
-  This creates a global guard that will be applied to all routes. In a real
-  application, implementing guards or per-route protections would give you more
-  flexibility. See [our example app](https://github.com/arcjet/example-nestjs) for
-  how to do this.
+This creates a global guard that will be applied to all routes. In a real
+application, implementing guards or per-route protections would give you more
+flexibility. See [our example app](https://github.com/arcjet/example-nestjs) for
+how to do this.
 
 </div>
 </SelectableContent>

--- a/src/snippets/get-started/next-js/Step3.mdx
+++ b/src/snippets/get-started/next-js/Step3.mdx
@@ -1,7 +1,7 @@
-import Step3AppJS from "/src/snippets/get-started/next-js/Step3App.js?raw";
-import Step3AppTS from "/src/snippets/get-started/next-js/Step3App.ts?raw";
-import Step3PagesJS from "/src/snippets/get-started/next-js/Step3Pages.js?raw";
-import Step3PagesTS from "/src/snippets/get-started/next-js/Step3Pages.ts?raw";
+import Step3AppJS from "./Step3App.js?raw";
+import Step3AppTS from "./Step3App.ts?raw";
+import Step3PagesJS from "./Step3Pages.js?raw";
+import Step3PagesTS from "./Step3Pages.ts?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/get-started/node-js-express/Step3.mdx
+++ b/src/snippets/get-started/node-js-express/Step3.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import Express from "/src/snippets/get-started/node-js-express/Express.js?raw";
+import Express from "./Express.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="JS" slotIdx="1">

--- a/src/snippets/get-started/node-js-hono/Step3.mdx
+++ b/src/snippets/get-started/node-js-hono/Step3.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import Step3 from "/src/snippets/get-started/node-js-hono/Step3.ts?raw";
+import Step3 from "./Step3.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/get-started/node-js/Step3.mdx
+++ b/src/snippets/get-started/node-js/Step3.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import Step3JS from "/src/snippets/get-started/node-js/Step3.js?raw";
-import Step3TS from "/src/snippets/get-started/node-js/Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/get-started/remix/Step3.mdx
+++ b/src/snippets/get-started/remix/Step3.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import Step3 from "@/snippets/get-started/remix/Step3.tsx?raw";
+import Step3 from "./Step3.tsx?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/get-started/sveltekit/Step3.mdx
+++ b/src/snippets/get-started/sveltekit/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/get-started/sveltekit/Step3.ts?raw";
-import Step3JS from "/src/snippets/get-started/sveltekit/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/rate-limiting/quick-start/bun/Step3.mdx
+++ b/src/snippets/rate-limiting/quick-start/bun/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/rate-limiting/quick-start/bun/Step3.ts?raw";
-import Step3JS from "/src/snippets/rate-limiting/quick-start/bun/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/rate-limiting/quick-start/nextjs/Step3.mdx
+++ b/src/snippets/rate-limiting/quick-start/nextjs/Step3.mdx
@@ -1,7 +1,7 @@
-import Step3AppJS from "/src/snippets/rate-limiting/quick-start/nextjs/Step3App.js?raw";
-import Step3AppTS from "/src/snippets/rate-limiting/quick-start/nextjs/Step3App.ts?raw";
-import Step3PagesJS from "/src/snippets/rate-limiting/quick-start/nextjs/Step3Pages.js?raw";
-import Step3PagesTS from "/src/snippets/rate-limiting/quick-start/nextjs/Step3Pages.ts?raw";
+import Step3AppJS from "./Step3App.js?raw";
+import Step3AppTS from "./Step3App.ts?raw";
+import Step3PagesJS from "./Step3Pages.js?raw";
+import Step3PagesTS from "./Step3Pages.ts?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/rate-limiting/quick-start/nodejs/Step3.mdx
+++ b/src/snippets/rate-limiting/quick-start/nodejs/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/rate-limiting/quick-start/nodejs/Step3.ts?raw";
-import Step3JS from "/src/snippets/rate-limiting/quick-start/nodejs/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/rate-limiting/quick-start/sveltekit/Step3.mdx
+++ b/src/snippets/rate-limiting/quick-start/sveltekit/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/rate-limiting/quick-start/sveltekit/Step3.ts?raw";
-import Step3JS from "/src/snippets/rate-limiting/quick-start/sveltekit/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/rate-limiting/reference/bun/ByUserId.mdx
+++ b/src/snippets/rate-limiting/reference/bun/ByUserId.mdx
@@ -1,7 +1,7 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import ByUserIdTS from "/src/snippets/rate-limiting/reference/bun/ByUserId.ts?raw";
-import ByUserIdJS from "/src/snippets/rate-limiting/reference/bun/ByUserId.js?raw";
+import ByUserIdTS from "./ByUserId.ts?raw";
+import ByUserIdJS from "./ByUserId.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/bun/DecisionLog.mdx
+++ b/src/snippets/rate-limiting/reference/bun/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/rate-limiting/reference/bun/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/rate-limiting/reference/bun/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/bun/DryRun.mdx
+++ b/src/snippets/rate-limiting/reference/bun/DryRun.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DryRun from "/src/snippets/rate-limiting/reference/bun/DryRun.ts?raw";
+import DryRun from "./DryRun.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/bun/Errors.mdx
+++ b/src/snippets/rate-limiting/reference/bun/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/rate-limiting/reference/bun/Errors.js?raw";
-import ErrorsTS from "/src/snippets/rate-limiting/reference/bun/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/bun/FixedWindow.mdx
+++ b/src/snippets/rate-limiting/reference/bun/FixedWindow.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import FixedWindow from "/src/snippets/rate-limiting/reference/bun/FixedWindow.ts?raw";
+import FixedWindow from "./FixedWindow.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/bun/Headers.mdx
+++ b/src/snippets/rate-limiting/reference/bun/Headers.mdx
@@ -1,7 +1,7 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import HeadersTS from "/src/snippets/rate-limiting/reference/bun/Headers.ts?raw";
-import HeadersJS from "/src/snippets/rate-limiting/reference/bun/Headers.js?raw";
+import HeadersTS from "./Headers.ts?raw";
+import HeadersJS from "./Headers.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/bun/SingleRateLimit.mdx
+++ b/src/snippets/rate-limiting/reference/bun/SingleRateLimit.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import SingleRateLimit from "/src/snippets/rate-limiting/reference/bun/SingleRateLimit.ts?raw";
+import SingleRateLimit from "./SingleRateLimit.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/bun/SlidingWindow.mdx
+++ b/src/snippets/rate-limiting/reference/bun/SlidingWindow.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import SlidingWindow from "/src/snippets/rate-limiting/reference/bun/SlidingWindow.ts?raw";
+import SlidingWindow from "./SlidingWindow.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/bun/TokenBucket.mdx
+++ b/src/snippets/rate-limiting/reference/bun/TokenBucket.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import TokenBucket from "/src/snippets/rate-limiting/reference/bun/TokenBucket.ts?raw";
+import TokenBucket from "./TokenBucket.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/bun/TokenBucketRequest.mdx
+++ b/src/snippets/rate-limiting/reference/bun/TokenBucketRequest.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import TokenBucketRequestTS from "/src/snippets/rate-limiting/reference/bun/TokenBucketRequest.js?raw";
-import TokenBucketRequestJS from "/src/snippets/rate-limiting/reference/bun/TokenBucketRequest.ts?raw";
+import TokenBucketRequestTS from "./TokenBucketRequest.js?raw";
+import TokenBucketRequestJS from "./TokenBucketRequest.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nextjs/ByUserId.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/ByUserId.mdx
@@ -1,9 +1,9 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import ByUserIdAppTS from "/src/snippets/rate-limiting/reference/nextjs/ByUserIdApp.ts?raw";
-import ByUserIdPagesTS from "/src/snippets/rate-limiting/reference/nextjs/ByUserIdPages.ts?raw";
-import ByUserIdAppJS from "/src/snippets/rate-limiting/reference/nextjs/ByUserIdApp.js?raw";
-import ByUserIdPagesJS from "/src/snippets/rate-limiting/reference/nextjs/ByUserIdPages.js?raw";
+import ByUserIdAppTS from "./ByUserIdApp.ts?raw";
+import ByUserIdPagesTS from "./ByUserIdPages.ts?raw";
+import ByUserIdAppJS from "./ByUserIdApp.js?raw";
+import ByUserIdPagesJS from "./ByUserIdPages.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nextjs/DecisionLog.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/DecisionLog.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogAppJS from "/src/snippets/rate-limiting/reference/nextjs/DecisionLogApp.js?raw";
-import DecisionLogAppTS from "/src/snippets/rate-limiting/reference/nextjs/DecisionLogApp.ts?raw";
-import DecisionLogPagesJS from "/src/snippets/rate-limiting/reference/nextjs/DecisionLogPages.js?raw";
-import DecisionLogPagesTS from "/src/snippets/rate-limiting/reference/nextjs/DecisionLogPages.ts?raw";
+import DecisionLogAppJS from "./DecisionLogApp.js?raw";
+import DecisionLogAppTS from "./DecisionLogApp.ts?raw";
+import DecisionLogPagesJS from "./DecisionLogPages.js?raw";
+import DecisionLogPagesTS from "./DecisionLogPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nextjs/DryRun.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/DryRun.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DryRun from "/src/snippets/rate-limiting/reference/nextjs/DryRun.ts?raw";
+import DryRun from "./DryRun.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nextjs/Errors.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/Errors.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsAppJS from "/src/snippets/rate-limiting/reference/nextjs/ErrorsApp.js?raw";
-import ErrorsAppTS from "/src/snippets/rate-limiting/reference/nextjs/ErrorsApp.ts?raw";
-import ErrorsPagesJS from "/src/snippets/rate-limiting/reference/nextjs/ErrorsPages.js?raw";
-import ErrorsPagesTS from "/src/snippets/rate-limiting/reference/nextjs/ErrorsPages.ts?raw";
+import ErrorsAppJS from "./ErrorsApp.js?raw";
+import ErrorsAppTS from "./ErrorsApp.ts?raw";
+import ErrorsPagesJS from "./ErrorsPages.js?raw";
+import ErrorsPagesTS from "./ErrorsPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nextjs/Examples.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/Examples.mdx
@@ -1,25 +1,25 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ByIPAppTS from "/src/snippets/rate-limiting/reference/nextjs/ByIPApp.ts?raw";
-import ByIPPagesTS from "/src/snippets/rate-limiting/reference/nextjs/ByIPPages.ts?raw";
-import ByIPAppJS from "/src/snippets/rate-limiting/reference/nextjs/ByIPApp.js?raw";
-import ByIPPagesJS from "/src/snippets/rate-limiting/reference/nextjs/ByIPPages.js?raw";
-import ByIPCustomResponseAppTS from "/src/snippets/rate-limiting/reference/nextjs/ByIPCustomResponseApp.ts?raw";
-import ByIPCustomResponsePagesTS from "/src/snippets/rate-limiting/reference/nextjs/ByIPCustomResponsePages.ts?raw";
-import ByIPCustomResponseAppJS from "/src/snippets/rate-limiting/reference/nextjs/ByIPCustomResponseApp.js?raw";
-import ByIPCustomResponsePagesJS from "/src/snippets/rate-limiting/reference/nextjs/ByIPCustomResponsePages.js?raw";
-import AIChatBotAppTS from "/src/snippets/rate-limiting/reference/nextjs/AIChatBotApp.ts?raw";
-import AIChatBotAppJS from "/src/snippets/rate-limiting/reference/nextjs/AIChatBotApp.js?raw";
-import ByAPIKeyHeader from "/src/snippets/rate-limiting/reference/nextjs/ByAPIKeyHeader.ts?raw";
-import MiddlewareGlobal from "/src/snippets/rate-limiting/reference/nextjs/MiddlewareGlobal.ts?raw";
-import MiddlewareResponsePath from "/src/snippets/rate-limiting/reference/nextjs/MiddlewareResponsePath.ts?raw";
-import MiddlewareRewriteRedirect from "/src/snippets/rate-limiting/reference/nextjs/MiddlewareRewriteRedirect.ts?raw";
-import WrapAppTS from "/src/snippets/rate-limiting/reference/nextjs/WrapApp.ts?raw";
-import WrapPagesNodeTS from "/src/snippets/rate-limiting/reference/nextjs/WrapPagesNode.ts?raw";
-import WrapPagesEdgeTS from "/src/snippets/rate-limiting/reference/nextjs/WrapPagesEdge.ts?raw";
-import WrapAppJS from "/src/snippets/rate-limiting/reference/nextjs/WrapApp.js?raw";
-import WrapPagesNodeJS from "/src/snippets/rate-limiting/reference/nextjs/WrapPagesNode.js?raw";
-import WrapPagesEdgeJS from "/src/snippets/rate-limiting/reference/nextjs/WrapPagesEdge.js?raw";
+import ByIPAppTS from "./ByIPApp.ts?raw";
+import ByIPPagesTS from "./ByIPPages.ts?raw";
+import ByIPAppJS from "./ByIPApp.js?raw";
+import ByIPPagesJS from "./ByIPPages.js?raw";
+import ByIPCustomResponseAppTS from "./ByIPCustomResponseApp.ts?raw";
+import ByIPCustomResponsePagesTS from "./ByIPCustomResponsePages.ts?raw";
+import ByIPCustomResponseAppJS from "./ByIPCustomResponseApp.js?raw";
+import ByIPCustomResponsePagesJS from "./ByIPCustomResponsePages.js?raw";
+import AIChatBotAppTS from "./AIChatBotApp.ts?raw";
+import AIChatBotAppJS from "./AIChatBotApp.js?raw";
+import ByAPIKeyHeader from "./ByAPIKeyHeader.ts?raw";
+import MiddlewareGlobal from "./MiddlewareGlobal.ts?raw";
+import MiddlewareResponsePath from "./MiddlewareResponsePath.ts?raw";
+import MiddlewareRewriteRedirect from "./MiddlewareRewriteRedirect.ts?raw";
+import WrapAppTS from "./WrapApp.ts?raw";
+import WrapPagesNodeTS from "./WrapPagesNode.ts?raw";
+import WrapPagesEdgeTS from "./WrapPagesEdge.ts?raw";
+import WrapAppJS from "./WrapApp.js?raw";
+import WrapPagesNodeJS from "./WrapPagesNode.js?raw";
+import WrapPagesEdgeJS from "./WrapPagesEdge.js?raw";
 
 ## Examples
 

--- a/src/snippets/rate-limiting/reference/nextjs/FixedWindow.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/FixedWindow.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import FixedWindow from "/src/snippets/rate-limiting/reference/nextjs/FixedWindow.ts?raw";
+import FixedWindow from "./FixedWindow.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nextjs/Headers.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/Headers.mdx
@@ -1,9 +1,9 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import HeadersAppTS from "/src/snippets/rate-limiting/reference/nextjs/HeadersApp.ts?raw";
-import HeadersPagesTS from "/src/snippets/rate-limiting/reference/nextjs/HeadersPages.ts?raw";
-import HeadersAppJS from "/src/snippets/rate-limiting/reference/nextjs/HeadersApp.js?raw";
-import HeadersPagesJS from "/src/snippets/rate-limiting/reference/nextjs/HeadersPages.js?raw";
+import HeadersAppTS from "./HeadersApp.ts?raw";
+import HeadersPagesTS from "./HeadersPages.ts?raw";
+import HeadersAppJS from "./HeadersApp.js?raw";
+import HeadersPagesJS from "./HeadersPages.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nextjs/MiddlewareAllRoutes.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/MiddlewareAllRoutes.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import HookAllRoutes from "/src/snippets/rate-limiting/reference/sveltekit/HookAllRoutes.ts?raw";
+import MiddlewareAllRoutes from "./MiddlewareAllRoutes.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
-    <Code code={HookAllRoutes} lang="ts" title="/src/hooks.server.ts" />
+    <Code code={MiddlewareAllRoutes} lang="ts" title="/src/hooks.server.ts" />
   </div>
 </SelectableContent>

--- a/src/snippets/rate-limiting/reference/nextjs/MiddlewareMatcher.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/MiddlewareMatcher.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import MiddlewareMatcher from "/src/snippets/rate-limiting/reference/nextjs/MiddlewareMatcher.js?raw";
+import MiddlewareMatcher from "./MiddlewareMatcher.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nextjs/MiddlewareMatchingPaths.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/MiddlewareMatchingPaths.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import MiddlewareAllRoutes from "/src/snippets/rate-limiting/reference/nextjs/MiddlewareAllRoutes.js?raw";
+import MiddlewareAllRoutes from "./MiddlewareAllRoutes.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nextjs/PerRouteVsMiddleware.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/PerRouteVsMiddleware.mdx
@@ -1,8 +1,8 @@
 import SelectableContent from "@/components/SelectableContent";
 import SlotByFramework from "@/components/SlotByFramework";
-import MiddlewareMatchingPaths from "@/snippets/rate-limiting/reference/nextjs/MiddlewareMatchingPaths.mdx";
-import MiddlewareAllRoutes from "@/snippets/rate-limiting/reference/nextjs/MiddlewareAllRoutes.mdx";
-import MiddlewareMatcher from "@/snippets/rate-limiting/reference/nextjs/MiddlewareMatcher.mdx";
+import MiddlewareMatchingPaths from "./MiddlewareMatchingPaths.mdx";
+import MiddlewareAllRoutes from "./MiddlewareAllRoutes.mdx";
+import MiddlewareMatcher from "./MiddlewareMatcher.mdx";
 
 ## Per route vs middleware
 

--- a/src/snippets/rate-limiting/reference/nextjs/SingleRateLimit.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/SingleRateLimit.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import SingleRateLimit from "/src/snippets/rate-limiting/reference/nextjs/SingleRateLimit.ts?raw";
+import SingleRateLimit from "./SingleRateLimit.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nextjs/SlidingWindow.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/SlidingWindow.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import SlidingWindow from "/src/snippets/rate-limiting/reference/nextjs/SlidingWindow.ts?raw";
+import SlidingWindow from "./SlidingWindow.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nextjs/TokenBucket.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/TokenBucket.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import TokenBucket from "/src/snippets/rate-limiting/reference/nextjs/TokenBucket.ts?raw";
+import TokenBucket from "./TokenBucket.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nextjs/TokenBucketRequest.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/TokenBucketRequest.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import TokenBucketAppTS from "/src/snippets/rate-limiting/reference/nextjs/TokenBucketApp.js?raw";
-import TokenBucketPagesTS from "/src/snippets/rate-limiting/reference/nextjs/TokenBucketPages.ts?raw";
-import TokenBucketAppJS from "/src/snippets/rate-limiting/reference/nextjs/TokenBucketApp.js?raw";
-import TokenBucketPagesJS from "/src/snippets/rate-limiting/reference/nextjs/TokenBucketPages.ts?raw";
+import TokenBucketAppTS from "./TokenBucketApp.js?raw";
+import TokenBucketPagesTS from "./TokenBucketPages.ts?raw";
+import TokenBucketAppJS from "./TokenBucketApp.js?raw";
+import TokenBucketPagesJS from "./TokenBucketPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nodejs/ByUserId.mdx
+++ b/src/snippets/rate-limiting/reference/nodejs/ByUserId.mdx
@@ -1,7 +1,7 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import ByUserIdTS from "/src/snippets/rate-limiting/reference/nodejs/ByUserId.ts?raw";
-import ByUserIdJS from "/src/snippets/rate-limiting/reference/nodejs/ByUserId.js?raw";
+import ByUserIdTS from "./ByUserId.ts?raw";
+import ByUserIdJS from "./ByUserId.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nodejs/DecisionLog.mdx
+++ b/src/snippets/rate-limiting/reference/nodejs/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/rate-limiting/reference/nodejs/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/rate-limiting/reference/nodejs/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nodejs/DryRun.mdx
+++ b/src/snippets/rate-limiting/reference/nodejs/DryRun.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DryRun from "/src/snippets/rate-limiting/reference/nodejs/DryRun.ts?raw";
+import DryRun from "./DryRun.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nodejs/Errors.mdx
+++ b/src/snippets/rate-limiting/reference/nodejs/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/rate-limiting/reference/sveltekit/Errors.js?raw";
-import ErrorsTS from "/src/snippets/rate-limiting/reference/sveltekit/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nodejs/FixedWindow.mdx
+++ b/src/snippets/rate-limiting/reference/nodejs/FixedWindow.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import FixedWindow from "/src/snippets/rate-limiting/reference/nodejs/FixedWindow.ts?raw";
+import FixedWindow from "./FixedWindow.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nodejs/Headers.mdx
+++ b/src/snippets/rate-limiting/reference/nodejs/Headers.mdx
@@ -1,7 +1,7 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import HeadersTS from "/src/snippets/rate-limiting/reference/nodejs/Headers.ts?raw";
-import HeadersJS from "/src/snippets/rate-limiting/reference/nodejs/Headers.js?raw";
+import HeadersTS from "./Headers.ts?raw";
+import HeadersJS from "./Headers.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nodejs/SingleRateLimit.mdx
+++ b/src/snippets/rate-limiting/reference/nodejs/SingleRateLimit.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import SingleRateLimit from "/src/snippets/rate-limiting/reference/nodejs/SingleRateLimit.ts?raw";
+import SingleRateLimit from "./SingleRateLimit.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nodejs/SlidingWindow.mdx
+++ b/src/snippets/rate-limiting/reference/nodejs/SlidingWindow.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import SlidingWindow from "/src/snippets/rate-limiting/reference/nodejs/SlidingWindow.ts?raw";
+import SlidingWindow from "./SlidingWindow.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nodejs/TokenBucket.mdx
+++ b/src/snippets/rate-limiting/reference/nodejs/TokenBucket.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import TokenBucket from "/src/snippets/rate-limiting/reference/nodejs/TokenBucket.ts?raw";
+import TokenBucket from "./TokenBucket.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nodejs/TokenBucketRequest.mdx
+++ b/src/snippets/rate-limiting/reference/nodejs/TokenBucketRequest.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import TokenBucketRequestJS from "/src/snippets/rate-limiting/reference/nodejs/TokenBucketRequest.js?raw";
-import TokenBucketRequestTS from "/src/snippets/rate-limiting/reference/nodejs/TokenBucketRequest.ts?raw";
+import TokenBucketRequestJS from "./TokenBucketRequest.js?raw";
+import TokenBucketRequestTS from "./TokenBucketRequest.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/sveltekit/ByUserId.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/ByUserId.mdx
@@ -1,7 +1,7 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import ByUserIdTS from "/src/snippets/rate-limiting/reference/sveltekit/ByUserId.ts?raw";
-import ByUserIdJS from "/src/snippets/rate-limiting/reference/sveltekit/ByUserId.js?raw";
+import ByUserIdTS from "./ByUserId.ts?raw";
+import ByUserIdJS from "./ByUserId.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/sveltekit/DecisionLog.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/rate-limiting/reference/sveltekit/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/rate-limiting/reference/sveltekit/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/sveltekit/DryRun.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/DryRun.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DryRun from "/src/snippets/rate-limiting/reference/sveltekit/DryRun.ts?raw";
+import DryRun from "./DryRun.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/sveltekit/Errors.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/rate-limiting/reference/sveltekit/Errors.js?raw";
-import ErrorsTS from "/src/snippets/rate-limiting/reference/sveltekit/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/sveltekit/FixedWindow.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/FixedWindow.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import FixedWindow from "/src/snippets/rate-limiting/reference/sveltekit/FixedWindow.ts?raw";
+import FixedWindow from "./FixedWindow.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/sveltekit/Headers.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/Headers.mdx
@@ -1,7 +1,7 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import HeadersTS from "/src/snippets/rate-limiting/reference/sveltekit/Headers.ts?raw";
-import HeadersJS from "/src/snippets/rate-limiting/reference/sveltekit/Headers.js?raw";
+import HeadersTS from "./Headers.ts?raw";
+import HeadersJS from "./Headers.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/sveltekit/HookAllRoutes.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/HookAllRoutes.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import HookAllRoutes from "/src/snippets/rate-limiting/reference/sveltekit/HookAllRoutes.ts?raw";
+import HookAllRoutes from "./HookAllRoutes.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/sveltekit/HookMatcher.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/HookMatcher.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import HookMatcher from "/src/snippets/rate-limiting/reference/sveltekit/HookMatcher.ts?raw";
+import HookMatcher from "./HookMatcher.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/sveltekit/HookMatchingPaths.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/HookMatchingPaths.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import HookMatchingPaths from "/src/snippets/rate-limiting/reference/sveltekit/HookMatchingPaths.ts?raw";
+import HookMatchingPaths from "./HookMatchingPaths.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/sveltekit/PerRouteVsHooks.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/PerRouteVsHooks.mdx
@@ -1,8 +1,8 @@
 import SelectableContent from "@/components/SelectableContent";
 import SlotByFramework from "@/components/SlotByFramework";
-import HookMatchingPaths from "@/snippets/rate-limiting/reference/sveltekit/HookMatchingPaths.mdx";
-import HookAllRoutes from "/src/snippets/rate-limiting/reference/sveltekit/HookAllRoutes.mdx";
-import HookMatcher from "/src/snippets/rate-limiting/reference/sveltekit/HookMatcher.mdx";
+import HookMatchingPaths from "./HookMatchingPaths.mdx";
+import HookAllRoutes from "./HookAllRoutes.mdx";
+import HookMatcher from "./HookMatcher.mdx";
 
 ## Per route vs hooks
 

--- a/src/snippets/rate-limiting/reference/sveltekit/SingleRateLimit.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/SingleRateLimit.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import SingleRateLimit from "/src/snippets/rate-limiting/reference/sveltekit/SingleRateLimit.ts?raw";
+import SingleRateLimit from "./SingleRateLimit.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/sveltekit/SlidingWindow.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/SlidingWindow.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import SlidingWindow from "/src/snippets/rate-limiting/reference/sveltekit/SlidingWindow.ts?raw";
+import SlidingWindow from "./SlidingWindow.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/sveltekit/TokenBucket.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/TokenBucket.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import TokenBucket from "/src/snippets/rate-limiting/reference/sveltekit/TokenBucket.ts?raw";
+import TokenBucket from "./TokenBucket.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/sveltekit/TokenBucketRequest.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/TokenBucketRequest.mdx
@@ -1,7 +1,7 @@
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
-import TokenBucketRequestTS from "/src/snippets/rate-limiting/reference/sveltekit/TokenBucketRequest.ts?raw";
-import TokenBucketRequestJS from "/src/snippets/rate-limiting/reference/sveltekit/TokenBucketRequest.js?raw";
+import TokenBucketRequestTS from "./TokenBucketRequest.ts?raw";
+import TokenBucketRequestJS from "./TokenBucketRequest.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/sensitive-info/quick-start/bun/Step3.mdx
+++ b/src/snippets/sensitive-info/quick-start/bun/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/sensitive-info/quick-start/bun/Step3.ts?raw";
-import Step3JS from "/src/snippets/sensitive-info/quick-start/bun/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/sensitive-info/quick-start/nextjs/Step3.mdx
+++ b/src/snippets/sensitive-info/quick-start/nextjs/Step3.mdx
@@ -1,7 +1,7 @@
-import Step3AppJS from "/src/snippets/sensitive-info/quick-start/nextjs/Step3App.js?raw";
-import Step3AppTS from "/src/snippets/sensitive-info/quick-start/nextjs/Step3App.ts?raw";
-import Step3PagesJS from "/src/snippets/sensitive-info/quick-start/nextjs/Step3Pages.js?raw";
-import Step3PagesTS from "/src/snippets/sensitive-info/quick-start/nextjs/Step3Pages.ts?raw";
+import Step3AppJS from "./Step3App.js?raw";
+import Step3AppTS from "./Step3App.ts?raw";
+import Step3PagesJS from "./Step3Pages.js?raw";
+import Step3PagesTS from "./Step3Pages.ts?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/sensitive-info/quick-start/nodejs/Step3.mdx
+++ b/src/snippets/sensitive-info/quick-start/nodejs/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/sensitive-info/quick-start/nodejs/Step3.ts?raw";
-import Step3JS from "/src/snippets/sensitive-info/quick-start/nodejs/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/sensitive-info/quick-start/sveltekit/Step3.mdx
+++ b/src/snippets/sensitive-info/quick-start/sveltekit/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/sensitive-info/quick-start/sveltekit/Step3.ts?raw";
-import Step3JS from "/src/snippets/sensitive-info/quick-start/sveltekit/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/sensitive-info/reference/bun/CustomDetect.mdx
+++ b/src/snippets/sensitive-info/reference/bun/CustomDetect.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import CustomDetectTS from "/src/snippets/sensitive-info/reference/bun/CustomDetect.ts?raw";
-import CustomDetectJS from "/src/snippets/sensitive-info/reference/bun/CustomDetect.js?raw";
+import CustomDetectTS from "./CustomDetect.ts?raw";
+import CustomDetectJS from "./CustomDetect.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/bun/DecisionLog.mdx
+++ b/src/snippets/sensitive-info/reference/bun/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/sensitive-info/reference/bun/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/sensitive-info/reference/bun/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/bun/Errors.mdx
+++ b/src/snippets/sensitive-info/reference/bun/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/sensitive-info/reference/bun/Errors.js?raw";
-import ErrorsTS from "/src/snippets/sensitive-info/reference/bun/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/nextjs/CustomDetect.mdx
+++ b/src/snippets/sensitive-info/reference/nextjs/CustomDetect.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import CustomDetectAppTS from "/src/snippets/sensitive-info/reference/nextjs/CustomDetectApp.ts?raw";
-import CustomDetectAppJS from "/src/snippets/sensitive-info/reference/nextjs/CustomDetectApp.js?raw";
-import CustomDetectPagesTS from "/src/snippets/sensitive-info/reference/nextjs/CustomDetectPages.ts?raw";
-import CustomDetectPagesJS from "/src/snippets/sensitive-info/reference/nextjs/CustomDetectPages.js?raw";
+import CustomDetectAppTS from "./CustomDetectApp.ts?raw";
+import CustomDetectAppJS from "./CustomDetectApp.js?raw";
+import CustomDetectPagesTS from "./CustomDetectPages.ts?raw";
+import CustomDetectPagesJS from "./CustomDetectPages.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/nextjs/DecisionLog.mdx
+++ b/src/snippets/sensitive-info/reference/nextjs/DecisionLog.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogAppJS from "/src/snippets/sensitive-info/reference/nextjs/DecisionLogApp.js?raw";
-import DecisionLogAppTS from "/src/snippets/sensitive-info/reference/nextjs/DecisionLogApp.ts?raw";
-import DecisionLogPagesJS from "/src/snippets/sensitive-info/reference/nextjs/DecisionLogPages.js?raw";
-import DecisionLogPagesTS from "/src/snippets/sensitive-info/reference/nextjs/DecisionLogPages.ts?raw";
+import DecisionLogAppJS from "./DecisionLogApp.js?raw";
+import DecisionLogAppTS from "./DecisionLogApp.ts?raw";
+import DecisionLogPagesJS from "./DecisionLogPages.js?raw";
+import DecisionLogPagesTS from "./DecisionLogPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/nextjs/Errors.mdx
+++ b/src/snippets/sensitive-info/reference/nextjs/Errors.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsAppJS from "/src/snippets/sensitive-info/reference/nextjs/ErrorsApp.js?raw";
-import ErrorsAppTS from "/src/snippets/sensitive-info/reference/nextjs/ErrorsApp.ts?raw";
-import ErrorsPagesJS from "/src/snippets/sensitive-info/reference/nextjs/ErrorsPages.js?raw";
-import ErrorsPagesTS from "/src/snippets/sensitive-info/reference/nextjs/ErrorsPages.ts?raw";
+import ErrorsAppJS from "./ErrorsApp.js?raw";
+import ErrorsAppTS from "./ErrorsApp.ts?raw";
+import ErrorsPagesJS from "./ErrorsPages.js?raw";
+import ErrorsPagesTS from "./ErrorsPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/nextjs/Middleware.mdx
+++ b/src/snippets/sensitive-info/reference/nextjs/Middleware.mdx
@@ -1,8 +1,8 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import MiddlewareTS from "/src/snippets/sensitive-info/reference/nextjs/Middleware.ts?raw";
-import MiddlewareJS from "/src/snippets/sensitive-info/reference/nextjs/Middleware.js?raw";
-import MiddlewareMatcher from "/src/snippets/sensitive-info/reference/nextjs/MiddlewareMatcher.ts?raw";
+import MiddlewareTS from "./Middleware.ts?raw";
+import MiddlewareJS from "./Middleware.js?raw";
+import MiddlewareMatcher from "./MiddlewareMatcher.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/nextjs/PerRoute.mdx
+++ b/src/snippets/sensitive-info/reference/nextjs/PerRoute.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import PerRouteAppJS from "/src/snippets/sensitive-info/reference/nextjs/PerRouteApp.js?raw";
-import PerRouteAppTS from "/src/snippets/sensitive-info/reference/nextjs/PerRouteApp.ts?raw";
-import PerRoutePagesJS from "/src/snippets/sensitive-info/reference/nextjs/PerRoutePages.js?raw";
-import PerRoutePagesTS from "/src/snippets/sensitive-info/reference/nextjs/PerRoutePages.ts?raw";
+import PerRouteAppJS from "./PerRouteApp.js?raw";
+import PerRouteAppTS from "./PerRouteApp.ts?raw";
+import PerRoutePagesJS from "./PerRoutePages.js?raw";
+import PerRoutePagesTS from "./PerRoutePages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/nextjs/PerRouteVsMiddleware.mdx
+++ b/src/snippets/sensitive-info/reference/nextjs/PerRouteVsMiddleware.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import SlotByFramework from "@/components/SlotByFramework";
-import MiddlewareNextJs from "@/snippets/sensitive-info/reference/nextjs/Middleware.mdx";
-import PerRouteNextJs from "@/snippets/sensitive-info/reference/nextjs/PerRoute.mdx";
+import MiddlewareNextJs from "./Middleware.mdx";
+import PerRouteNextJs from "./PerRoute.mdx";
 
 ## Per route vs middleware
 

--- a/src/snippets/sensitive-info/reference/nodejs/CustomDetect.mdx
+++ b/src/snippets/sensitive-info/reference/nodejs/CustomDetect.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import AccessBodyJS from "/src/snippets/sensitive-info/reference/nodejs/AccessBody.js?raw";
-import AccessBodyTS from "/src/snippets/sensitive-info/reference/nodejs/AccessBody.ts?raw";
-import CustomDetectJS from "/src/snippets/sensitive-info/reference/nodejs/CustomDetect.js?raw";
-import CustomDetectTS from "/src/snippets/sensitive-info/reference/nodejs/CustomDetect.ts?raw";
+import AccessBodyJS from "./AccessBody.js?raw";
+import AccessBodyTS from "./AccessBody.ts?raw";
+import CustomDetectJS from "./CustomDetect.js?raw";
+import CustomDetectTS from "./CustomDetect.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/nodejs/DecisionLog.mdx
+++ b/src/snippets/sensitive-info/reference/nodejs/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/sensitive-info/reference/nodejs/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/sensitive-info/reference/nodejs/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/nodejs/Errors.mdx
+++ b/src/snippets/sensitive-info/reference/nodejs/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/sensitive-info/reference/nodejs/Errors.js?raw";
-import ErrorsTS from "/src/snippets/sensitive-info/reference/nodejs/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/sveltekit/CustomDetect.mdx
+++ b/src/snippets/sensitive-info/reference/sveltekit/CustomDetect.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import CustomDetectJS from "/src/snippets/sensitive-info/reference/sveltekit/CustomDetect.js?raw";
-import CustomDetectTS from "/src/snippets/sensitive-info/reference/sveltekit/CustomDetect.ts?raw";
+import CustomDetectJS from "./CustomDetect.js?raw";
+import CustomDetectTS from "./CustomDetect.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/sveltekit/DecisionLog.mdx
+++ b/src/snippets/sensitive-info/reference/sveltekit/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/sensitive-info/reference/nodejs/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/sensitive-info/reference/nodejs/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/sveltekit/Errors.mdx
+++ b/src/snippets/sensitive-info/reference/sveltekit/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/sensitive-info/reference/nodejs/Errors.js?raw";
-import ErrorsTS from "/src/snippets/sensitive-info/reference/nodejs/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/sveltekit/Filtering.mdx
+++ b/src/snippets/sensitive-info/reference/sveltekit/Filtering.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import FilteringTS from "/src/snippets/signup-protection/reference/sveltekit/Filtering.ts?raw";
-import FilteringJS from "/src/snippets/signup-protection/reference/sveltekit/Filtering.js?raw";
+import FilteringTS from "./Filtering.ts?raw";
+import FilteringJS from "./Filtering.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/sveltekit/Hooks.js
+++ b/src/snippets/sensitive-info/reference/sveltekit/Hooks.js
@@ -1,0 +1,25 @@
+import { env } from "$env/dynamic/private";
+import arcjet, { sensitiveInfo } from "@arcjet/sveltekit";
+import { error } from "@sveltejs/kit";
+
+const aj = arcjet({
+  key: env.ARCJET_KEY, // Get your site key from https://app.arcjet.com
+  rules: [
+    // This allows all sensitive entities other than email addresses and those containing a dash character.
+    sensitiveInfo({
+      mode: "LIVE", // Will block requests, use "DRY_RUN" to log only
+      // allow: ["EMAIL"], Will block all sensitive information types other than email.
+      deny: ["EMAIL"], // Will block email addresses
+    }),
+  ],
+});
+
+export async function handle({ event, resolve }) {
+  const decision = await aj.protect(event);
+
+  if (decision.isDenied()) {
+    return error(400, "Bad request - sensitive information detected");
+  }
+
+  return resolve(event);
+}

--- a/src/snippets/sensitive-info/reference/sveltekit/Hooks.mdx
+++ b/src/snippets/sensitive-info/reference/sveltekit/Hooks.mdx
@@ -1,15 +1,13 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import PerRouteTS from "/src/snippets/bot-protection/reference/sveltekit/PerRoute.ts?raw";
-import PerRouteJS from "/src/snippets/bot-protection/reference/sveltekit/PerRoute.js?raw";
-import Step3TS from "/src/snippets/sensitive-info/quick-start/sveltekit/Step3.ts?raw";
-import Step3JS from "/src/snippets/sensitive-info/quick-start/sveltekit/Step3.js?raw";
+import HooksTS from "./Hooks.ts?raw";
+import HooksJS from "./Hooks.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
-    <Code code={Step3TS} lang="ts" title="/src/hooks.server.ts" />
+    <Code code={HooksTS} lang="ts" title="/src/hooks.server.ts" />
   </div>
   <div slot="JS" slotIdx="2">
-    <Code code={Step3JS} lang="js" title="/src/hooks.server.js" />
+    <Code code={HooksJS} lang="js" title="/src/hooks.server.js" />
   </div>
 </SelectableContent>

--- a/src/snippets/sensitive-info/reference/sveltekit/Hooks.ts
+++ b/src/snippets/sensitive-info/reference/sveltekit/Hooks.ts
@@ -1,0 +1,31 @@
+import { env } from "$env/dynamic/private";
+import arcjet, { sensitiveInfo } from "@arcjet/sveltekit";
+import { error, type RequestEvent } from "@sveltejs/kit";
+
+const aj = arcjet({
+  key: env.ARCJET_KEY!, // Get your site key from https://app.arcjet.com
+  rules: [
+    // This allows all sensitive entities other than email addresses and those containing a dash character.
+    sensitiveInfo({
+      mode: "LIVE", // Will block requests, use "DRY_RUN" to log only
+      // allow: ["EMAIL"], Will block all sensitive information types other than email.
+      deny: ["EMAIL"], // Will block email addresses
+    }),
+  ],
+});
+
+export async function handle({
+  event,
+  resolve,
+}: {
+  event: RequestEvent;
+  resolve: (event: RequestEvent) => Response | Promise<Response>;
+}): Promise<Response> {
+  const decision = await aj.protect(event);
+
+  if (decision.isDenied()) {
+    return error(400, "Bad request - sensitive information detected");
+  }
+
+  return resolve(event);
+}

--- a/src/snippets/sensitive-info/reference/sveltekit/PerRoute.mdx
+++ b/src/snippets/sensitive-info/reference/sveltekit/PerRoute.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import PerRouteTS from "/src/snippets/sensitive-info/reference/sveltekit/PerRoute.ts?raw";
-import PerRouteJS from "/src/snippets/sensitive-info/reference/sveltekit/PerRoute.js?raw";
+import PerRouteTS from "./PerRoute.ts?raw";
+import PerRouteJS from "./PerRoute.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/sveltekit/PerRouteVsHooks.mdx
+++ b/src/snippets/sensitive-info/reference/sveltekit/PerRouteVsHooks.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import SlotByFramework from "@/components/SlotByFramework";
-import Hooks from "@/snippets/bot-protection/reference/sveltekit/Hooks.mdx";
-import PerRoute from "@/snippets/bot-protection/reference/sveltekit/PerRoute.mdx";
+import Hooks from "./Hooks.mdx";
+import PerRoute from "./PerRoute.mdx";
 import { Code } from "@astrojs/starlight/components";
-import HookMatcher from "/src/snippets/bot-protection/reference/sveltekit/HookMatcher.ts?raw";
+import HookMatcher from "./HookMatcher.ts?raw";
 
 ## Per route vs hooks
 

--- a/src/snippets/shield/quick-start/bun/Step3.mdx
+++ b/src/snippets/shield/quick-start/bun/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/shield/quick-start/bun/Step3.ts?raw";
-import Step3JS from "/src/snippets/shield/quick-start/bun/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/shield/quick-start/nextjs/Step3.mdx
+++ b/src/snippets/shield/quick-start/nextjs/Step3.mdx
@@ -1,7 +1,7 @@
-import Step3AppJS from "/src/snippets/shield/quick-start/nextjs/PerRouteApp.js?raw";
-import Step3AppTS from "/src/snippets/shield/quick-start/nextjs/PerRouteApp.ts?raw";
-import Step3PagesJS from "/src/snippets/shield/quick-start/nextjs/PerRoutePages.js?raw";
-import Step3PagesTS from "/src/snippets/shield/quick-start/nextjs/PerRoutePages.ts?raw";
+import Step3AppJS from "./PerRouteApp.js?raw";
+import Step3AppTS from "./PerRouteApp.ts?raw";
+import Step3PagesJS from "./PerRoutePages.js?raw";
+import Step3PagesTS from "./PerRoutePages.ts?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/shield/quick-start/nodejs/Step3.mdx
+++ b/src/snippets/shield/quick-start/nodejs/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/shield/quick-start/nodejs/Step3.ts?raw";
-import Step3JS from "/src/snippets/shield/quick-start/nodejs/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/shield/quick-start/sveltekit/Step3.mdx
+++ b/src/snippets/shield/quick-start/sveltekit/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/shield/quick-start/sveltekit/Step3.ts?raw";
-import Step3JS from "/src/snippets/shield/quick-start/sveltekit/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/shield/reference/bun/DecisionLog.mdx
+++ b/src/snippets/shield/reference/bun/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/shield/reference/bun/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/shield/reference/bun/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/shield/reference/bun/Errors.mdx
+++ b/src/snippets/shield/reference/bun/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/shield/reference/bun/Errors.js?raw";
-import ErrorsTS from "/src/snippets/shield/reference/bun/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/shield/reference/nextjs/DecisionLog.mdx
+++ b/src/snippets/shield/reference/nextjs/DecisionLog.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogAppJS from "/src/snippets/shield/reference/nextjs/DecisionLogApp.js?raw";
-import DecisionLogAppTS from "/src/snippets/shield/reference/nextjs/DecisionLogApp.ts?raw";
-import DecisionLogPagesJS from "/src/snippets/shield/reference/nextjs/DecisionLogPages.js?raw";
-import DecisionLogPagesTS from "/src/snippets/shield/reference/nextjs/DecisionLogPages.ts?raw";
+import DecisionLogAppJS from "./DecisionLogApp.js?raw";
+import DecisionLogAppTS from "./DecisionLogApp.ts?raw";
+import DecisionLogPagesJS from "./DecisionLogPages.js?raw";
+import DecisionLogPagesTS from "./DecisionLogPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/shield/reference/nextjs/Errors.mdx
+++ b/src/snippets/shield/reference/nextjs/Errors.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsAppJS from "/src/snippets/shield/reference/nextjs/ErrorsApp.js?raw";
-import ErrorsAppTS from "/src/snippets/shield/reference/nextjs/ErrorsApp.ts?raw";
-import ErrorsPagesJS from "/src/snippets/shield/reference/nextjs/ErrorsPages.js?raw";
-import ErrorsPagesTS from "/src/snippets/shield/reference/nextjs/ErrorsPages.ts?raw";
+import ErrorsAppJS from "./ErrorsApp.js?raw";
+import ErrorsAppTS from "./ErrorsApp.ts?raw";
+import ErrorsPagesJS from "./ErrorsPages.js?raw";
+import ErrorsPagesTS from "./ErrorsPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/shield/reference/nextjs/Middleware.mdx
+++ b/src/snippets/shield/reference/nextjs/Middleware.mdx
@@ -1,8 +1,8 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import MiddlewareTS from "/src/snippets/shield/reference/nextjs/Middleware.ts?raw";
-import MiddlewareJS from "/src/snippets/shield/reference/nextjs/Middleware.js?raw";
-import MiddlewareMatcher from "/src/snippets/shield/reference/nextjs/MiddlewareMatcher.ts?raw";
+import MiddlewareTS from "./Middleware.ts?raw";
+import MiddlewareJS from "./Middleware.js?raw";
+import MiddlewareMatcher from "./MiddlewareMatcher.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   This will run on every request to your Next.js app, except for static assets

--- a/src/snippets/shield/reference/nextjs/PerRoute.mdx
+++ b/src/snippets/shield/reference/nextjs/PerRoute.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import PerRouteAppJS from "/src/snippets/bot-protection/reference/nextjs/PerRouteApp.js?raw";
-import PerRouteAppTS from "/src/snippets/bot-protection/reference/nextjs/PerRouteApp.ts?raw";
-import PerRoutePagesJS from "/src/snippets/bot-protection/reference/nextjs/PerRoutePages.js?raw";
-import PerRoutePagesTS from "/src/snippets/bot-protection/reference/nextjs/PerRoutePages.ts?raw";
+import PerRouteAppJS from "./PerRouteApp.js?raw";
+import PerRouteAppTS from "./PerRouteApp.ts?raw";
+import PerRoutePagesJS from "./PerRoutePages.js?raw";
+import PerRoutePagesTS from "./PerRoutePages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/shield/reference/nextjs/PerRouteVsMiddleware.mdx
+++ b/src/snippets/shield/reference/nextjs/PerRouteVsMiddleware.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import SlotByFramework from "@/components/SlotByFramework";
-import MiddlewareNextJs from "@/snippets/shield/reference/nextjs/Middleware.mdx";
-import PerRouteNextJs from "@/snippets/shield/reference/nextjs/PerRoute.mdx";
+import MiddlewareNextJs from "./Middleware.mdx";
+import PerRouteNextJs from "./PerRoute.mdx";
 
 ## Per route vs middleware
 

--- a/src/snippets/shield/reference/nodejs/DecisionLog.mdx
+++ b/src/snippets/shield/reference/nodejs/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/shield/reference/nodejs/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/shield/reference/nodejs/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/shield/reference/nodejs/Errors.mdx
+++ b/src/snippets/shield/reference/nodejs/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/shield/reference/nodejs/Errors.js?raw";
-import ErrorsTS from "/src/snippets/shield/reference/nodejs/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/shield/reference/sveltekit/DecisionLog.mdx
+++ b/src/snippets/shield/reference/sveltekit/DecisionLog.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import DecisionLogJS from "/src/snippets/shield/reference/sveltekit/DecisionLog.js?raw";
-import DecisionLogTS from "/src/snippets/shield/reference/sveltekit/DecisionLog.ts?raw";
+import DecisionLogJS from "./DecisionLog.js?raw";
+import DecisionLogTS from "./DecisionLog.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/shield/reference/sveltekit/Errors.mdx
+++ b/src/snippets/shield/reference/sveltekit/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/shield/reference/sveltekit/Errors.js?raw";
-import ErrorsTS from "/src/snippets/shield/reference/sveltekit/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/shield/reference/sveltekit/Hooks.js
+++ b/src/snippets/shield/reference/sveltekit/Hooks.js
@@ -1,0 +1,23 @@
+import { env } from "$env/dynamic/private";
+import arcjet, { shield } from "@arcjet/sveltekit";
+import { error } from "@sveltejs/kit";
+
+const aj = arcjet({
+  key: env.ARCJET_KEY, // Get your site key from https://app.arcjet.com
+  rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
+  ],
+});
+
+export async function handle({ event, resolve }) {
+  const decision = await aj.protect(event);
+
+  if (decision.isDenied()) {
+    return error(403, "Forbidden");
+  }
+
+  return resolve(event);
+}

--- a/src/snippets/shield/reference/sveltekit/Hooks.mdx
+++ b/src/snippets/shield/reference/sveltekit/Hooks.mdx
@@ -1,15 +1,13 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import PerRouteTS from "/src/snippets/shield/reference/sveltekit/PerRoute.ts?raw";
-import PerRouteJS from "/src/snippets/shield/reference/sveltekit/PerRoute.js?raw";
-import Step3TS from "/src/snippets/shield/quick-start/sveltekit/Step3.ts?raw";
-import Step3JS from "/src/snippets/shield/quick-start/sveltekit/Step3.js?raw";
+import HooksTS from "./Hooks.ts?raw";
+import HooksJS from "./Hooks.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
-    <Code code={Step3TS} lang="ts" title="/src/hooks.server.ts" />
+    <Code code={HooksTS} lang="ts" title="/src/hooks.server.ts" />
   </div>
   <div slot="JS" slotIdx="2">
-    <Code code={Step3JS} lang="js" title="/src/hooks.server.js" />
+    <Code code={HooksJS} lang="js" title="/src/hooks.server.js" />
   </div>
 </SelectableContent>

--- a/src/snippets/shield/reference/sveltekit/Hooks.ts
+++ b/src/snippets/shield/reference/sveltekit/Hooks.ts
@@ -1,0 +1,29 @@
+import { env } from "$env/dynamic/private";
+import arcjet, { shield } from "@arcjet/sveltekit";
+import { error, type RequestEvent } from "@sveltejs/kit";
+
+const aj = arcjet({
+  key: env.ARCJET_KEY!, // Get your site key from https://app.arcjet.com
+  rules: [
+    // Protect against common attacks with Arcjet Shield
+    shield({
+      mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
+    }),
+  ],
+});
+
+export async function handle({
+  event,
+  resolve,
+}: {
+  event: RequestEvent;
+  resolve: (event: RequestEvent) => Response | Promise<Response>;
+}): Promise<Response> {
+  const decision = await aj.protect(event);
+
+  if (decision.isDenied()) {
+    return error(403, "Forbidden");
+  }
+
+  return resolve(event);
+}

--- a/src/snippets/shield/reference/sveltekit/PerRoute.mdx
+++ b/src/snippets/shield/reference/sveltekit/PerRoute.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import PerRouteTS from "/src/snippets/shield/reference/sveltekit/PerRoute.ts?raw";
-import PerRouteJS from "/src/snippets/shield/reference/sveltekit/PerRoute.js?raw";
+import PerRouteTS from "./PerRoute.ts?raw";
+import PerRouteJS from "./PerRoute.js?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/shield/reference/sveltekit/PerRouteVsHooks.mdx
+++ b/src/snippets/shield/reference/sveltekit/PerRouteVsHooks.mdx
@@ -1,10 +1,10 @@
 import SelectableContent from "@/components/SelectableContent";
 import SlotByFramework from "@/components/SlotByFramework";
-import Hooks from "@/snippets/shield/reference/sveltekit/Hooks.mdx";
-import PerRoute from "@/snippets/shield/reference/sveltekit/PerRoute.mdx";
+import Hooks from "./Hooks.mdx";
+import PerRoute from "./PerRoute.mdx";
 import { Code } from "@astrojs/starlight/components";
-import FilterRoutesJS from "/src/snippets/shield/reference/sveltekit/FilterRoutes.js?raw";
-import FilterRoutesTS from "/src/snippets/shield/reference/sveltekit/FilterRoutes.ts?raw";
+import FilterRoutesJS from "./FilterRoutes.js?raw";
+import FilterRoutesTS from "./FilterRoutes.ts?raw";
 
 ## Per route vs hooks
 

--- a/src/snippets/signup-protection/quick-start/bun/Step3.mdx
+++ b/src/snippets/signup-protection/quick-start/bun/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/signup-protection/quick-start/bun/Step3.ts?raw";
-import Step3JS from "/src/snippets/signup-protection/quick-start/bun/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/signup-protection/quick-start/nextjs/Step3.mdx
+++ b/src/snippets/signup-protection/quick-start/nextjs/Step3.mdx
@@ -1,11 +1,11 @@
-import Step3AppJS from "/src/snippets/signup-protection/quick-start/nextjs/Step3RouteApp.js?raw";
-import Step3AppTS from "/src/snippets/signup-protection/quick-start/nextjs/Step3RouteApp.ts?raw";
-import Step3PagesJS from "/src/snippets/signup-protection/quick-start/nextjs/Step3RoutePages.js?raw";
-import Step3PagesTS from "/src/snippets/signup-protection/quick-start/nextjs/Step3RoutePages.ts?raw";
-import Step3FormAppTS from "/src/snippets/signup-protection/quick-start/nextjs/Step3FormPages.jsx?raw";
-import Step3FormPagesTS from "/src/snippets/signup-protection/quick-start/nextjs/Step3FormApp.tsx?raw";
-import Step3FormAppJS from "/src/snippets/signup-protection/quick-start/nextjs/Step3FormPages.jsx?raw";
-import Step3FormPagesJS from "/src/snippets/signup-protection/quick-start/nextjs/Step3FormApp.tsx?raw";
+import Step3AppJS from "./Step3RouteApp.js?raw";
+import Step3AppTS from "./Step3RouteApp.ts?raw";
+import Step3PagesJS from "./Step3RoutePages.js?raw";
+import Step3PagesTS from "./Step3RoutePages.ts?raw";
+import Step3FormAppTS from "./Step3FormPages.jsx?raw";
+import Step3FormPagesTS from "./Step3FormApp.tsx?raw";
+import Step3FormAppJS from "./Step3FormPages.jsx?raw";
+import Step3FormPagesJS from "./Step3FormApp.tsx?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/signup-protection/quick-start/nodejs/Step3.mdx
+++ b/src/snippets/signup-protection/quick-start/nodejs/Step3.mdx
@@ -1,5 +1,5 @@
-import Step3TS from "/src/snippets/signup-protection/quick-start/nodejs/Step3.ts?raw";
-import Step3JS from "/src/snippets/signup-protection/quick-start/nodejs/Step3.js?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/signup-protection/quick-start/sveltekit/Step3.mdx
+++ b/src/snippets/signup-protection/quick-start/sveltekit/Step3.mdx
@@ -1,6 +1,6 @@
-import Step3Svelte from "/src/snippets/signup-protection/quick-start/sveltekit/Step3.svelte?raw";
-import Step3TS from "/src/snippets/signup-protection/quick-start/sveltekit/Step3.ts?raw";
-import Step3JS from "/src/snippets/shield/quick-start/sveltekit/Step3.js?raw";
+import Step3Svelte from "./Step3.svelte?raw";
+import Step3TS from "./Step3.ts?raw";
+import Step3JS from "./Step3.js?raw";
 import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 

--- a/src/snippets/signup-protection/reference/bun/CustomVerification.mdx
+++ b/src/snippets/signup-protection/reference/bun/CustomVerification.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import CustomVerificationTS from "/src/snippets/signup-protection/reference/bun/CustomVerification.js?raw";
-import CustomVerificationJS from "/src/snippets/signup-protection/reference/bun/CustomVerification.ts?raw";
+import CustomVerificationTS from "./CustomVerification.js?raw";
+import CustomVerificationJS from "./CustomVerification.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/signup-protection/reference/bun/Errors.mdx
+++ b/src/snippets/signup-protection/reference/bun/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/signup-protection/reference/bun/Errors.js?raw";
-import ErrorsTS from "/src/snippets/signup-protection/reference/bun/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/signup-protection/reference/bun/Recommended.mdx
+++ b/src/snippets/signup-protection/reference/bun/Recommended.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import RecommendedTS from "/src/snippets/signup-protection/reference/bun/Recommended.ts?raw";
+import RecommendedTS from "./Recommended.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/signup-protection/reference/nextjs/CustomVerification.mdx
+++ b/src/snippets/signup-protection/reference/nextjs/CustomVerification.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import CustomVerificationAppJS from "/src/snippets/signup-protection/reference/nextjs/CustomVerificationApp.js?raw";
-import CustomVerificationAppTS from "/src/snippets/signup-protection/reference/nextjs/CustomVerificationApp.ts?raw";
-import CustomVerificationPagesJS from "/src/snippets/signup-protection/reference/nextjs/CustomVerificationPages.js?raw";
-import CustomVerificationPagesTS from "/src/snippets/signup-protection/reference/nextjs/CustomVerificationPages.ts?raw";
+import CustomVerificationAppJS from "./CustomVerificationApp.js?raw";
+import CustomVerificationAppTS from "./CustomVerificationApp.ts?raw";
+import CustomVerificationPagesJS from "./CustomVerificationPages.js?raw";
+import CustomVerificationPagesTS from "./CustomVerificationPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/signup-protection/reference/nextjs/Errors.mdx
+++ b/src/snippets/signup-protection/reference/nextjs/Errors.mdx
@@ -1,9 +1,9 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorHandlingAppJS from "/src/snippets/signup-protection/reference/nextjs/ErrorHandlingApp.js?raw";
-import ErrorHandlingAppTS from "/src/snippets/signup-protection/reference/nextjs/ErrorHandlingApp.ts?raw";
-import ErrorHandlingPagesJS from "/src/snippets/signup-protection/reference/nextjs/ErrorHandlingPages.js?raw";
-import ErrorHandlingPagesTS from "/src/snippets/signup-protection/reference/nextjs/ErrorHandlingPages.ts?raw";
+import ErrorHandlingAppJS from "./ErrorHandlingApp.js?raw";
+import ErrorHandlingAppTS from "./ErrorHandlingApp.ts?raw";
+import ErrorHandlingPagesJS from "./ErrorHandlingPages.js?raw";
+import ErrorHandlingPagesTS from "./ErrorHandlingPages.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/signup-protection/reference/nextjs/Recommended.mdx
+++ b/src/snippets/signup-protection/reference/nextjs/Recommended.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import RecommendedTS from "/src/snippets/signup-protection/reference/nextjs/Recommended.ts?raw";
+import RecommendedTS from "./Recommended.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/signup-protection/reference/nodejs/CustomVerification.mdx
+++ b/src/snippets/signup-protection/reference/nodejs/CustomVerification.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import CustomVerificationTS from "/src/snippets/signup-protection/reference/nodejs/CustomVerification.js?raw";
-import CustomVerificationJS from "/src/snippets/signup-protection/reference/nodejs/CustomVerification.ts?raw";
+import CustomVerificationTS from "./CustomVerification.js?raw";
+import CustomVerificationJS from "./CustomVerification.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/signup-protection/reference/nodejs/Errors.mdx
+++ b/src/snippets/signup-protection/reference/nodejs/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/signup-protection/reference/nodejs/Errors.js?raw";
-import ErrorsTS from "/src/snippets/signup-protection/reference/nodejs/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/signup-protection/reference/nodejs/Recommended.mdx
+++ b/src/snippets/signup-protection/reference/nodejs/Recommended.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import RecommendedTS from "/src/snippets/signup-protection/reference/nodejs/Recommended.ts?raw";
+import RecommendedTS from "./Recommended.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/signup-protection/reference/sveltekit/CustomVerification.mdx
+++ b/src/snippets/signup-protection/reference/sveltekit/CustomVerification.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import CustomVerificationTS from "/src/snippets/signup-protection/reference/sveltekit/CustomVerification.js?raw";
-import CustomVerificationJS from "/src/snippets/signup-protection/reference/sveltekit/CustomVerification.ts?raw";
+import CustomVerificationTS from "./CustomVerification.js?raw";
+import CustomVerificationJS from "./CustomVerification.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/signup-protection/reference/sveltekit/Errors.mdx
+++ b/src/snippets/signup-protection/reference/sveltekit/Errors.mdx
@@ -1,7 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import ErrorsJS from "/src/snippets/signup-protection/reference/sveltekit/Errors.js?raw";
-import ErrorsTS from "/src/snippets/signup-protection/reference/sveltekit/Errors.ts?raw";
+import ErrorsJS from "./Errors.js?raw";
+import ErrorsTS from "./Errors.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/signup-protection/reference/sveltekit/Recommended.mdx
+++ b/src/snippets/signup-protection/reference/sveltekit/Recommended.mdx
@@ -1,6 +1,6 @@
 import SelectableContent from "@/components/SelectableContent";
 import { Code } from "@astrojs/starlight/components";
-import RecommendedTS from "/src/snippets/signup-protection/reference/sveltekit/Recommended.ts?raw";
+import RecommendedTS from "./Recommended.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">


### PR DESCRIPTION
As @danni-popova pointed out in #222, using absolute paths for snippets can cause problems that we can't easily catch. We should be using relative paths so everything is contained in the snippets directory, which I've changed in this PR.

It also helped me catch some more of these mistakes.