### PR TITLE
chore: Change default bot rules to show some other common options

### DIFF
--- a/src/snippets/bot-protection/quick-start/bun/Step3.js
+++ b/src/snippets/bot-protection/quick-start/bun/Step3.js
@@ -6,9 +6,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/bot-protection/quick-start/bun/Step3.ts
+++ b/src/snippets/bot-protection/quick-start/bun/Step3.ts
@@ -6,9 +6,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/bot-protection/quick-start/deno/Step3.ts
+++ b/src/snippets/bot-protection/quick-start/deno/Step3.ts
@@ -7,9 +7,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/bot-protection/quick-start/nextjs/Step3.js
+++ b/src/snippets/bot-protection/quick-start/nextjs/Step3.js
@@ -9,9 +9,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/bot-protection/quick-start/nextjs/Step3.ts
+++ b/src/snippets/bot-protection/quick-start/nextjs/Step3.ts
@@ -9,9 +9,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/bot-protection/quick-start/nextjs/Step3Advanced.js
+++ b/src/snippets/bot-protection/quick-start/nextjs/Step3Advanced.js
@@ -11,9 +11,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/bot-protection/quick-start/nextjs/Step3Advanced.ts
+++ b/src/snippets/bot-protection/quick-start/nextjs/Step3Advanced.ts
@@ -11,9 +11,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/bot-protection/quick-start/nodejs/Step3.js
+++ b/src/snippets/bot-protection/quick-start/nodejs/Step3.js
@@ -6,9 +6,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/bot-protection/quick-start/nodejs/Step3.ts
+++ b/src/snippets/bot-protection/quick-start/nodejs/Step3.ts
@@ -6,9 +6,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/bot-protection/quick-start/sveltekit/Step3.js
+++ b/src/snippets/bot-protection/quick-start/sveltekit/Step3.js
@@ -7,9 +7,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/bot-protection/quick-start/sveltekit/Step3.ts
+++ b/src/snippets/bot-protection/quick-start/sveltekit/Step3.ts
@@ -7,9 +7,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/bot-protection/reference/nextjs/Middleware.js
+++ b/src/snippets/bot-protection/reference/nextjs/Middleware.js
@@ -9,9 +9,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/bot-protection/reference/nextjs/Middleware.ts
+++ b/src/snippets/bot-protection/reference/nextjs/Middleware.ts
@@ -9,9 +9,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/bot-protection/reference/sveltekit/Hooks.js
+++ b/src/snippets/bot-protection/reference/sveltekit/Hooks.js
@@ -7,9 +7,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/bot-protection/reference/sveltekit/Hooks.ts
+++ b/src/snippets/bot-protection/reference/sveltekit/Hooks.ts
@@ -7,9 +7,14 @@ const aj = arcjet({
   rules: [
     detectBot({
       mode: "LIVE", // will block requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See the full list of bots
-      // for other options: https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });

--- a/src/snippets/get-started/bun-hono/Step3.ts
+++ b/src/snippets/get-started/bun-hono/Step3.ts
@@ -11,9 +11,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/bun/BunServe.ts
+++ b/src/snippets/get-started/bun/BunServe.ts
@@ -11,9 +11,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/bun/Step3.js
+++ b/src/snippets/get-started/bun/Step3.js
@@ -10,9 +10,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/bun/Step3.ts
+++ b/src/snippets/get-started/bun/Step3.ts
@@ -10,9 +10,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/deno/Step3.ts
+++ b/src/snippets/get-started/deno/Step3.ts
@@ -11,9 +11,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/nest-js/GlobalGuard.ts
+++ b/src/snippets/get-started/nest-js/GlobalGuard.ts
@@ -23,9 +23,14 @@ import { APP_GUARD, NestFactory } from "@nestjs/core";
         // Create a bot detection rule
         detectBot({
           mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-          // Block all bots except search engine crawlers. See
-          // https://arcjet.com/bot-list
-          allow: ["CATEGORY:SEARCH_ENGINE"],
+          // Block all bots except the following
+          allow: [
+            "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+            // Uncomment to allow these other common bot categories
+            // See the full list at https://arcjet.com/bot-list
+            //"CATEGORY:MONITOR", // Uptime monitoring services
+            //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+          ],
         }),
         // Create a fixed window rate limit. Other algorithms are supported.
         fixedWindow({

--- a/src/snippets/get-started/next-js/Step3App.js
+++ b/src/snippets/get-started/next-js/Step3App.js
@@ -10,9 +10,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/next-js/Step3App.ts
+++ b/src/snippets/get-started/next-js/Step3App.ts
@@ -10,9 +10,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/next-js/Step3Pages.js
+++ b/src/snippets/get-started/next-js/Step3Pages.js
@@ -9,9 +9,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/next-js/Step3Pages.ts
+++ b/src/snippets/get-started/next-js/Step3Pages.ts
@@ -10,9 +10,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/node-js-express/Express.js
+++ b/src/snippets/get-started/node-js-express/Express.js
@@ -15,9 +15,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/node-js-hono/Step3.ts
+++ b/src/snippets/get-started/node-js-hono/Step3.ts
@@ -11,9 +11,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/node-js/Step3.js
+++ b/src/snippets/get-started/node-js/Step3.js
@@ -10,9 +10,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/node-js/Step3.ts
+++ b/src/snippets/get-started/node-js/Step3.ts
@@ -10,9 +10,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/remix/Step3.tsx
+++ b/src/snippets/get-started/remix/Step3.tsx
@@ -10,9 +10,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/sveltekit/Step3.js
+++ b/src/snippets/get-started/sveltekit/Step3.js
@@ -11,9 +11,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/get-started/sveltekit/Step3.ts
+++ b/src/snippets/get-started/sveltekit/Step3.ts
@@ -11,9 +11,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
     // Create a token bucket rate limit. Other algorithms are supported.
     tokenBucket({

--- a/src/snippets/reference/nextjs/PageComponent.tsx
+++ b/src/snippets/reference/nextjs/PageComponent.tsx
@@ -10,9 +10,14 @@ const aj = arcjet({
     // Create a bot detection rule
     detectBot({
       mode: "LIVE", // Blocks requests. Use "DRY_RUN" to log only
-      // Block all bots except search engine crawlers. See
-      // https://arcjet.com/bot-list
-      allow: ["CATEGORY:SEARCH_ENGINE"],
+      // Block all bots except the following
+      allow: [
+        "CATEGORY:SEARCH_ENGINE", // Google, Bing, etc
+        // Uncomment to allow these other common bot categories
+        // See the full list at https://arcjet.com/bot-list
+        //"CATEGORY:MONITOR", // Uptime monitoring services
+        //"CATEGORY:PREVIEW", // Link previews e.g. Slack, Discord
+      ],
     }),
   ],
 });


### PR DESCRIPTION
It's common to also want to allow uptime monitoring and social preview links to
work properly alongside search engines, so provide those examples as well.
