### PR TITLE
feat: Add component describing Arcjet utilities

### DIFF
--- a/src/components/WhatAreArcjetUtilities.astro
+++ b/src/components/WhatAreArcjetUtilities.astro
@@ -9,6 +9,6 @@
 
   <p>
     We take the pain out of implementing security tasks through these utilities
-    to provide a wholistic approach to developer-first security.
+    to provide a security as code approach to developer-first security.
   </p>
 </details>

--- a/src/components/WhatAreArcjetUtilities.astro
+++ b/src/components/WhatAreArcjetUtilities.astro
@@ -1,0 +1,14 @@
+<details>
+  <summary><strong>What are Arcjet utilities?</strong></summary>
+
+  <p>
+    <a href="https://arcjet.com">Arcjet</a> utilities are independent libraries
+    that do not require the use of the main Arcjet SDK—they can be used with or
+    without other Arcjet rules.
+  </p>
+
+  <p>
+    We take the pain out of implementing security tasks through these utilities
+    to provide a wholistic approach to developer-first security.
+  </p>
+</details>

--- a/src/content/docs/redact/quick-start.mdx
+++ b/src/content/docs/redact/quick-start.mdx
@@ -4,17 +4,16 @@ description: "Quick start guide for redacting sensitive information locally."
 ---
 
 import { Code } from "@astrojs/starlight/components";
-import WhatIsArcjet from "/src/components/WhatIsArcjet.astro";
+import WhatAreArcjetUtilities from "@/components/WhatAreArcjetUtilities.astro";
 import FAQs from "/src/components/FAQs.astro";
 import QuickStartRedact from "/src/snippets/redact/QuickStartRedact.ts?raw";
 import QuickStartUnredact from "/src/snippets/redact/QuickStartUnredact.ts?raw";
 import Comments from "/src/components/Comments.astro";
 
 The Arcjet Redaction library makes it easy to redact sensitive information
-locally. It is a utility library independent of the main Arcjet SDK so can be
-used with or without other Arcjet rules.
+locally.
 
-<WhatIsArcjet />
+<WhatAreArcjetUtilities />
 
 ## SDK installation
 

--- a/src/content/docs/redact/reference.mdx
+++ b/src/content/docs/redact/reference.mdx
@@ -4,7 +4,7 @@ description: "Reference for the Arcjet redaction library"
 ---
 
 import { Code } from "@astrojs/starlight/components";
-import WhatIsArcjet from "/src/components/WhatIsArcjet.astro";
+import WhatAreArcjetUtilities from "@/components/WhatAreArcjetUtilities.astro";
 import FAQs from "/src/components/FAQs.astro";
 import CustomEntities from "/src/snippets/redact/CustomEntities.ts?raw";
 import CustomRedact from "/src/snippets/redact/CustomRedact.ts?raw";
@@ -12,10 +12,9 @@ import QuickStartUnredact from "/src/snippets/redact/QuickStartUnredact.ts?raw";
 import Comments from "/src/components/Comments.astro";
 
 The Arcjet Redaction library makes it easy to redact sensitive information
-locally. It is a utility library independent of the main Arcjet SDK so can be
-used with or without other Arcjet rules.
+locally.
 
-<WhatIsArcjet />
+<WhatAreArcjetUtilities />
 
 ## Configuration
 


### PR DESCRIPTION
Implements @davidmytton's suggestion from https://github.com/arcjet/arcjet-docs/pull/279/files#r1862108081 because it should be out-of-scope for that PR.

Let's get the wording and stuff resolved here and then pull it into the nosecone PR.