### PR TITLE
chore: Refactor rate limiting quick start

### DIFF
--- a/src/content/docs/rate-limiting/quick-start.mdx
+++ b/src/content/docs/rate-limiting/quick-start.mdx
@@ -34,26 +34,32 @@ ajToc:
 ---
 
 import { LinkCard, CardGrid } from "@astrojs/starlight/components";
-import WhatIsArcjet from "/src/components/WhatIsArcjet.astro";
+import WhatIsArcjet from "@/components/WhatIsArcjet.astro";
 import SlotByFramework from "@/components/SlotByFramework";
 import FrameworkName from "@/components/FrameworkName";
-import VideoQuickStart from "@/snippets/rate-limiting/quick-start/nextjs/VideoQuickStart.mdx";
-import Step1Bun from "@/snippets/rate-limiting/quick-start/bun/Step1.mdx";
-import Step1NextJs from "@/snippets/rate-limiting/quick-start/nextjs/Step1.mdx";
-import Step1NodeJs from "@/snippets/rate-limiting/quick-start/nodejs/Step1.mdx";
-import Step1SvelteKit from "@/snippets/rate-limiting/quick-start/sveltekit/Step1.mdx";
-import Step2 from "@/snippets/rate-limiting/quick-start/shared/Step2.mdx";
-import Step2SetEnv from "@/snippets/rate-limiting/quick-start/shared/Step2SetEnv.mdx";
-import Step3Bun from "@/snippets/rate-limiting/quick-start/bun/Step3.mdx";
-import Step3NextJs from "@/snippets/rate-limiting/quick-start/nextjs/Step3.mdx";
-import Step3NodeJs from "@/snippets/rate-limiting/quick-start/nodejs/Step3.mdx";
-import Step3SvelteKit from "@/snippets/rate-limiting/quick-start/sveltekit/Step3.mdx";
-import Step4 from "@/snippets/rate-limiting/quick-start/nextjs/Step4.mdx";
-import Step4SvelteKit from "@/snippets/rate-limiting/quick-start/sveltekit/Step4.mdx";
-import Step4Bun from "@/snippets/rate-limiting/quick-start/bun/Step4.mdx";
-import Step4NodeJs from "@/snippets/rate-limiting/quick-start/nodejs/Step4.mdx";
-import FAQs from "/src/components/FAQs.astro";
-import Comments from "/src/components/Comments.astro";
+import FAQs from "@/components/FAQs.astro";
+import Comments from "@/components/Comments.astro";
+
+import BunStep1 from "@/snippets/rate-limiting/quick-start/bun/Step1.mdx";
+import BunStep2 from "@/snippets/rate-limiting/quick-start/bun/Step2.mdx";
+import BunStep3 from "@/snippets/rate-limiting/quick-start/bun/Step3.mdx";
+import BunStep4 from "@/snippets/rate-limiting/quick-start/bun/Step4.mdx";
+
+import NextJsVideoQuickStart from "@/snippets/rate-limiting/quick-start/nextjs/VideoQuickStart.mdx";
+import NextJsStep1 from "@/snippets/rate-limiting/quick-start/nextjs/Step1.mdx";
+import NextJsStep2 from "@/snippets/rate-limiting/quick-start/nextjs/Step2.mdx";
+import NextJsStep3 from "@/snippets/rate-limiting/quick-start/nextjs/Step3.mdx";
+import NextJsStep4 from "@/snippets/rate-limiting/quick-start/nextjs/Step4.mdx";
+
+import NodeJsStep1 from "@/snippets/rate-limiting/quick-start/nodejs/Step1.mdx";
+import NodeJsStep2 from "@/snippets/rate-limiting/quick-start/nodejs/Step2.mdx";
+import NodeJsStep3 from "@/snippets/rate-limiting/quick-start/nodejs/Step3.mdx";
+import NodeJsStep4 from "@/snippets/rate-limiting/quick-start/nodejs/Step4.mdx";
+
+import SvelteKitStep1 from "@/snippets/rate-limiting/quick-start/sveltekit/Step1.mdx";
+import SvelteKitStep2 from "@/snippets/rate-limiting/quick-start/sveltekit/Step2.mdx";
+import SvelteKitStep3 from "@/snippets/rate-limiting/quick-start/sveltekit/Step3.mdx";
+import SvelteKitStep4 from "@/snippets/rate-limiting/quick-start/sveltekit/Step4.mdx";
 
 Arcjet rate limiting allows you to define rules which limit the number of
 requests a client can make over a period of time.
@@ -61,7 +67,7 @@ requests a client can make over a period of time.
 <WhatIsArcjet />
 
 <SlotByFramework client:load>
-  <VideoQuickStart slot="next-js" />
+  <NextJsVideoQuickStart slot="next-js" />
 </SlotByFramework>
 
 ## Quick start
@@ -73,23 +79,22 @@ This guide will show you how to add a simple rate limit to your <FrameworkName c
 In your project root, run the following command to install the SDK:
 
 <SlotByFramework client:load>
-  <Step1Bun slot="bun" />
-  <Step1NextJs slot="next-js" />
-  <Step1NodeJs slot="node-js" />
-  <Step1SvelteKit slot="sveltekit" />
+  <BunStep1 slot="bun" />
+  <NextJsStep1 slot="next-js" />
+  <NodeJsStep1 slot="node-js" />
+  <SvelteKitStep1 slot="sveltekit" />
 </SlotByFramework>
 
 ### 2. Set your key
 
 [Create a free Arcjet account](https://app.arcjet.com) then follow the
-instructions to add a site and get a key. Add it to a `.env.local` file in your
-project root.
+instructions to add a site and get a key.
 
 <SlotByFramework client:load>
-  <Step2SetEnv slot="bun" />
-  <Step2 slot="next-js" />
-  <Step2SetEnv slot="node-js" />
-  <Step2 slot="sveltekit" />
+  <BunStep2 slot="bun" />
+  <NextJsStep2 slot="next-js" />
+  <NodeJsStep2 slot="node-js" />
+  <SvelteKitStep2 slot="sveltekit" />
 </SlotByFramework>
 
 ### 3. Add a rate limit to a route
@@ -100,17 +105,17 @@ configured with a maximum capacity of 10 tokens and refills by 5 tokens every
 10 seconds. Each request consumes 5 tokens.
 
 <SlotByFramework client:load>
-  <Step3Bun slot="bun" />
-  <Step3NextJs slot="next-js" />
-  <Step3NodeJs slot="node-js" />
-  <Step3SvelteKit slot="sveltekit" />
+  <BunStep3 slot="bun" />
+  <NextJsStep3 slot="next-js" />
+  <NodeJsStep3 slot="node-js" />
+  <SvelteKitStep3 slot="sveltekit" />
 </SlotByFramework>
 
 <SlotByFramework client:load>
-  <Step4Bun slot="bun" />
-  <Step4 slot="next-js" />
-  <Step4NodeJs slot="node-js" />
-  <Step4SvelteKit slot="sveltekit" />
+  <BunStep4 slot="bun" />
+  <NextJsStep4 slot="next-js" />
+  <NodeJsStep4 slot="node-js" />
+  <SvelteKitStep4 slot="sveltekit" />
 </SlotByFramework>
 
 ## FAQs

--- a/src/snippets/rate-limiting/quick-start/bun/Step2.mdx
+++ b/src/snippets/rate-limiting/quick-start/bun/Step2.mdx
@@ -1,0 +1,15 @@
+Add your key to a `.env.local` file in your project root.
+
+```ini title=".env.local"
+# NODE_ENV is not set automatically, so tell Arcjet we're in dev
+# You can leave this unset in prod
+ARCJET_ENV=development
+# Get your site key from https://app.arcjet.com
+ARCJET_KEY=ajkey_yourkey
+```
+
+:::caution[IP Address]
+Arcjet only accepts non-local IP addresses with a fallback to 127.0.0.1 in
+development mode. Since Bun doesn't set `NODE_ENV` for you, you also need to
+set `ARCJET_ENV` in your environment file.
+:::

--- a/src/snippets/rate-limiting/quick-start/nextjs/Step2.mdx
+++ b/src/snippets/rate-limiting/quick-start/nextjs/Step2.mdx
@@ -1,0 +1,5 @@
+Add your key to a `.env.local` file in your project root.
+
+```ini title=".env.local"
+ARCJET_KEY=ajkey_yourkey
+```

--- a/src/snippets/rate-limiting/quick-start/nodejs/Step2.mdx
+++ b/src/snippets/rate-limiting/quick-start/nodejs/Step2.mdx
@@ -1,0 +1,15 @@
+Add your key to a `.env.local` file in your project root.
+
+```ini title=".env.local"
+# NODE_ENV is not set automatically, so tell Arcjet we're in dev
+# You can leave this unset in prod
+ARCJET_ENV=development
+# Get your site key from https://app.arcjet.com
+ARCJET_KEY=ajkey_yourkey
+```
+
+:::caution[IP Address]
+Arcjet only accepts non-local IP addresses with a fallback to 127.0.0.1 in
+development mode. Since Node.js doesn't set `NODE_ENV` for you, you also need to
+set `ARCJET_ENV` in your environment file.
+:::

--- a/src/snippets/rate-limiting/quick-start/shared/Step2.mdx
+++ b/src/snippets/rate-limiting/quick-start/shared/Step2.mdx
@@ -1,3 +1,0 @@
-```ini title=".env.local"
-ARCJET_KEY=ajkey_yourkey
-```

--- a/src/snippets/rate-limiting/quick-start/shared/Step2SetEnv.mdx
+++ b/src/snippets/rate-limiting/quick-start/shared/Step2SetEnv.mdx
@@ -1,9 +1,0 @@
-import FrameworkName from "@/components/FrameworkName";
-
-```ini title=".env.local"
-# NODE_ENV is not set automatically, so tell Arcjet we're in dev
-# You can leave this unset in prod
-ARCJET_ENV=development
-# Get your site key from https://app.arcjet.com
-ARCJET_KEY=ajkey_yourkey
-```

--- a/src/snippets/rate-limiting/quick-start/sveltekit/Step2.mdx
+++ b/src/snippets/rate-limiting/quick-start/sveltekit/Step2.mdx
@@ -1,0 +1,5 @@
+Add your key to a `.env` file in your project root.
+
+```ini title=".env"
+ARCJET_KEY=ajkey_yourkey
+```


### PR DESCRIPTION
This refactors the rate limit quick start the same way that I've been refactoring the other docs. It makes it easier to copy-paste new frameworks.

Built upon #248 since I removed the extra import I found.