### PR TITLE
deps: Explicitly depend upon Node.js types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "@types/bun": "1.1.13",
         "@types/deno": "2.0.0",
         "@types/express": "5.0.0",
+        "@types/node": "18.19.66",
         "@types/react": "18.3.12",
         "@types/react-dom": "18.3.1"
       }
@@ -4325,9 +4326,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.19.56",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.56.tgz",
-      "integrity": "sha512-4EMJlWwwGnVPflJAtM14p9eVSa6BOv5b92mCsh5zcM1UagNtEtrbbtaE6WE1tw2TabavatnwqXjlIpcAEuJJNg==",
+      "version": "18.19.66",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.66.tgz",
+      "integrity": "sha512-14HmtUdGxFUalGRfLLn9Gc1oNWvWh5zNbsyOLo5JV6WARSeN1QcEBKRnZm9QqNfrutgsl/hY4eJW63aZ44aBCg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@types/bun": "1.1.13",
     "@types/deno": "2.0.0",
     "@types/express": "5.0.0",
+    "@types/node": "18.19.66",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1"
   }


### PR DESCRIPTION
This makes the `@types/node` dependency explicit. I found that we were using outdated types and I needed something added in a newer version. By making it explicit, we can be in control of the version.