### PR TITLE
fix: Only apply line numbers to some languages

### DIFF
--- a/ec.config.mjs
+++ b/ec.config.mjs
@@ -2,7 +2,42 @@ import { pluginCollapsibleSections } from "@expressive-code/plugin-collapsible-s
 import { pluginLineNumbers } from "@expressive-code/plugin-line-numbers";
 import { defineEcConfig } from "astro-expressive-code";
 
+function lineNumbers() {
+  // Only show line numbers on these languages
+  const lineNumberLanguages = [
+    "js",
+    "jsx",
+    "ts",
+    "tsx",
+    "ini",
+  ];
+
+  let plugin = pluginLineNumbers();
+
+  return {
+    ...plugin,
+    name: `Line numbers (${lineNumberLanguages.join(", ")})`,
+    hooks: {
+      preprocessMetadata: (opt) => {
+        const { codeBlock: { language } } = opt;
+        if (lineNumberLanguages.includes(language)) {
+          return plugin.hooks.preprocessMetadata(opt);
+        }
+      },
+
+      postprocessRenderedBlock: (opt) => {
+        const { codeBlock: { language } } = opt;
+        if (lineNumberLanguages.includes(language)) {
+          return plugin.hooks.postprocessRenderedBlock(opt);
+        }
+      },
+    }
+  };
+}
+
 export default defineEcConfig({
-  plugins: [pluginCollapsibleSections()],
-  plugins: [pluginLineNumbers(), pluginCollapsibleSections()],
+  plugins: [
+    lineNumbers(),
+    pluginCollapsibleSections(),
+  ],
 });


### PR DESCRIPTION
Something that has been bugging me was that we had line numbers on terminals and output. With this change, I'm restricting the Expressive Code Line Numbers plugin to only apply to some languages (see the array in the PR).