### PR TITLE
chore: Change homepage to drop right into the docs

### DIFF
--- a/src/components/FrameworkLinks.tsx
+++ b/src/components/FrameworkLinks.tsx
@@ -19,8 +19,16 @@ import styles from "./FrameworkLinks.module.scss";
  *
  * Renders a list of buttons that switch to a specific framework.
  */
+
+interface FrameworkLinksProps extends PropsWithChildren {
+  title?: string;
+}
+
 const FrameworkLinks = forwardRef(
-  ({ ...props }: PropsWithChildren, ref: ForwardedRef<HTMLDivElement>) => {
+  (
+    { title = "Choose a framework", ...props }: FrameworkLinksProps,
+    ref: ForwardedRef<HTMLDivElement>,
+  ) => {
     const [hide, setHide] = useState(true);
 
     const $queryParamFramework = useStore(queryParamFramework);
@@ -39,7 +47,7 @@ const FrameworkLinks = forwardRef(
     return (
       !hide && (
         <div ref={ref} className={cls} {...props}>
-          <h2 id="choose-a-framework">Choose a framework</h2>
+          <h2 id="choose-a-framework">{title}</h2>
           <div className={styles.Links}>
             <Button
               as="link"

--- a/src/components/Hero.module.scss
+++ b/src/components/Hero.module.scss
@@ -89,7 +89,6 @@
   .Hero {
     grid-template-columns: 7fr 4fr;
     gap: 4%;
-    padding-block: clamp(2.5rem, calc(1rem + 10vmin), 10rem);
 
     .Image {
       order: 2;

--- a/src/content/docs/get-started.mdx
+++ b/src/content/docs/get-started.mdx
@@ -111,7 +111,7 @@ protection. Data redaction. A developer-first approach to security.
 
 This guide will show you how to set up a simple API server protected by Arcjet.
 
-<FrameworkLinks client:load />
+<FrameworkLinks title="Choose a framework" client:load />
 
 ## 1. Install Arcjet
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -4,115 +4,42 @@ head:
   # Use a custom <title> tag
   - tag: title
     content: Arcjet docs
-template: splash
+tableOfContents: false
 hero:
-  tagline: Arcjet helps developers protect their apps in just a few lines of code. Bot detection. Rate limiting. Email validation. Attack protection. Data redaction. A developer-first approach to security.
+  tagline: Bot detection. Rate limiting. Email validation. Attack protection. Data redaction. A developer-first approach to security.
   image:
     alt: Arcjet space object.
     dark: "/src/assets/arcjet-space-obj-v2-5-dark.png"
     light: "/src/assets/arcjet-space-obj-v2-5-light.png"
-  actions:
-    - text: Get started
-      link: /get-started
-      icon: right-arrow
-      variant: primary
-      attrs:
-        ajIcon: mark
-        ajIconPos: left
-        group: 0
-    - text: Next.js
-      link: /get-started?f=next-js
-      icon: right-arrow
-      variant: minimal
-      attrs:
-        ajIcon: next-js
-        ajIconPos: left
-        group: 1
-    - text: Node.js
-      link: /get-started?f=node-js
-      icon: right-arrow
-      variant: minimal
-      attrs:
-        ajIcon: node-js
-        ajIconPos: left
-        group: 1
-    - text: Bun, Remix, NestJS & more...
-      link: /get-started
-      icon: right-arrow
-      variant: minimal
-      attrs:
-        ajIcon: arrow-right
-        ajIconPos: right
-        group: 1
 ---
 
-import Block from "/src/components/Block";
+import FrameworkLinks from "@/components/FrameworkLinks";
 import Launch from "@/components/Launch";
-import { Card, CardGrid } from "@astrojs/starlight/components";
-import "/src/styles/docs/index.scss";
 
-<CardGrid>
-  <Block>
-    <a href="/signup-protection/concepts">
-      <h4>Signup form protection</h4>
-    </a>
-    Combine rate limiting, bot protection, and email validation to [protect your
-    signup forms from abuse](/signup-protection/concepts).
-  </Block>
-  <Block>
-    <a href="/rate-limiting/concepts">
-      <h4>Rate limiting</h4>
-    </a>
-    [Set up rate limits](/rate-limiting/concepts) to prevent abuse of your
-    application.
-  </Block>
-  <Block>
-    <a href="/bot-protection/concepts">
-      <h4>Bot protection</h4>
-    </a>
-    [Manage traffic](/bot-protection/concepts) from automated clients and bots.
-  </Block>
-  <Block>
-    <a href="/email-validation/concepts">
-      <h4>Email validation</h4>
-    </a>
-    [Validate & verify](/email-validation/concepts) email addresses to prevent
-    signup spam.
-  </Block>
-  <Block>
-    <a href="/shield/concepts">
-      <h4>Shield</h4>
-    </a>
-    Protect your application from common attacks using [Arcjet
-    Shield](/shield/concepts).
-  </Block>
-  <Block>
-    <a href="/sensitive-info/concepts">
-      <h4>Sensitive information</h4>
-    </a>
-    [Protects against](/sensitive-info/concepts) clients sending you PII that
-    you do not wish to handle.
-  </Block>
-  <Block>
-    <a href="/architecture">
-      <h4>Architecture</h4>
-    </a>
-    Learn about [how Arcjet works](/architecture).
-  </Block>
-  <Block>
-    <a href="/examples">
-      <h4>Examples & blueprints</h4>
-    </a>
-    See what you can do with Arcjet.
-  </Block>
-</CardGrid>
+<FrameworkLinks title="Get started" client:load />
 
+## Learn more
+
+<br />
+
+<Launch
+  client:load
+  text="Use cases and example apps."
+  actions={[
+    {
+      text: "Examples & blueprints",
+      link: "/examples/",
+      decoratorRight: "arrow-right",
+    },
+  ]}
+/>
+<br />
 <Launch
   client:load
   text="Learn about how Arcjet works."
   actions={[
     {
-      text: "Arcjet’s architecture",
+      text: "Arcjet's architecture",
       link: "/architecture/",
       decoratorRight: "arrow-right",
     },


### PR DESCRIPTION
Based on the feedback from one of our developer interviews, this changes the home landing page to drop the user right into the docs.

This reveals the full sidebar immediately so it's one less click to get where you want to go if you already know what you want. It also shows the full depth of the docs to new users.
