### PR TITLE
fix: Leverage twoslasher singleton to avoid OOM

### DIFF
--- a/src/components/DisplayType.astro
+++ b/src/components/DisplayType.astro
@@ -1,9 +1,7 @@
 ---
-import { createTwoslasher} from "twoslash"
 import { format } from "prettier";
 import { Code } from "@astrojs/starlight/components";
-
-const twoslasher = createTwoslasher();
+import twoslasher from "@/lib/twoslasher";
 
 const generics = Array.isArray(Astro.props.generics) && Astro.props.generics.length > 0
     ? `<${Astro.props.generics.join(", ")}>`

--- a/src/lib/twoslasher.ts
+++ b/src/lib/twoslasher.ts
@@ -1,0 +1,5 @@
+import { createTwoslasher} from "twoslash"
+
+const twoslasher = createTwoslasher();
+
+export default twoslasher;


### PR DESCRIPTION
When trying to use the new `DisplayType` component many time on a larger page resulted in a Out-Of-Memory crash. This was due to a new instance of twoslasher being created for each use. By moving it into a module, the singleton is reused by every instance and the OoM goes away.