### PR TITLE
docs: document bot verification

### DIFF
--- a/src/content/docs/bot-protection/reference.mdx
+++ b/src/content/docs/bot-protection/reference.mdx
@@ -287,6 +287,8 @@ properties.
 </SlotByFramework>
 
 ## Error handling
+
+Arcjet is designed to fail open so that a service issue or misconfiguration does
 not block all requests. The SDK will also time out and fail open after 1000ms
 when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
 in most cases, the response time will be less than 20-30ms.
@@ -333,12 +335,13 @@ their "advertising quality" bot.
 
 ## Bot verification
 
-We support verifying the authenticity of requests from identifiable bots by
+We support verifying the authenticity of requests from some bots by
 comparing the request IP to published bot IP ranges or performing a reverse
-DNS query. To check the verification status, use the `.isSpoofed()` or `.isVerified()`
-methods on the reason object. If verification was performed, one of these will be true
-and the other false; both will be false if verification failed or is unsupported
-for the identified bot. 
+DNS query. Verificaiton is performed for supported bots using the appropriate method
+automatically after the bot is identified by Arcjet. To check the verification status,
+use the `.isSpoofed()` or `.isVerified()` methods on the bot reason object. If
+verification was performed, one of these will be true and the other false; both
+will be false if verification failed or if we don't support verifying the identified bot. 
 
 :::note
 It's recommended to check verification status only when using an allow configuration.

--- a/src/content/docs/bot-protection/reference.mdx
+++ b/src/content/docs/bot-protection/reference.mdx
@@ -62,6 +62,8 @@ ajToc:
     anchor: "error-handling"
   - text: "Filtering categories"
     anchor: "filtering-categories"
+  - text: "Bot verification"
+    anchor: "bot-verification"
   - text: "Testing"
     anchor: "testing"
   - text: "Examples"
@@ -168,8 +170,8 @@ Most applications want to block almost all bots. However, it is common to allow
 some bots to access your system, such as bots for search indexing or API
 access from the command line.
 
-When allowing specific bots we recommend that you also check the verification
-status after an allow decision is returned to ensure that the bots are who they
+When allowing specific bots we recommend that you also [check the verification
+status](#bot-verification) after an allow decision is returned to ensure that the bots are who they
 say they are.
 
 This behavior is configured with an `allow` list from our [full list of
@@ -338,7 +340,9 @@ their "advertising quality" bot.
 We support verifying the authenticity of requests from some bots by
 comparing the request IP to published bot IP ranges or performing a reverse
 DNS query. Verificaiton is performed for supported bots using the appropriate method
-automatically after the bot is identified by Arcjet. To check the verification status,
+automatically after the bot is identified by Arcjet.
+
+To check the verification status,
 use the `.isSpoofed()` or `.isVerified()` methods on the bot reason object. If
 verification was performed, one of these will be true and the other false; both
 will be false if verification failed or if we don't support verifying the identified bot. 

--- a/src/content/docs/bot-protection/reference.mdx
+++ b/src/content/docs/bot-protection/reference.mdx
@@ -168,6 +168,10 @@ Most applications want to block almost all bots. However, it is common to allow
 some bots to access your system, such as bots for search indexing or API
 access from the command line.
 
+When allowing specific bots we recommend that you also check the verification
+status after an allow decision is returned to ensure that the bots are who they
+say they are.
+
 This behavior is configured with an `allow` list from our [full list of
 bots](https://arcjet.com/bot-list) and/or [bot
 categories](/bot-protection/identifying-bots#bot-categories).
@@ -283,8 +287,6 @@ properties.
 </SlotByFramework>
 
 ## Error handling
-
-Arcjet is designed to fail open so that a service issue or misconfiguration does
 not block all requests. The SDK will also time out and fail open after 1000ms
 when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
 in most cases, the response time will be less than 20-30ms.
@@ -328,6 +330,32 @@ their "advertising quality" bot.
   <RemixFiltering slot="remix" />
   <SvelteKitFiltering slot="sveltekit" />
 </SlotByFramework>
+
+## Bot verification
+
+We support verifying the authenticity of requests from identifiable bots by
+comparing the request IP to published bot IP ranges or performing a reverse
+DNS query. To check the verification status, use the `.isSpoofed()` or `.isVerified()`
+methods on the reason object. If verification was performed, one of these will be true
+and the other false; both will be false if verification failed or is unsupported
+for the identified bot. 
+
+:::note
+It's recommended to check verification status only when using an allow configuration.
+For deny configurations, verification is skipped as you'd want to block listed bots
+regardless of legitimacy.
+:::
+
+Here's a basic usage example:
+```ts
+if (decision.reason.isSpoofed()) {
+  // Show a custom block page for spoofed bots
+} else if (decision.reason.isVerified()) {
+  // You can now trust that the bot is who they say they are and proceed as normal
+} else {
+  // The bot either does not support verification, or verification failed.
+}
+```
 
 ## Testing
 

--- a/src/content/docs/bot-protection/reference.mdx
+++ b/src/content/docs/bot-protection/reference.mdx
@@ -339,7 +339,7 @@ their "advertising quality" bot.
 
 We support verifying the authenticity of requests from some bots by
 comparing the request IP to published bot IP ranges or performing a reverse
-DNS query. Verificaiton is performed for supported bots using the appropriate method
+DNS query. Verification is performed for supported bots using the appropriate method
 automatically after the bot is identified by Arcjet.
 
 To check the verification status,

--- a/src/snippets/bot-protection/quick-start/bun/Step3.js
+++ b/src/snippets/bot-protection/quick-start/bun/Step3.js
@@ -27,6 +27,10 @@ export default {
       return new Response("Forbidden", { status: 403 });
     }
 
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 };

--- a/src/snippets/bot-protection/quick-start/bun/Step3.ts
+++ b/src/snippets/bot-protection/quick-start/bun/Step3.ts
@@ -27,6 +27,10 @@ export default {
       return new Response("Forbidden", { status: 403 });
     }
 
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 };

--- a/src/snippets/bot-protection/quick-start/deno/Step3.ts
+++ b/src/snippets/bot-protection/quick-start/deno/Step3.ts
@@ -28,6 +28,10 @@ Deno.serve(
       return new Response("Forbidden", { status: 403 });
     }
 
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 );

--- a/src/snippets/bot-protection/quick-start/nodejs/Step3.js
+++ b/src/snippets/bot-protection/quick-start/nodejs/Step3.js
@@ -18,7 +18,7 @@ const aj = arcjet({
   ],
 });
 
-const server = http.createServer(async function (req, res) {
+const server = http.createServer(async function(req, res) {
   const decision = await aj.protect(req);
   console.log("Arcjet decision", decision);
 
@@ -26,6 +26,11 @@ const server = http.createServer(async function (req, res) {
     res.writeHead(403, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "Forbidden" }));
   } else {
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Forbidden" }));
+    }
+
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ message: "Hello world" }));
   }

--- a/src/snippets/bot-protection/quick-start/nodejs/Step3.ts
+++ b/src/snippets/bot-protection/quick-start/nodejs/Step3.ts
@@ -18,7 +18,7 @@ const aj = arcjet({
   ],
 });
 
-const server = http.createServer(async function (
+const server = http.createServer(async function(
   req: http.IncomingMessage,
   res: http.ServerResponse,
 ) {
@@ -29,6 +29,11 @@ const server = http.createServer(async function (
     res.writeHead(403, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "Forbidden" }));
   } else {
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Forbidden" }));
+    }
+
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ message: "Hello world" }));
   }

--- a/src/snippets/bot-protection/quick-start/remix/Step3.jsx
+++ b/src/snippets/bot-protection/quick-start/remix/Step3.jsx
@@ -29,6 +29,10 @@ export async function loader(args) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }
 
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
+  }
+
   // We don't need to use the decision elsewhere, but you could return it to
   // the component
   return null;

--- a/src/snippets/bot-protection/quick-start/remix/Step3.tsx
+++ b/src/snippets/bot-protection/quick-start/remix/Step3.tsx
@@ -30,6 +30,10 @@ export async function loader(args: LoaderFunctionArgs) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }
 
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
+  }
+
   // We don't need to use the decision elsewhere, but you could return it to
   // the component
   return null;

--- a/src/snippets/bot-protection/quick-start/sveltekit/Step3.js
+++ b/src/snippets/bot-protection/quick-start/sveltekit/Step3.js
@@ -26,5 +26,9 @@ export async function handle({ event, resolve }) {
     return error(403, "Forbidden");
   }
 
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return error(403, "Forbidden");
+  }
+
   return resolve(event);
 }

--- a/src/snippets/bot-protection/quick-start/sveltekit/Step3.ts
+++ b/src/snippets/bot-protection/quick-start/sveltekit/Step3.ts
@@ -32,5 +32,9 @@ export async function handle({
     return error(403, "Forbidden");
   }
 
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return error(403, "Forbidden");
+  }
+
   return resolve(event);
 }

--- a/src/snippets/bot-protection/reference/bun/AllowingBots.js
+++ b/src/snippets/bot-protection/reference/bun/AllowingBots.js
@@ -28,6 +28,10 @@ export default {
       return new Response("Forbidden", { status: 403 });
     }
 
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 };

--- a/src/snippets/bot-protection/reference/bun/AllowingBots.ts
+++ b/src/snippets/bot-protection/reference/bun/AllowingBots.ts
@@ -28,6 +28,10 @@ export default {
       return new Response("Forbidden", { status: 403 });
     }
 
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 };

--- a/src/snippets/bot-protection/reference/bun/DecisionLog.js
+++ b/src/snippets/bot-protection/reference/bun/DecisionLog.js
@@ -38,6 +38,10 @@ export default {
       return new Response("Forbidden", { status: 403 });
     }
 
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 };

--- a/src/snippets/bot-protection/reference/bun/DecisionLog.ts
+++ b/src/snippets/bot-protection/reference/bun/DecisionLog.ts
@@ -38,6 +38,10 @@ export default {
       return new Response("Forbidden", { status: 403 });
     }
 
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 };

--- a/src/snippets/bot-protection/reference/bun/Errors.js
+++ b/src/snippets/bot-protection/reference/bun/Errors.js
@@ -31,6 +31,10 @@ export default {
       return new Response("Forbidden", { status: 403 });
     }
 
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 };

--- a/src/snippets/bot-protection/reference/bun/Errors.ts
+++ b/src/snippets/bot-protection/reference/bun/Errors.ts
@@ -31,6 +31,10 @@ export default {
       return new Response("Forbidden", { status: 403 });
     }
 
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 };

--- a/src/snippets/bot-protection/reference/bun/Filtering.js
+++ b/src/snippets/bot-protection/reference/bun/Filtering.js
@@ -27,6 +27,10 @@ export default {
       return new Response("Forbidden", { status: 403 });
     }
 
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 };

--- a/src/snippets/bot-protection/reference/bun/Filtering.ts
+++ b/src/snippets/bot-protection/reference/bun/Filtering.ts
@@ -27,6 +27,10 @@ export default {
       return new Response("Forbidden", { status: 403 });
     }
 
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 };

--- a/src/snippets/bot-protection/reference/deno/AllowingBots.ts
+++ b/src/snippets/bot-protection/reference/deno/AllowingBots.ts
@@ -27,6 +27,10 @@ Deno.serve(
       return new Response("Forbidden", { status: 403 });
     }
 
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 );

--- a/src/snippets/bot-protection/reference/deno/Filtering.ts
+++ b/src/snippets/bot-protection/reference/deno/Filtering.ts
@@ -26,6 +26,10 @@ Deno.serve(
       return new Response("Forbidden", { status: 403 });
     }
 
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 );

--- a/src/snippets/bot-protection/reference/nextjs/AllowingBotsApp.js
+++ b/src/snippets/bot-protection/reference/nextjs/AllowingBotsApp.js
@@ -22,16 +22,28 @@ const aj = arcjet({
 export async function POST(req) {
   const decision = await aj.protect(req);
 
-  if (decision.isDenied() && decision.reason.isBot()) {
-    return NextResponse.json(
-      {
-        error: "You are a bot!",
-        // Useful for debugging, but don't return these to the client in
-        // production
-        denied: decision.reason.denied,
-      },
-      { status: 403 },
-    );
+  if (decision.reason.isBot()) {
+    if (decision.isDenied()) {
+      return NextResponse.json(
+        {
+          error: "You are a bot!",
+          // Useful for debugging, but don't return these to the client in
+          // production
+          denied: decision.reason.denied,
+        },
+        { status: 403 },
+      );
+    } else if (decision.reason.isSpoofed()) {
+      return NextResponse.json(
+        {
+          error: "You are a bot!",
+          // Useful for debugging, but don't return these to the client in
+          // production
+          denied: decision.reason.denied,
+        },
+        { status: 403 },
+      );
+    }
   }
 
   return NextResponse.json({

--- a/src/snippets/bot-protection/reference/nextjs/AllowingBotsApp.js
+++ b/src/snippets/bot-protection/reference/nextjs/AllowingBotsApp.js
@@ -23,17 +23,7 @@ export async function POST(req) {
   const decision = await aj.protect(req);
 
   if (decision.reason.isBot()) {
-    if (decision.isDenied()) {
-      return NextResponse.json(
-        {
-          error: "You are a bot!",
-          // Useful for debugging, but don't return these to the client in
-          // production
-          denied: decision.reason.denied,
-        },
-        { status: 403 },
-      );
-    } else if (decision.reason.isSpoofed()) {
+    if (decision.isDenied() || decision.reason.isSpoofed()) {
       return NextResponse.json(
         {
           error: "You are a bot!",

--- a/src/snippets/bot-protection/reference/nextjs/AllowingBotsApp.ts
+++ b/src/snippets/bot-protection/reference/nextjs/AllowingBotsApp.ts
@@ -22,16 +22,28 @@ const aj = arcjet({
 export async function POST(req: Request) {
   const decision = await aj.protect(req);
 
-  if (decision.isDenied() && decision.reason.isBot()) {
-    return NextResponse.json(
-      {
-        error: "You are a bot!",
-        // Useful for debugging, but don't return these to the client in
-        // production
-        denied: decision.reason.denied,
-      },
-      { status: 403 },
-    );
+  if (decision.reason.isBot()) {
+    if (decision.isDenied()) {
+      return NextResponse.json(
+        {
+          error: "You are a bot!",
+          // Useful for debugging, but don't return these to the client in
+          // production
+          denied: decision.reason.denied,
+        },
+        { status: 403 },
+      );
+    } else if (decision.reason.isSpoofed()) {
+      return NextResponse.json(
+        {
+          error: "You are a bot!",
+          // Useful for debugging, but don't return these to the client in
+          // production
+          denied: decision.reason.denied,
+        },
+        { status: 403 },
+      );
+    }
   }
 
   return NextResponse.json({

--- a/src/snippets/bot-protection/reference/nextjs/AllowingBotsApp.ts
+++ b/src/snippets/bot-protection/reference/nextjs/AllowingBotsApp.ts
@@ -22,18 +22,9 @@ const aj = arcjet({
 export async function POST(req: Request) {
   const decision = await aj.protect(req);
 
+
   if (decision.reason.isBot()) {
-    if (decision.isDenied()) {
-      return NextResponse.json(
-        {
-          error: "You are a bot!",
-          // Useful for debugging, but don't return these to the client in
-          // production
-          denied: decision.reason.denied,
-        },
-        { status: 403 },
-      );
-    } else if (decision.reason.isSpoofed()) {
+    if (decision.isDenied() || decision.reason.isSpoofed()) {
       return NextResponse.json(
         {
           error: "You are a bot!",

--- a/src/snippets/bot-protection/reference/nextjs/AllowingBotsPages.js
+++ b/src/snippets/bot-protection/reference/nextjs/AllowingBotsPages.js
@@ -21,13 +21,22 @@ const aj = arcjet({
 export default async function handler(req, res) {
   const decision = await aj.protect(req);
 
-  if (decision.isDenied() && decision.reason.isBot()) {
-    return res.status(403).json({
-      error: "Forbidden",
-      // Useful for debugging, but don't return these to the client in
-      // production
-      denied: decision.reason.denied,
-    });
+  if (decision.reason.isBot()) {
+    if (decision.isDenied()) {
+      return res.status(403).json({
+        error: "Forbidden",
+        // Useful for debugging, but don't return these to the client in
+        // production
+        denied: decision.reason.denied,
+      });
+    } else if (decision.reason.isSpoofed()) {
+      return res.status(403).json({
+        error: "Forbidden",
+        // Useful for debugging, but don't return these to the client in
+        // production
+        denied: decision.reason.denied,
+      });
+    }
   }
 
   res.status(200).json({ name: "Hello world" });

--- a/src/snippets/bot-protection/reference/nextjs/AllowingBotsPages.ts
+++ b/src/snippets/bot-protection/reference/nextjs/AllowingBotsPages.ts
@@ -25,13 +25,23 @@ export default async function handler(
 ) {
   const decision = await aj.protect(req);
 
-  if (decision.isDenied() && decision.reason.isBot()) {
-    return res.status(403).json({
-      error: "Forbidden",
-      // Useful for debugging, but don't return these to the client in
-      // production
-      denied: decision.reason.denied,
-    });
+  if (decision.reason.isBot()) {
+    if (decision.isDenied()) {
+      return res.status(403).json({
+        error: "Forbidden",
+        // Useful for debugging, but don't return these to the client in
+        // production
+        denied: decision.reason.denied,
+      });
+    } else if (decision.reason.isSpoofed()) {
+
+      return res.status(403).json({
+        error: "Forbidden",
+        // Useful for debugging, but don't return these to the client in
+        // production
+        denied: decision.reason.denied,
+      });
+    }
   }
 
   res.status(200).json({ name: "Hello world" });

--- a/src/snippets/bot-protection/reference/nextjs/AllowingBotsPages.ts
+++ b/src/snippets/bot-protection/reference/nextjs/AllowingBotsPages.ts
@@ -34,7 +34,6 @@ export default async function handler(
         denied: decision.reason.denied,
       });
     } else if (decision.reason.isSpoofed()) {
-
       return res.status(403).json({
         error: "Forbidden",
         // Useful for debugging, but don't return these to the client in

--- a/src/snippets/bot-protection/reference/nextjs/FilteringApp.js
+++ b/src/snippets/bot-protection/reference/nextjs/FilteringApp.js
@@ -21,16 +21,28 @@ const aj = arcjet({
 export async function POST(req) {
   const decision = await aj.protect(req);
 
-  if (decision.isDenied() && decision.reason.isBot()) {
-    return NextResponse.json(
-      {
-        error: "You are a bot!",
-        // Useful for debugging, but don't return these to the client in
-        // production
-        denied: decision.reason.denied,
-      },
-      { status: 403 },
-    );
+  if (decision.reason.isBot()) {
+    if (decision.isDenied()) {
+      return NextResponse.json(
+        {
+          error: "You are a bot!",
+          // Useful for debugging, but don't return these to the client in
+          // production
+          denied: decision.reason.denied,
+        },
+        { status: 403 },
+      );
+    } else if (decision.reason.isSpoofed()) {
+      return NextResponse.json(
+        {
+          error: "You are a bot!",
+          // Useful for debugging, but don't return these to the client in
+          // production
+          denied: decision.reason.denied,
+        },
+        { status: 403 },
+      );
+    }
   }
 
   return NextResponse.json({

--- a/src/snippets/bot-protection/reference/nextjs/FilteringApp.ts
+++ b/src/snippets/bot-protection/reference/nextjs/FilteringApp.ts
@@ -21,16 +21,28 @@ const aj = arcjet({
 export async function POST(req: Request) {
   const decision = await aj.protect(req);
 
-  if (decision.isDenied() && decision.reason.isBot()) {
-    return NextResponse.json(
-      {
-        error: "You are a bot!",
-        // Useful for debugging, but don't return these to the client in
-        // production
-        denied: decision.reason.denied,
-      },
-      { status: 403 },
-    );
+  if (decision.reason.isBot()) {
+    if (decision.isDenied()) {
+      return NextResponse.json(
+        {
+          error: "You are a bot!",
+          // Useful for debugging, but don't return these to the client in
+          // production
+          denied: decision.reason.denied,
+        },
+        { status: 403 },
+      );
+    } else if (decision.reason.isSpoofed()) {
+      return NextResponse.json(
+        {
+          error: "You are a bot!",
+          // Useful for debugging, but don't return these to the client in
+          // production
+          denied: decision.reason.denied,
+        },
+        { status: 403 },
+      );
+    }
   }
 
   return NextResponse.json({

--- a/src/snippets/bot-protection/reference/nextjs/FilteringPages.js
+++ b/src/snippets/bot-protection/reference/nextjs/FilteringPages.js
@@ -20,13 +20,22 @@ const aj = arcjet({
 export default async function handler(req, res) {
   const decision = await aj.protect(req);
 
-  if (decision.isDenied() && decision.reason.isBot()) {
-    return res.status(403).json({
-      error: "Forbidden",
-      // Useful for debugging, but don't return these to the client in
-      // production
-      denied: decision.reason.denied,
-    });
+  if (decision.reason.isBot()) {
+    if (decision.isDenied()) {
+      return res.status(403).json({
+        error: "Forbidden",
+        // Useful for debugging, but don't return these to the client in
+        // production
+        denied: decision.reason.denied,
+      });
+    } else if (decision.reason.isSpoofed()) {
+      return res.status(403).json({
+        error: "Forbidden",
+        // Useful for debugging, but don't return these to the client in
+        // production
+        denied: decision.reason.denied,
+      });
+    }
   }
 
   res.status(200).json({ name: "Hello world" });

--- a/src/snippets/bot-protection/reference/nextjs/FilteringPages.ts
+++ b/src/snippets/bot-protection/reference/nextjs/FilteringPages.ts
@@ -24,13 +24,22 @@ export default async function handler(
 ) {
   const decision = await aj.protect(req);
 
-  if (decision.isDenied() && decision.reason.isBot()) {
-    return res.status(403).json({
-      error: "Forbidden",
-      // Useful for debugging, but don't return these to the client in
-      // production
-      denied: decision.reason.denied,
-    });
+  if (decision.reason.isBot()) {
+    if (decision.isDenied()) {
+      return res.status(403).json({
+        error: "Forbidden",
+        // Useful for debugging, but don't return these to the client in
+        // production
+        denied: decision.reason.denied,
+      });
+    } else if (decision.reason.isSpoofed()) {
+      return res.status(403).json({
+        error: "Forbidden",
+        // Useful for debugging, but don't return these to the client in
+        // production
+        denied: decision.reason.denied,
+      });
+    }
   }
 
   res.status(200).json({ name: "Hello world" });

--- a/src/snippets/bot-protection/reference/remix/AllowingBots.js
+++ b/src/snippets/bot-protection/reference/remix/AllowingBots.js
@@ -25,5 +25,9 @@ export async function loader(args) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }
 
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
+  }
+
   return null;
 }

--- a/src/snippets/bot-protection/reference/remix/AllowingBots.ts
+++ b/src/snippets/bot-protection/reference/remix/AllowingBots.ts
@@ -26,5 +26,9 @@ export async function loader(args: LoaderFunctionArgs) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }
 
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
+  }
+
   return null;
 }

--- a/src/snippets/bot-protection/reference/remix/Filtering.js
+++ b/src/snippets/bot-protection/reference/remix/Filtering.js
@@ -24,5 +24,9 @@ export async function loader(args) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }
 
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
+  }
+
   return null;
 }

--- a/src/snippets/bot-protection/reference/sveltekit/AllowingBots.js
+++ b/src/snippets/bot-protection/reference/sveltekit/AllowingBots.js
@@ -27,5 +27,9 @@ export async function handle({ event, resolve }) {
     return error(403, "You are a bot!");
   }
 
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return error(403, "You are a bot!");
+  }
+
   return resolve(event);
 }

--- a/src/snippets/bot-protection/reference/sveltekit/AllowingBots.ts
+++ b/src/snippets/bot-protection/reference/sveltekit/AllowingBots.ts
@@ -33,5 +33,9 @@ export async function handle({
     return error(403, "You are a bot!");
   }
 
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return error(403, "You are a bot!");
+  }
+
   return resolve(event);
 }

--- a/src/snippets/bot-protection/reference/sveltekit/Filtering.js
+++ b/src/snippets/bot-protection/reference/sveltekit/Filtering.js
@@ -26,5 +26,9 @@ export async function handle({ event, resolve }) {
     return error(403, "You are a bot!");
   }
 
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return error(403, "You are a bot!");
+  }
+
   return resolve(event);
 }

--- a/src/snippets/bot-protection/reference/sveltekit/Hooks.js
+++ b/src/snippets/bot-protection/reference/sveltekit/Hooks.js
@@ -26,5 +26,9 @@ export async function handle({ event, resolve }) {
     return error(403, "Forbidden");
   }
 
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return error(403, "You are a bot!");
+  }
+
   return resolve(event);
 }

--- a/src/snippets/bot-protection/reference/sveltekit/Hooks.ts
+++ b/src/snippets/bot-protection/reference/sveltekit/Hooks.ts
@@ -32,5 +32,9 @@ export async function handle({
     return error(403, "Forbidden");
   }
 
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return error(403, "You are a bot!");
+  }
+
   return resolve(event);
 }


### PR DESCRIPTION
Adds documentation for Arcjet's bot verification feature.

It only updates examples that are configured in an "allow" mode, because that is how we recommend using the feature.