### PR TITLE
feat: Introduce DisplayType component that outputs pretty-printed types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,11 +61,14 @@
         "pagefind": "1.2.0",
         "pino": "9.5.0",
         "pino-pretty": "13.0.0",
+        "prettier": "3.4.2",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "sass": "1.81.1",
         "sharp": "0.33.5",
         "starlight-links-validator": "0.13.4",
+        "twoslash": "0.2.12",
+        "type-fest": "4.30.0",
         "typescript": "5.7.2",
         "zod": "3.23.8",
         "zod-validation-error": "3.4.0"
@@ -76,7 +79,8 @@
         "@types/express": "5.0.0",
         "@types/node": "18.19.66",
         "@types/react": "18.3.12",
-        "@types/react-dom": "18.3.1"
+        "@types/react-dom": "18.3.1",
+        "patch-package": "8.0.0"
       }
     },
     "node_modules/@ai-sdk/openai": {
@@ -4751,6 +4755,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript/vfs": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.6.0.tgz",
+      "integrity": "sha512-hvJUjNVeBMp77qPINuUvYXj4FyWeeMMKZkxEATEU3hqBAQ7qdTBCUFT7Sp0Zu0faeEtFf+ldXxMEDr/bk73ISg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
@@ -4936,6 +4952,13 @@
       "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
       "integrity": "sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==",
       "license": "(Apache-2.0 AND MIT)"
+    },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/@zxing/text-encoding": {
       "version": "0.9.0",
@@ -5473,6 +5496,16 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -6361,7 +6394,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -7646,6 +7678,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/find-yarn-workspace-root2": {
       "version": "1.2.16",
       "resolved": "https://registry.npmjs.org/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.16.tgz",
@@ -7774,6 +7816,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/fs-minipass": {
@@ -9148,8 +9216,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/iso-datestring-validator": {
       "version": "2.2.2",
@@ -9256,12 +9323,38 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz",
+      "integrity": "sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/json-stable-stringify/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -9308,6 +9401,39 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonpointer": {
@@ -9378,6 +9504,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -11452,6 +11588,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/oidc-token-hash": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
@@ -11514,6 +11660,52 @@
         "emoji-regex-xs": "^1.0.0",
         "regex": "^5.0.2",
         "regex-recursion": "^4.3.0"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/openai": {
@@ -11663,6 +11855,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/p-finally": {
@@ -11873,6 +12075,77 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/patch-package": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -11902,7 +12175,6 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12267,12 +12539,10 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13261,7 +13531,6 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -13274,7 +13543,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13884,6 +14152,19 @@
         "tlds": "bin.js"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -14021,6 +14302,25 @@
       "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
       "license": "ISC"
     },
+    "node_modules/twoslash": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/twoslash/-/twoslash-0.2.12.tgz",
+      "integrity": "sha512-tEHPASMqi7kqwfJbkk7hc/4EhlrKCSLcur+TcvYki3vhIfaRMXnXjaYFgXpoZRbT6GdprD4tGuVBEmTpUgLBsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript/vfs": "^1.6.0",
+        "twoslash-protocol": "0.2.12"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/twoslash-protocol": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/twoslash-protocol/-/twoslash-protocol-0.2.12.tgz",
+      "integrity": "sha512-5qZLXVYfZ9ABdjqbvPc4RWMr7PrpPaaDSeaYY55vl/w1j6H6kzsWK/urAEIXlzYlyrFmyz1UbwIt+AA0ck+wbg==",
+      "license": "MIT"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -14035,9 +14335,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
-      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.30.0.tgz",
+      "integrity": "sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -14893,7 +15193,6 @@
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
+    "prepare": "patch-package",
     "dev": "astro dev --host",
     "start": "astro dev",
     "build": "astro check && astro build",
@@ -63,11 +64,14 @@
     "pagefind": "1.2.0",
     "pino": "9.5.0",
     "pino-pretty": "13.0.0",
+    "prettier": "3.4.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "sass": "1.81.1",
     "sharp": "0.33.5",
     "starlight-links-validator": "0.13.4",
+    "twoslash": "0.2.12",
+    "type-fest": "4.30.0",
     "typescript": "5.7.2",
     "zod": "3.23.8",
     "zod-validation-error": "3.4.0"
@@ -82,6 +86,7 @@
     "@types/express": "5.0.0",
     "@types/node": "18.19.66",
     "@types/react": "18.3.12",
-    "@types/react-dom": "18.3.1"
+    "@types/react-dom": "18.3.1",
+    "patch-package": "8.0.0"
   }
 }

--- a/patches/typescript+5.7.2.patch
+++ b/patches/typescript+5.7.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/typescript/lib/typescript.js b/node_modules/typescript/lib/typescript.js
+index 33387ea..2429417 100644
+--- a/node_modules/typescript/lib/typescript.js
++++ b/node_modules/typescript/lib/typescript.js
+@@ -16114,7 +16114,7 @@ function isInternalDeclaration(node, sourceFile) {
+ // src/compiler/utilities.ts
+ var resolvingEmptyArray = [];
+ var externalHelpersModuleNameText = "tslib";
+-var defaultMaximumTruncationLength = 160;
++var defaultMaximumTruncationLength = 1e6;
+ var noTruncationMaximumTruncationLength = 1e6;
+ function getDeclarationOfKind(symbol, kind) {
+   const declarations = symbol.declarations;

--- a/src/components/DisplayType.astro
+++ b/src/components/DisplayType.astro
@@ -1,0 +1,28 @@
+---
+import { createTwoslasher} from "twoslash"
+import { format } from "prettier";
+import { Code } from "@astrojs/starlight/components";
+
+const twoslasher = createTwoslasher();
+
+const generics = Array.isArray(Astro.props.generics) && Astro.props.generics.length > 0
+    ? `<${Astro.props.generics.join(", ")}>`
+    : ''
+
+const snippet = `
+import type { Simplify } from "type-fest";
+import type { ${Astro.props.type} as __Dummy } from "${Astro.props.from}";
+type ${Astro.props.type}${generics} = Simplify<__Dummy${generics}>;
+//   ^?
+`
+
+const result = twoslasher(snippet, "ts");
+
+let types = [];
+for (const query of result.queries) {
+    types.push(query.text);
+}
+let code = await format(types.join("\n"), { parser: "typescript" });
+---
+
+<Code code={code} lang="ts" />

--- a/src/content/docs/email-validation/reference.mdx
+++ b/src/content/docs/email-validation/reference.mdx
@@ -25,6 +25,7 @@ ajToc:
 import { Aside } from "@astrojs/starlight/components";
 import SlotByFramework from "@/components/SlotByFramework";
 import TextByFramework from "@/components/TextByFramework";
+import DisplayType from "@/components/DisplayType.astro";
 
 import DecisionLogBun from "@/snippets/email-validation/reference/bun/DecisionLog.mdx";
 import DecisionLogNestJs from "@/snippets/email-validation/reference/nestjs/DecisionLog.mdx";
@@ -51,19 +52,13 @@ reduce the amount of spam or fraudulent accounts.
 Email validation is configured by specifying the email types you wish to block
 and whether you wish to modify certain validation options.
 
-The configuration definition is:
+The `arcjet` client can be configured with one or more Email validation rules,
+which are constructed with the `validateEmail(options: EmailOptions)` function
+and configured by `EmailOptions`:
 
-```ts
-type EmailOptions = {
-  mode?: "LIVE" | "DRY_RUN";
-  block?: ArcjetEmailType[];
-  requireTopLevelDomain?: boolean; // default: true
-  allowDomainLiteral?: boolean; // default: false
-};
-```
-
-The `arcjet` client is configured with one or many `validateEmail` rules which
-take `EmailOptions`.
+<DisplayType type="EmailOptions" from="arcjet" />
+<DisplayType type="ArcjetMode" from="arcjet" />
+<DisplayType type="ArcjetEmailType" from="arcjet" />
 
 <Aside type="note">
   When specifying multiple rules, the order of the rules is ignored. Rule

--- a/src/content/docs/sensitive-info/reference.mdx
+++ b/src/content/docs/sensitive-info/reference.mdx
@@ -59,6 +59,7 @@ ajToc:
 
 import SlotByFramework from "@/components/SlotByFramework";
 import TextByFramework from "@/components/TextByFramework";
+import DisplayType from "@/components/DisplayType.astro";
 
 import NestJsDecoratorRoutes from "@/snippets/sensitive-info/reference/nestjs/DecoratorRoutes.mdx";
 import PerRouteVsMiddlewareNextJs from "@/snippets/sensitive-info/reference/nextjs/PerRouteVsMiddleware.mdx";
@@ -92,32 +93,42 @@ sensitive information such as PII that you do not wish to handle.
 
 ## Configuration
 
-Sensitive Info is configured by specifying which mode you want it to run in.
+Sensitive information detection is configured by allowing or denying a subset of
+sensitive information. The `allow` and `deny` lists are mutually-exclusive, such
+that using `allow` will result in a `DENY` decision for any detected sensitive
+information that is not specified in the `allow` list and using `deny` will
+result in an `ALLOW` decision for any detected sensitive information that is not
+specified in the `deny` list.
 
-The configuration definition is:
+The `arcjet` client can be configured with one or more Sensitive information
+rules, which are constructed with the
+`sensitiveInfo(options: SensitiveInfoOptionsAllow | SensitiveInfoOptionsDeny)`
+function and configured by `SensitiveInfoOptionsAllow` or
+`SensitiveInfoOptionsDeny`:
 
 ```ts
-type SensitiveInfoOptions = {
+type SensitiveInfoOptionsAllow = {
   mode?: "LIVE" | "DRY_RUN";
-  allow?: Array<SensitiveInfoType>; // Cannot be specified if `deny` is present
-  deny?: Array<SensitiveInfoType>;// Cannot be specified if `allow` is present
+  allow?: Array<ArcjetSensitiveInfoType>;
   contextWindowSize?: number;
+  // You can also provide a custom detection function to detect other types
+  // of sensitive information (see below).
   detect?: (tokens: string[]) -> Array<SensitiveInfoType | undefined>;
 };
 ```
 
-The `arcjet` client is configured with one or more `sensitiveInfo` rules which take
-one or many `SensitiveInfoOptions`.
+```ts
+type SensitiveInfoOptionsDeny = {
+  mode?: "LIVE" | "DRY_RUN";
+  deny?: Array<ArcjetSensitiveInfoType>;
+  contextWindowSize?: number;
+  // You can also provide a custom detection function to detect other types
+  // of sensitive information (see below).
+  detect?: (tokens: string[]) -> Array<SensitiveInfoType | undefined>;
+};
+```
 
-The `SensitiveInfoType` enum allows the following values:
-
-- `EMAIL`
-- `CREDIT_CARD`
-- `IP_ADDRESS`
-- `PHONE_NUMBER`
-
-You can also provide a custom detection function to detect other types of
-sensitive information (see below).
+<DisplayType type="ArcjetSensitiveInfoType" from="arcjet" />
 
 :::note
 When specifying multiple rules, the order of the rules is ignored. Rule

--- a/src/content/docs/shield/reference.mdx
+++ b/src/content/docs/shield/reference.mdx
@@ -60,6 +60,7 @@ ajToc:
 
 import SlotByFramework from "@/components/SlotByFramework";
 import TextByFramework from "@/components/TextByFramework";
+import DisplayType from "@/components/DisplayType.astro";
 
 import DecisionLogBun from "@/snippets/shield/reference/bun/DecisionLog.mdx";
 import ErrorsBun from "@/snippets/shield/reference/bun/Errors.mdx";
@@ -87,16 +88,12 @@ Arcjet Shield protects your application against common attacks, including the
 
 Shield is configured by specifying which mode you want it to run in.
 
-The configuration definition is:
+The `arcjet` client can be configured with one or more Shield rules, which are
+constructed with the `shield(options: ShieldOptions)` function and configured by
+`ShieldOptions`:
 
-```ts
-type ShieldOptions = {
-  mode?: "LIVE" | "DRY_RUN";
-};
-```
-
-The `arcjet` client is configured with one or more `shield` rules which take
-one or many `ShieldOptions`.
+<DisplayType type="ShieldOptions" from="arcjet" />
+<DisplayType type="ArcjetMode" from="arcjet" />
 
 :::note
 When specifying multiple rules, the order of the rules is ignored. Rule


### PR DESCRIPTION
This introduces an Astro component that loads a module, extracts a specified type, simplifies it by one level, and then pretty-prints it.

This will ensure that our docs always match exported types from the SDK packages and can reduce the work needed to document large types like `NoseconeOptions`.

It doesn't work on all types because we might want to handwrite them in a simpler fashion, such as the `SensitiveInfoOptions`; this is common when we have heavy use of generics.

This work also highlighted some places where we should probably export types, such as `BotOptionsAllow` and `BotOptionsDeny`.

TypeScript has a hardcoded truncation length. It is [on their roadmap](https://github.com/microsoft/TypeScript/issues/59029), but in the meantime I introduced `patch-package` to update the value when we do `npm ci`.

Lastly, I cleaned up some of the wording in the reference documentation where I introduced `<DisplayType />`