### PR TITLE
chore: Extend verification examples and docs

### DIFF
--- a/src/content/docs/blueprints/payment-form.mdx
+++ b/src/content/docs/blueprints/payment-form.mdx
@@ -101,6 +101,15 @@ if (decision.isDenied()) {
   }
 }
 
+// Arcjet Pro plan verifies the authenticity of common bots using IP data.
+// Verification isn't always possible, so we recommend checking the decision
+// separately.
+// https://docs.arcjet.com/bot-protection/reference#bot-verification
+if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+  console.error("Spoofed bot detected", decision);
+  // Return 403
+}
+
 // Base Arcjet rules all passed, but we can do further inspection based on
 // our knowledge of our customers
 
@@ -341,6 +350,18 @@ export async function POST(request: Request) {
           { status: 403 },
         );
       }
+    }
+
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      console.error("Spoofed bot detected", decision);
+      return NextResponse.json(
+        { success: false, message: "Forbidden" },
+        { status: 403 },
+      );
     }
 
     // Base Arcjet rules all passed, but we can do further inspection based on

--- a/src/content/docs/bot-protection/concepts.mdx
+++ b/src/content/docs/bot-protection/concepts.mdx
@@ -4,6 +4,7 @@ description: "Arcjet bot protection allows you to manage traffic by automated cl
 prev: false
 ---
 
+import { Badge } from "@astrojs/starlight/components";
 import WhatIsArcjet from "/src/components/WhatIsArcjet.astro";
 import Comments from "/src/components/Comments.astro";
 
@@ -26,6 +27,11 @@ It's impossible to create a system that can block all bots. Good bots identify
 themselves in a consistent manner so it is straightforward to identify them, but
 those are often not the bots you wish to block! Bad bots pretend to be real
 clients and use various mechanisms to evade bot detection.
+
+The Arcjet <Badge text="Pro" variant="note" /> plan or above provides additional
+bot verification using IP analysis, which can help if you are under attack from
+bots pretending to be good bots e.g. clients pretending to be Google (who you
+usually want to allow).
 
 Arcjet's bot protect works best when combined with [rate
 limiting](/rate-limiting/concepts). This allows you to block clients that are

--- a/src/content/docs/bot-protection/identifying-bots.mdx
+++ b/src/content/docs/bot-protection/identifying-bots.mdx
@@ -4,6 +4,7 @@ description: "Arcjet can detect many different bots and automated clients."
 next: false
 ---
 
+import { Badge } from "@astrojs/starlight/components";
 import Comments from "/src/components/Comments.astro";
 
 Arcjet allows you to configure a list of bots to allow or deny. To construct the
@@ -85,9 +86,13 @@ if you need a specific category.
 
 ## Detection
 
-For basic detection, Arcjet uses the `User-Agent` header to identify specific
-bots. Advanced bot detection supplements this with additional fingerprinting
-techniques such as IP address analysis.
+For basic detection on the <Badge text="Free" variant="caution" /> plan, Arcjet
+uses the `User-Agent` header to identify specific bots.
+
+The Arcjet <Badge text="Pro" variant="note" /> plan or above provides additional
+bot verification using IP analysis, which can help if you are under attack from
+bots pretending to be good bots e.g. clients pretending to be Google (who you
+usually want to allow).
 
 :::note
 Requests without `User-Agent` headers can not be identified as any particular

--- a/src/content/docs/bot-protection/reference.mdx
+++ b/src/content/docs/bot-protection/reference.mdx
@@ -74,6 +74,7 @@ ajToc:
     framework: ["next-js"]
 ---
 
+import { Badge } from "@astrojs/starlight/components";
 import Comments from "@/components/Comments.astro";
 import SlotByFramework from "@/components/SlotByFramework";
 import TextByFramework from "@/components/TextByFramework";
@@ -340,30 +341,45 @@ their "advertising quality" bot.
 
 ## Bot verification
 
-We support verifying the authenticity of requests from some bots by
-comparing the request IP to published bot IP ranges or performing a reverse
-DNS query. Verification is performed for supported bots using the appropriate method
-automatically after the bot is identified by Arcjet.
+Requests analyzed by Arcjet for users on the <Badge text="Pro" variant="note" />
+plan or above automatically get additional bot verification. Behind the scenes,
+Arcjet will verify the authenticity of requests from known bots using IP data
+and reverse DNS queries.
 
-To check the verification status,
-use the `.isSpoofed()` or `.isVerified()` methods on the bot reason object. If
-verification was performed, one of these will be true and the other false; both
-will be false if verification failed or if we don't support verifying the identified bot. 
+This helps protect against spoofed bots where clients pretend to be someone
+else. For example, we can detect if a client is really Googlebot by checking if
+the request IP is within Google's published IP ranges.
+
+If we detect a spoofed bot (or successfully verify a bot), additional metadata
+will be added to the response decision. This does not currently mark a request
+as denied, so we recommend checking this in your code.
 
 :::note
-It's recommended to check verification status only when using an allow configuration.
-For deny configurations, verification is skipped as you'd want to block listed bots
+This is only helpful when you have configured an `allow` list.
+For deny configurations, verification is skipped because you'd want to block those bots
 regardless of legitimacy.
 :::
 
-Here's a basic usage example:
+### Check for spoofed bots
+
+This will check if the bot is spoofed. You would usually return a 403 or similar
+response to block the request.
+
 ```ts
-if (decision.reason.isSpoofed()) {
-  // Show a custom block page for spoofed bots
-} else if (decision.reason.isVerified()) {
-  // You can now trust that the bot is who they say they are and proceed as normal
-} else {
-  // The bot either does not support verification, or verification failed.
+if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+  console.log("Detected spoofed bot", decision.reason.spoofed);
+  // Return a 403 or similar response
+}
+```
+
+### Check bot verification
+
+This will check if the bot is verified.
+
+```ts
+if (decision.reason.isBot() && decision.reason.isVerified()) {
+  console.log("Verified bot", decision.reason.verified);
+  // Allow the request
 }
 ```
 

--- a/src/snippets/blueprints/SamplingMiddleware.js
+++ b/src/snippets/blueprints/SamplingMiddleware.js
@@ -56,7 +56,7 @@ export default async function middleware(request) {
     } else if (decision.reason.isShield()) {
       return NextResponse.json({ error: "Shields up!" }, { status: 403 });
     } else {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
   } else {
     return NextResponse.next();

--- a/src/snippets/blueprints/SamplingMiddleware.ts
+++ b/src/snippets/blueprints/SamplingMiddleware.ts
@@ -56,7 +56,7 @@ export default async function middleware(request: NextRequest) {
     } else if (decision.reason.isShield()) {
       return NextResponse.json({ error: "Shields up!" }, { status: 403 });
     } else {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
   } else {
     return NextResponse.next();

--- a/src/snippets/bot-protection/quick-start/bun/Step3.js
+++ b/src/snippets/bot-protection/quick-start/bun/Step3.js
@@ -23,10 +23,15 @@ export default {
   fetch: aj.handler(async (req) => {
     const decision = await aj.protect(req);
 
+    // Bots not in the allow list will be blocked
     if (decision.isDenied()) {
       return new Response("Forbidden", { status: 403 });
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.reason.isBot() && decision.reason.isSpoofed()) {
       return new Response("Forbidden", { status: 403 });
     }

--- a/src/snippets/bot-protection/quick-start/bun/Step3.ts
+++ b/src/snippets/bot-protection/quick-start/bun/Step3.ts
@@ -23,10 +23,15 @@ export default {
   fetch: aj.handler(async (req) => {
     const decision = await aj.protect(req);
 
+    // Bots not in the allow list will be blocked
     if (decision.isDenied()) {
       return new Response("Forbidden", { status: 403 });
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.reason.isBot() && decision.reason.isSpoofed()) {
       return new Response("Forbidden", { status: 403 });
     }

--- a/src/snippets/bot-protection/quick-start/deno/Step3.ts
+++ b/src/snippets/bot-protection/quick-start/deno/Step3.ts
@@ -24,10 +24,15 @@ Deno.serve(
   aj.handler(async (req) => {
     const decision = await aj.protect(req);
 
+    // Bots not in the allow list will be blocked
     if (decision.isDenied()) {
       return new Response("Forbidden", { status: 403 });
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.reason.isBot() && decision.reason.isSpoofed()) {
       return new Response("Forbidden", { status: 403 });
     }

--- a/src/snippets/bot-protection/quick-start/nextjs/Step3Advanced.js
+++ b/src/snippets/bot-protection/quick-start/nextjs/Step3Advanced.js
@@ -26,15 +26,18 @@ const aj = arcjet({
 export default async function middleware(request) {
   const decision = await aj.protect(request);
 
-  if (
-    // If this deny comes from a bot rule then block the request. You can
-    // customize this logic to fit your needs e.g. checking the IP address type
-    // or changing the status code.
-    decision.isDenied() &&
-    decision.reason.isBot()
-  ) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
-  } else {
-    return NextResponse.next();
+  // Bots not in the allow list will be blocked
+  if (decision.isDenied()) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
+
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  return NextResponse.next();
 }

--- a/src/snippets/bot-protection/quick-start/nextjs/Step3Advanced.ts
+++ b/src/snippets/bot-protection/quick-start/nextjs/Step3Advanced.ts
@@ -26,14 +26,18 @@ const aj = arcjet({
 export default async function middleware(request: NextRequest) {
   const decision = await aj.protect(request);
 
-  if (
-    // If this deny comes from a bot rule then block the request. You can
-    // customize this logic to fit your needs e.g. changing the status code.
-    decision.isDenied() &&
-    decision.reason.isBot()
-  ) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
-  } else {
-    return NextResponse.next();
+  // Bots not in the allow list will be blocked
+  if (decision.isDenied()) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
+
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  return NextResponse.next();
 }

--- a/src/snippets/bot-protection/quick-start/nodejs/Step3.js
+++ b/src/snippets/bot-protection/quick-start/nodejs/Step3.js
@@ -18,22 +18,29 @@ const aj = arcjet({
   ],
 });
 
-const server = http.createServer(async function(req, res) {
+const server = http.createServer(async function (req, res) {
   const decision = await aj.protect(req);
   console.log("Arcjet decision", decision);
 
+  // Bots not in the allow list will be blocked
   if (decision.isDenied()) {
     res.writeHead(403, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "Forbidden" }));
-  } else {
-    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
-      res.writeHead(403, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Forbidden" }));
-    }
-
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ message: "Hello world" }));
+    return;
   }
+
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    res.writeHead(403, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Forbidden" }));
+    return;
+  }
+
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ message: "Hello world" }));
 });
 
 server.listen(8000);

--- a/src/snippets/bot-protection/quick-start/remix/Step3.jsx
+++ b/src/snippets/bot-protection/quick-start/remix/Step3.jsx
@@ -25,10 +25,15 @@ export async function loader(args) {
   const decision = await aj.protect(args);
   console.log("Arcjet decision", decision);
 
+  // Bots not in the allow list will be blocked
   if (decision.isDenied()) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
   if (decision.reason.isBot() && decision.reason.isSpoofed()) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }

--- a/src/snippets/bot-protection/quick-start/remix/Step3.tsx
+++ b/src/snippets/bot-protection/quick-start/remix/Step3.tsx
@@ -26,10 +26,15 @@ export async function loader(args: LoaderFunctionArgs) {
   const decision = await aj.protect(args);
   console.log("Arcjet decision", decision);
 
+  // Bots not in the allow list will be blocked
   if (decision.isDenied()) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
   if (decision.reason.isBot() && decision.reason.isSpoofed()) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }

--- a/src/snippets/bot-protection/quick-start/sveltekit/Step3.js
+++ b/src/snippets/bot-protection/quick-start/sveltekit/Step3.js
@@ -22,10 +22,15 @@ const aj = arcjet({
 export async function handle({ event, resolve }) {
   const decision = await aj.protect(event);
 
+  // Bots not in the allow list will be blocked
   if (decision.isDenied()) {
     return error(403, "Forbidden");
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
   if (decision.reason.isBot() && decision.reason.isSpoofed()) {
     return error(403, "Forbidden");
   }

--- a/src/snippets/bot-protection/quick-start/sveltekit/Step3.ts
+++ b/src/snippets/bot-protection/quick-start/sveltekit/Step3.ts
@@ -28,10 +28,15 @@ export async function handle({
 }): Promise<Response> {
   const decision = await aj.protect(event);
 
+  // Bots not in the allow list will be blocked
   if (decision.isDenied()) {
     return error(403, "Forbidden");
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
   if (decision.reason.isBot() && decision.reason.isSpoofed()) {
     return error(403, "Forbidden");
   }

--- a/src/snippets/bot-protection/reference/bun/AllowingBots.js
+++ b/src/snippets/bot-protection/reference/bun/AllowingBots.js
@@ -24,10 +24,15 @@ export default {
   fetch: aj.handler(async (req) => {
     const decision = await aj.protect(req);
 
+    // Bots not in the allow list will be blocked
     if (decision.isDenied()) {
       return new Response("Forbidden", { status: 403 });
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.reason.isBot() && decision.reason.isSpoofed()) {
       return new Response("Forbidden", { status: 403 });
     }

--- a/src/snippets/bot-protection/reference/bun/AllowingBots.ts
+++ b/src/snippets/bot-protection/reference/bun/AllowingBots.ts
@@ -24,10 +24,15 @@ export default {
   fetch: aj.handler(async (req) => {
     const decision = await aj.protect(req);
 
+    // Bots not in the allow list will be blocked
     if (decision.isDenied()) {
       return new Response("Forbidden", { status: 403 });
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.reason.isBot() && decision.reason.isSpoofed()) {
       return new Response("Forbidden", { status: 403 });
     }

--- a/src/snippets/bot-protection/reference/bun/DecisionLog.js
+++ b/src/snippets/bot-protection/reference/bun/DecisionLog.js
@@ -34,10 +34,15 @@ export default {
       }
     }
 
+    // Bots not in the allow list will be blocked
     if (decision.isDenied()) {
       return new Response("Forbidden", { status: 403 });
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.reason.isBot() && decision.reason.isSpoofed()) {
       return new Response("Forbidden", { status: 403 });
     }

--- a/src/snippets/bot-protection/reference/bun/DecisionLog.ts
+++ b/src/snippets/bot-protection/reference/bun/DecisionLog.ts
@@ -34,10 +34,15 @@ export default {
       }
     }
 
+    // Bots not in the allow list will be blocked
     if (decision.isDenied()) {
       return new Response("Forbidden", { status: 403 });
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.reason.isBot() && decision.reason.isSpoofed()) {
       return new Response("Forbidden", { status: 403 });
     }

--- a/src/snippets/bot-protection/reference/bun/Errors.js
+++ b/src/snippets/bot-protection/reference/bun/Errors.js
@@ -33,10 +33,15 @@ export default {
       }
     }
 
+    // Bots not in the allow list will be blocked
     if (decision.isDenied()) {
       return new Response("Forbidden", { status: 403 });
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.reason.isBot() && decision.reason.isSpoofed()) {
       return new Response("Forbidden", { status: 403 });
     }

--- a/src/snippets/bot-protection/reference/bun/Errors.ts
+++ b/src/snippets/bot-protection/reference/bun/Errors.ts
@@ -33,10 +33,15 @@ export default {
       }
     }
 
+    // Bots not in the allow list will be blocked
     if (decision.isDenied()) {
       return new Response("Forbidden", { status: 403 });
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.reason.isBot() && decision.reason.isSpoofed()) {
       return new Response("Forbidden", { status: 403 });
     }

--- a/src/snippets/bot-protection/reference/bun/Filtering.js
+++ b/src/snippets/bot-protection/reference/bun/Filtering.js
@@ -23,10 +23,15 @@ export default {
   fetch: aj.handler(async (req) => {
     const decision = await aj.protect(req);
 
+    // Bots not in the allow list will be blocked
     if (decision.isDenied()) {
       return new Response("Forbidden", { status: 403 });
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.reason.isBot() && decision.reason.isSpoofed()) {
       return new Response("Forbidden", { status: 403 });
     }

--- a/src/snippets/bot-protection/reference/bun/Filtering.ts
+++ b/src/snippets/bot-protection/reference/bun/Filtering.ts
@@ -23,10 +23,15 @@ export default {
   fetch: aj.handler(async (req) => {
     const decision = await aj.protect(req);
 
+    // Bots not in the allow list will be blocked
     if (decision.isDenied()) {
       return new Response("Forbidden", { status: 403 });
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.reason.isBot() && decision.reason.isSpoofed()) {
       return new Response("Forbidden", { status: 403 });
     }

--- a/src/snippets/bot-protection/reference/bun/IdentifiedBots.js
+++ b/src/snippets/bot-protection/reference/bun/IdentifiedBots.js
@@ -19,6 +19,16 @@ export default {
     if (decision.reason.isBot()) {
       console.log("detected + allowed bots", decision.reason.allowed);
       console.log("detected + denied bots", decision.reason.denied);
+
+      // Arcjet Pro plan verifies the authenticity of common bots using IP data
+      // https://docs.arcjet.com/bot-protection/reference#bot-verification
+      if (decision.reason.isSpoofed()) {
+        console.log("spoofed bot", decision.reason.spoofed);
+      }
+
+      if (decision.reason.isVerified()) {
+        console.log("verified bot", decision.reason.verified);
+      }
     }
 
     if (decision.isDenied()) {

--- a/src/snippets/bot-protection/reference/bun/IdentifiedBots.ts
+++ b/src/snippets/bot-protection/reference/bun/IdentifiedBots.ts
@@ -19,6 +19,16 @@ export default {
     if (decision.reason.isBot()) {
       console.log("detected + allowed bots", decision.reason.allowed);
       console.log("detected + denied bots", decision.reason.denied);
+
+      // Arcjet Pro plan verifies the authenticity of common bots using IP data
+      // https://docs.arcjet.com/bot-protection/reference#bot-verification
+      if (decision.reason.isSpoofed()) {
+        console.log("spoofed bot", decision.reason.spoofed);
+      }
+
+      if (decision.reason.isVerified()) {
+        console.log("verified bot", decision.reason.verified);
+      }
     }
 
     if (decision.isDenied()) {

--- a/src/snippets/bot-protection/reference/deno/AllowingBots.ts
+++ b/src/snippets/bot-protection/reference/deno/AllowingBots.ts
@@ -23,10 +23,15 @@ Deno.serve(
   aj.handler(async (req) => {
     const decision = await aj.protect(req);
 
+    // Bots not in the allow list will be blocked
     if (decision.isDenied()) {
       return new Response("Forbidden", { status: 403 });
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.reason.isBot() && decision.reason.isSpoofed()) {
       return new Response("Forbidden", { status: 403 });
     }

--- a/src/snippets/bot-protection/reference/deno/Filtering.ts
+++ b/src/snippets/bot-protection/reference/deno/Filtering.ts
@@ -22,10 +22,15 @@ Deno.serve(
   aj.handler(async (req) => {
     const decision = await aj.protect(req);
 
+    // Bots not in the allow list will be blocked
     if (decision.isDenied()) {
       return new Response("Forbidden", { status: 403 });
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.reason.isBot() && decision.reason.isSpoofed()) {
       return new Response("Forbidden", { status: 403 });
     }

--- a/src/snippets/bot-protection/reference/deno/IdentifiedBots.ts
+++ b/src/snippets/bot-protection/reference/deno/IdentifiedBots.ts
@@ -18,6 +18,16 @@ Deno.serve(
     if (decision.reason.isBot()) {
       console.log("detected + allowed bots", decision.reason.allowed);
       console.log("detected + denied bots", decision.reason.denied);
+
+      // Arcjet Pro plan verifies the authenticity of common bots using IP data
+      // https://docs.arcjet.com/bot-protection/reference#bot-verification
+      if (decision.reason.isSpoofed()) {
+        console.log("spoofed bot", decision.reason.spoofed);
+      }
+
+      if (decision.reason.isVerified()) {
+        console.log("verified bot", decision.reason.verified);
+      }
     }
 
     if (decision.isDenied()) {

--- a/src/snippets/bot-protection/reference/nestjs/IdentifiedBots.ts
+++ b/src/snippets/bot-protection/reference/nestjs/IdentifiedBots.ts
@@ -56,6 +56,16 @@ export class PageController {
     if (decision.reason.isBot()) {
       this.logger.log("detected + allowed bots", decision.reason.allowed);
       this.logger.log("detected + denied bots", decision.reason.denied);
+
+      // Arcjet Pro plan verifies the authenticity of common bots using IP data
+      // https://docs.arcjet.com/bot-protection/reference#bot-verification
+      if (decision.reason.isSpoofed()) {
+        console.log("spoofed bot", decision.reason.spoofed);
+      }
+
+      if (decision.reason.isVerified()) {
+        console.log("verified bot", decision.reason.verified);
+      }
     }
 
     if (decision.isDenied()) {

--- a/src/snippets/bot-protection/reference/nestjs/WithinRoute.ts
+++ b/src/snippets/bot-protection/reference/nestjs/WithinRoute.ts
@@ -53,6 +53,14 @@ export class PageAdvancedController {
       }
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
+    }
+
     return this.pageService.message();
   }
 }

--- a/src/snippets/bot-protection/reference/nextjs/AllowingBotsApp.js
+++ b/src/snippets/bot-protection/reference/nextjs/AllowingBotsApp.js
@@ -23,6 +23,8 @@ export async function POST(req) {
   const decision = await aj.protect(req);
 
   if (decision.reason.isBot()) {
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.isDenied() || decision.reason.isSpoofed()) {
       return NextResponse.json(
         {

--- a/src/snippets/bot-protection/reference/nextjs/AllowingBotsApp.ts
+++ b/src/snippets/bot-protection/reference/nextjs/AllowingBotsApp.ts
@@ -22,8 +22,9 @@ const aj = arcjet({
 export async function POST(req: Request) {
   const decision = await aj.protect(req);
 
-
   if (decision.reason.isBot()) {
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
     if (decision.isDenied() || decision.reason.isSpoofed()) {
       return NextResponse.json(
         {

--- a/src/snippets/bot-protection/reference/nextjs/AllowingBotsPages.js
+++ b/src/snippets/bot-protection/reference/nextjs/AllowingBotsPages.js
@@ -30,6 +30,8 @@ export default async function handler(req, res) {
         denied: decision.reason.denied,
       });
     } else if (decision.reason.isSpoofed()) {
+      // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+      // https://docs.arcjet.com/bot-protection/reference#bot-verification
       return res.status(403).json({
         error: "Forbidden",
         // Useful for debugging, but don't return these to the client in

--- a/src/snippets/bot-protection/reference/nextjs/AllowingBotsPages.ts
+++ b/src/snippets/bot-protection/reference/nextjs/AllowingBotsPages.ts
@@ -34,6 +34,8 @@ export default async function handler(
         denied: decision.reason.denied,
       });
     } else if (decision.reason.isSpoofed()) {
+      // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+      // https://docs.arcjet.com/bot-protection/reference#bot-verification
       return res.status(403).json({
         error: "Forbidden",
         // Useful for debugging, but don't return these to the client in

--- a/src/snippets/bot-protection/reference/nextjs/CustomizedMiddleware.js
+++ b/src/snippets/bot-protection/reference/nextjs/CustomizedMiddleware.js
@@ -26,7 +26,7 @@ export default async function middleware(request) {
     decision.reason.isBot() &&
     decision.ip.isHosting()
   ) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   } else {
     return NextResponse.next();
   }

--- a/src/snippets/bot-protection/reference/nextjs/CustomizedMiddleware.ts
+++ b/src/snippets/bot-protection/reference/nextjs/CustomizedMiddleware.ts
@@ -26,7 +26,7 @@ export default async function middleware(request: NextRequest) {
     decision.reason.isBot() &&
     decision.ip.isHosting()
   ) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   } else {
     return NextResponse.next();
   }

--- a/src/snippets/bot-protection/reference/nextjs/FilteringApp.js
+++ b/src/snippets/bot-protection/reference/nextjs/FilteringApp.js
@@ -33,6 +33,10 @@ export async function POST(req) {
         { status: 403 },
       );
     } else if (decision.reason.isSpoofed()) {
+      // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+      // Verification isn't always possible, so we recommend checking the decision
+      // separately.
+      // https://docs.arcjet.com/bot-protection/reference#bot-verification
       return NextResponse.json(
         {
           error: "You are a bot!",

--- a/src/snippets/bot-protection/reference/nextjs/FilteringApp.ts
+++ b/src/snippets/bot-protection/reference/nextjs/FilteringApp.ts
@@ -33,6 +33,10 @@ export async function POST(req: Request) {
         { status: 403 },
       );
     } else if (decision.reason.isSpoofed()) {
+      // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+      // Verification isn't always possible, so we recommend checking the decision
+      // separately.
+      // https://docs.arcjet.com/bot-protection/reference#bot-verification
       return NextResponse.json(
         {
           error: "You are a bot!",

--- a/src/snippets/bot-protection/reference/nextjs/FilteringPages.js
+++ b/src/snippets/bot-protection/reference/nextjs/FilteringPages.js
@@ -29,6 +29,10 @@ export default async function handler(req, res) {
         denied: decision.reason.denied,
       });
     } else if (decision.reason.isSpoofed()) {
+      // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+      // Verification isn't always possible, so we recommend checking the decision
+      // separately.
+      // https://docs.arcjet.com/bot-protection/reference#bot-verification
       return res.status(403).json({
         error: "Forbidden",
         // Useful for debugging, but don't return these to the client in

--- a/src/snippets/bot-protection/reference/nextjs/FilteringPages.ts
+++ b/src/snippets/bot-protection/reference/nextjs/FilteringPages.ts
@@ -33,6 +33,10 @@ export default async function handler(
         denied: decision.reason.denied,
       });
     } else if (decision.reason.isSpoofed()) {
+      // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+      // Verification isn't always possible, so we recommend checking the decision
+      // separately.
+      // https://docs.arcjet.com/bot-protection/reference#bot-verification
       return res.status(403).json({
         error: "Forbidden",
         // Useful for debugging, but don't return these to the client in

--- a/src/snippets/bot-protection/reference/nextjs/IdentifiedBotsApp.js
+++ b/src/snippets/bot-protection/reference/nextjs/IdentifiedBotsApp.js
@@ -17,6 +17,16 @@ export async function POST(req) {
   if (decision.reason.isBot()) {
     console.log("detected + allowed bots", decision.reason.allowed);
     console.log("detected + denied bots", decision.reason.denied);
+
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isSpoofed()) {
+      console.log("spoofed bot", decision.reason.spoofed);
+    }
+
+    if (decision.reason.isVerified()) {
+      console.log("verified bot", decision.reason.verified);
+    }
   }
 
   if (decision.isDenied()) {

--- a/src/snippets/bot-protection/reference/nextjs/IdentifiedBotsApp.ts
+++ b/src/snippets/bot-protection/reference/nextjs/IdentifiedBotsApp.ts
@@ -17,6 +17,16 @@ export async function POST(req: Request) {
   if (decision.reason.isBot()) {
     console.log("detected + allowed bots", decision.reason.allowed);
     console.log("detected + denied bots", decision.reason.denied);
+
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isSpoofed()) {
+      console.log("spoofed bot", decision.reason.spoofed);
+    }
+
+    if (decision.reason.isVerified()) {
+      console.log("verified bot", decision.reason.verified);
+    }
   }
 
   if (decision.isDenied()) {

--- a/src/snippets/bot-protection/reference/nextjs/IdentifiedBotsPages.js
+++ b/src/snippets/bot-protection/reference/nextjs/IdentifiedBotsPages.js
@@ -16,6 +16,16 @@ export default async function handler(req, res) {
   if (decision.reason.isBot()) {
     console.log("detected + allowed bots", decision.reason.allowed);
     console.log("detected + denied bots", decision.reason.denied);
+
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isSpoofed()) {
+      console.log("spoofed bot", decision.reason.spoofed);
+    }
+
+    if (decision.reason.isVerified()) {
+      console.log("verified bot", decision.reason.verified);
+    }
   }
 
   if (decision.isDenied()) {

--- a/src/snippets/bot-protection/reference/nextjs/IdentifiedBotsPages.ts
+++ b/src/snippets/bot-protection/reference/nextjs/IdentifiedBotsPages.ts
@@ -20,6 +20,16 @@ export default async function handler(
   if (decision.reason.isBot()) {
     console.log("detected + allowed bots", decision.reason.allowed);
     console.log("detected + denied bots", decision.reason.denied);
+
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isSpoofed()) {
+      console.log("spoofed bot", decision.reason.spoofed);
+    }
+
+    if (decision.reason.isVerified()) {
+      console.log("verified bot", decision.reason.verified);
+    }
   }
 
   if (decision.isDenied()) {

--- a/src/snippets/bot-protection/reference/nextjs/PerRouteApp.js
+++ b/src/snippets/bot-protection/reference/nextjs/PerRouteApp.js
@@ -23,6 +23,19 @@ export async function GET(req) {
     );
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return NextResponse.json(
+      {
+        error: "You are a bot!",
+      },
+      { status: 403 },
+    );
+  }
+
   return NextResponse.json({
     message: "Hello world",
   });

--- a/src/snippets/bot-protection/reference/nextjs/PerRouteApp.ts
+++ b/src/snippets/bot-protection/reference/nextjs/PerRouteApp.ts
@@ -23,6 +23,19 @@ export async function GET(req: Request) {
     );
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return NextResponse.json(
+      {
+        error: "You are a bot!",
+      },
+      { status: 403 },
+    );
+  }
+
   return NextResponse.json({
     message: "Hello world",
   });

--- a/src/snippets/bot-protection/reference/nextjs/PerRoutePages.js
+++ b/src/snippets/bot-protection/reference/nextjs/PerRoutePages.js
@@ -17,5 +17,13 @@ export default async function handler(req, res) {
     return res.status(403).json({ error: "You are a bot!" });
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return res.status(403).json({ error: "You are a bot!" });
+  }
+
   res.status(200).json({ name: "Hello world" });
 }

--- a/src/snippets/bot-protection/reference/nextjs/PerRoutePages.ts
+++ b/src/snippets/bot-protection/reference/nextjs/PerRoutePages.ts
@@ -21,5 +21,13 @@ export default async function handler(
     return res.status(403).json({ error: "You are a bot!" });
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return res.status(403).json({ error: "You are a bot!" });
+  }
+
   res.status(200).json({ name: "Hello world" });
 }

--- a/src/snippets/bot-protection/reference/nodejs/IdentifiedBots.js
+++ b/src/snippets/bot-protection/reference/nodejs/IdentifiedBots.js
@@ -17,6 +17,16 @@ const server = http.createServer(async function (req, res) {
   if (decision.reason.isBot()) {
     console.log("detected + allowed bots", decision.reason.allowed);
     console.log("detected + denied bots", decision.reason.denied);
+
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isSpoofed()) {
+      console.log("spoofed bot", decision.reason.spoofed);
+    }
+
+    if (decision.reason.isVerified()) {
+      console.log("verified bot", decision.reason.verified);
+    }
   }
 
   if (decision.isDenied()) {

--- a/src/snippets/bot-protection/reference/nodejs/IdentifiedBots.ts
+++ b/src/snippets/bot-protection/reference/nodejs/IdentifiedBots.ts
@@ -20,6 +20,16 @@ const server = http.createServer(async function (
   if (decision.reason.isBot()) {
     console.log("detected + allowed bots", decision.reason.allowed);
     console.log("detected + denied bots", decision.reason.denied);
+
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isSpoofed()) {
+      console.log("spoofed bot", decision.reason.spoofed);
+    }
+
+    if (decision.reason.isVerified()) {
+      console.log("verified bot", decision.reason.verified);
+    }
   }
 
   if (decision.isDenied()) {

--- a/src/snippets/bot-protection/reference/remix/AllowingBots.js
+++ b/src/snippets/bot-protection/reference/remix/AllowingBots.js
@@ -21,10 +21,15 @@ const aj = arcjet({
 export async function loader(args) {
   const decision = await aj.protect(args);
 
+  // Bots not in the allow list will be blocked
   if (decision.isDenied()) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
   if (decision.reason.isBot() && decision.reason.isSpoofed()) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }

--- a/src/snippets/bot-protection/reference/remix/AllowingBots.ts
+++ b/src/snippets/bot-protection/reference/remix/AllowingBots.ts
@@ -22,10 +22,15 @@ const aj = arcjet({
 export async function loader(args: LoaderFunctionArgs) {
   const decision = await aj.protect(args);
 
+  // Bots not in the allow list will be blocked
   if (decision.isDenied()) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
   if (decision.reason.isBot() && decision.reason.isSpoofed()) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }

--- a/src/snippets/bot-protection/reference/remix/Filtering.js
+++ b/src/snippets/bot-protection/reference/remix/Filtering.js
@@ -20,10 +20,15 @@ const aj = arcjet({
 export async function loader(args) {
   const decision = await aj.protect(args);
 
+  // Bots not in the allow list will be blocked
   if (decision.isDenied()) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
   if (decision.reason.isBot() && decision.reason.isSpoofed()) {
     throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }

--- a/src/snippets/bot-protection/reference/remix/IdentifiedBots.js
+++ b/src/snippets/bot-protection/reference/remix/IdentifiedBots.js
@@ -16,6 +16,16 @@ export async function loader(args) {
   if (decision.reason.isBot()) {
     console.log("detected + allowed bots", decision.reason.allowed);
     console.log("detected + denied bots", decision.reason.denied);
+
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isSpoofed()) {
+      console.log("spoofed bot", decision.reason.spoofed);
+    }
+
+    if (decision.reason.isVerified()) {
+      console.log("verified bot", decision.reason.verified);
+    }
   }
 
   if (decision.isDenied()) {

--- a/src/snippets/bot-protection/reference/remix/IdentifiedBots.ts
+++ b/src/snippets/bot-protection/reference/remix/IdentifiedBots.ts
@@ -17,6 +17,16 @@ export async function loader(args: LoaderFunctionArgs) {
   if (decision.reason.isBot()) {
     console.log("detected + allowed bots", decision.reason.allowed);
     console.log("detected + denied bots", decision.reason.denied);
+
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isSpoofed()) {
+      console.log("spoofed bot", decision.reason.spoofed);
+    }
+
+    if (decision.reason.isVerified()) {
+      console.log("verified bot", decision.reason.verified);
+    }
   }
 
   if (decision.isDenied()) {

--- a/src/snippets/bot-protection/reference/sveltekit/AllowingBots.js
+++ b/src/snippets/bot-protection/reference/sveltekit/AllowingBots.js
@@ -23,10 +23,15 @@ const aj = arcjet({
 export async function handle({ event, resolve }) {
   const decision = await aj.protect(event);
 
+  // Bots not in the allow list will be blocked
   if (decision.isDenied()) {
     return error(403, "You are a bot!");
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
   if (decision.reason.isBot() && decision.reason.isSpoofed()) {
     return error(403, "You are a bot!");
   }

--- a/src/snippets/bot-protection/reference/sveltekit/AllowingBots.ts
+++ b/src/snippets/bot-protection/reference/sveltekit/AllowingBots.ts
@@ -29,10 +29,15 @@ export async function handle({
 }): Promise<Response> {
   const decision = await aj.protect(event);
 
+  // Bots not in the allow list will be blocked
   if (decision.isDenied()) {
     return error(403, "You are a bot!");
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
   if (decision.reason.isBot() && decision.reason.isSpoofed()) {
     return error(403, "You are a bot!");
   }

--- a/src/snippets/bot-protection/reference/sveltekit/Filtering.js
+++ b/src/snippets/bot-protection/reference/sveltekit/Filtering.js
@@ -22,10 +22,15 @@ const aj = arcjet({
 export async function handle({ event, resolve }) {
   const decision = await aj.protect(event);
 
+  // Bots not in the allow list will be blocked
   if (decision.isDenied()) {
     return error(403, "You are a bot!");
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
   if (decision.reason.isBot() && decision.reason.isSpoofed()) {
     return error(403, "You are a bot!");
   }

--- a/src/snippets/bot-protection/reference/sveltekit/Hooks.js
+++ b/src/snippets/bot-protection/reference/sveltekit/Hooks.js
@@ -22,10 +22,15 @@ const aj = arcjet({
 export async function handle({ event, resolve }) {
   const decision = await aj.protect(event);
 
+  // Bots not in the allow list will be blocked
   if (decision.isDenied()) {
     return error(403, "Forbidden");
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
   if (decision.reason.isBot() && decision.reason.isSpoofed()) {
     return error(403, "You are a bot!");
   }

--- a/src/snippets/bot-protection/reference/sveltekit/Hooks.ts
+++ b/src/snippets/bot-protection/reference/sveltekit/Hooks.ts
@@ -28,10 +28,15 @@ export async function handle({
 }): Promise<Response> {
   const decision = await aj.protect(event);
 
+  // Bots not in the allow list will be blocked
   if (decision.isDenied()) {
     return error(403, "Forbidden");
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
   if (decision.reason.isBot() && decision.reason.isSpoofed()) {
     return error(403, "You are a bot!");
   }

--- a/src/snippets/bot-protection/reference/sveltekit/IdentifiedBots.js
+++ b/src/snippets/bot-protection/reference/sveltekit/IdentifiedBots.js
@@ -18,6 +18,16 @@ export async function handle({ event, resolve }) {
   if (decision.reason.isBot()) {
     console.log("detected + allowed bots", decision.reason.allowed);
     console.log("detected + denied bots", decision.reason.denied);
+
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isSpoofed()) {
+      console.log("spoofed bot", decision.reason.spoofed);
+    }
+
+    if (decision.reason.isVerified()) {
+      console.log("verified bot", decision.reason.verified);
+    }
   }
 
   if (decision.isDenied()) {

--- a/src/snippets/bot-protection/reference/sveltekit/IdentifiedBots.ts
+++ b/src/snippets/bot-protection/reference/sveltekit/IdentifiedBots.ts
@@ -24,6 +24,16 @@ export async function handle({
   if (decision.reason.isBot()) {
     console.log("detected + allowed bots", decision.reason.allowed);
     console.log("detected + denied bots", decision.reason.denied);
+
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isSpoofed()) {
+      console.log("spoofed bot", decision.reason.spoofed);
+    }
+
+    if (decision.reason.isVerified()) {
+      console.log("verified bot", decision.reason.verified);
+    }
   }
 
   if (decision.isDenied()) {

--- a/src/snippets/get-started/bun-hono/Step3.ts
+++ b/src/snippets/get-started/bun-hono/Step3.ts
@@ -46,6 +46,14 @@ app.get("/", async (c) => {
     }
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
+
   return c.json({ message: "Hello world" });
 });
 

--- a/src/snippets/get-started/bun/BunServe.ts
+++ b/src/snippets/get-started/bun/BunServe.ts
@@ -45,6 +45,14 @@ Bun.serve({
       }
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   },
 });

--- a/src/snippets/get-started/bun/Step3.js
+++ b/src/snippets/get-started/bun/Step3.js
@@ -45,6 +45,14 @@ export default {
       }
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 };

--- a/src/snippets/get-started/bun/Step3.ts
+++ b/src/snippets/get-started/bun/Step3.ts
@@ -45,6 +45,14 @@ export default {
       }
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 };

--- a/src/snippets/get-started/deno/Step3.ts
+++ b/src/snippets/get-started/deno/Step3.ts
@@ -46,6 +46,14 @@ Deno.serve(
       }
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
     return new Response("Hello world");
   }),
 );

--- a/src/snippets/get-started/next-js/Step3App.js
+++ b/src/snippets/get-started/next-js/Step3App.js
@@ -52,5 +52,16 @@ export async function GET(req) {
     }
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return NextResponse.json(
+      { error: "Forbidden", reason: decision.reason },
+      { status: 403 },
+    );
+  }
+
   return NextResponse.json({ message: "Hello world" });
 }

--- a/src/snippets/get-started/next-js/Step3App.ts
+++ b/src/snippets/get-started/next-js/Step3App.ts
@@ -52,5 +52,16 @@ export async function GET(req: Request) {
     }
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return NextResponse.json(
+      { error: "Forbidden", reason: decision.reason },
+      { status: 403 },
+    );
+  }
+
   return NextResponse.json({ message: "Hello world" });
 }

--- a/src/snippets/get-started/next-js/Step3Pages.js
+++ b/src/snippets/get-started/next-js/Step3Pages.js
@@ -48,5 +48,15 @@ export default async function handler(req, res) {
     }
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return res
+      .status(403)
+      .json({ error: "Forbidden", reason: decision.reason });
+  }
+
   res.status(200).json({ name: "Hello world" });
 }

--- a/src/snippets/get-started/next-js/Step3Pages.ts
+++ b/src/snippets/get-started/next-js/Step3Pages.ts
@@ -52,5 +52,15 @@ export default async function handler(
     }
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return res
+      .status(403)
+      .json({ error: "Forbidden", reason: decision.reason });
+  }
+
   res.status(200).json({ name: "Hello world" });
 }

--- a/src/snippets/get-started/node-js-express/Express.js
+++ b/src/snippets/get-started/node-js-express/Express.js
@@ -49,6 +49,13 @@ app.get("/", async (req, res) => {
       res.writeHead(403, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Forbidden" }));
     }
+  } else if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    res.writeHead(403, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Forbidden" }));
   } else {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ message: "Hello World" }));

--- a/src/snippets/get-started/node-js-hono/Step3.ts
+++ b/src/snippets/get-started/node-js-hono/Step3.ts
@@ -46,6 +46,14 @@ app.get("/", async (c) => {
     }
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
+
   return c.json({ message: "Hello Hono!" });
 });
 

--- a/src/snippets/get-started/node-js/Step3.js
+++ b/src/snippets/get-started/node-js/Step3.js
@@ -44,6 +44,13 @@ const server = http.createServer(async function (req, res) {
       res.writeHead(403, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Forbidden" }));
     }
+  } else if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    res.writeHead(403, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Forbidden" }));
   } else {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ message: "Hello world" }));

--- a/src/snippets/get-started/node-js/Step3.ts
+++ b/src/snippets/get-started/node-js/Step3.ts
@@ -47,6 +47,13 @@ const server = http.createServer(async function (
       res.writeHead(403, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Forbidden" }));
     }
+  } else if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    res.writeHead(403, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Forbidden" }));
   } else {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ message: "Hello world" }));

--- a/src/snippets/get-started/remix/Step3.tsx
+++ b/src/snippets/get-started/remix/Step3.tsx
@@ -51,6 +51,14 @@ export async function loader(args: LoaderFunctionArgs) {
     }
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
+  }
+
   // We don't need to use the decision elsewhere, but you could return it to
   // the component
   return null;

--- a/src/snippets/get-started/sveltekit/Step3.js
+++ b/src/snippets/get-started/sveltekit/Step3.js
@@ -44,5 +44,13 @@ export async function GET(event) {
     }
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return error(403, "Forbidden");
+  }
+
   return json({ message: "Hello World" });
 }

--- a/src/snippets/get-started/sveltekit/Step3.ts
+++ b/src/snippets/get-started/sveltekit/Step3.ts
@@ -44,5 +44,13 @@ export async function GET(event: RequestEvent) {
     }
   }
 
+  // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+  // Verification isn't always possible, so we recommend checking the decision
+  // separately.
+  // https://docs.arcjet.com/bot-protection/reference#bot-verification
+  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    return error(403, "Forbidden");
+  }
+
   return json({ message: "Hello World" });
 }

--- a/src/snippets/integrations/AuthJSPages.ts
+++ b/src/snippets/integrations/AuthJSPages.ts
@@ -40,7 +40,7 @@ const ajProtectedHandler = async (
       if (decision.reason.isRateLimit()) {
         return res.status(429).json({ error: "Too many requests" });
       } else {
-        return res.status(403).json({ error: "Unauthorized" });
+        return res.status(403).json({ error: "Forbidden" });
       }
     }
   }

--- a/src/snippets/integrations/AuthJSUserApp.ts
+++ b/src/snippets/integrations/AuthJSUserApp.ts
@@ -66,5 +66,5 @@ export const GET = auth(async (req: any) => {
     return Response.json({ data: "Protected data" });
   }
 
-  return Response.json({ message: "Not authenticated" }, { status: 401 });
+  return Response.json({ message: "Unauthorized" }, { status: 401 });
 }) as any;

--- a/src/snippets/integrations/ClerkNextJSAJMiddleware.ts
+++ b/src/snippets/integrations/ClerkNextJSAJMiddleware.ts
@@ -30,7 +30,7 @@ export default clerkMiddleware(async (auth, req) => {
   const decision = await aj.protect(req);
 
   if (decision.isDenied()) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   if (isProtectedRoute(req)) {

--- a/src/snippets/integrations/NextAuthApp.ts
+++ b/src/snippets/integrations/NextAuthApp.ts
@@ -41,7 +41,7 @@ const ajProtectedPOST = async (req: Request, res: Response) => {
     if (decision.reason.isRateLimit()) {
       return NextResponse.json({ error: "Too Many Requests" }, { status: 429 });
     } else {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
   }
 

--- a/src/snippets/integrations/NextAuthPages.ts
+++ b/src/snippets/integrations/NextAuthPages.ts
@@ -45,7 +45,7 @@ const ajProtectedHandler = async (
       if (decision.reason.isRateLimit()) {
         return res.status(429).json({ error: "Too many requests" });
       } else {
-        return res.status(403).json({ error: "Unauthorized" });
+        return res.status(403).json({ error: "Forbidden" });
       }
     }
   }

--- a/src/snippets/sensitive-info/reference/nestjs/DecisionLog.ts
+++ b/src/snippets/sensitive-info/reference/nestjs/DecisionLog.ts
@@ -96,6 +96,14 @@ export class PageController {
       }
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      return new HttpException("Forbidden", HttpStatus.FORBIDDEN);
+    }
+
     return this.pageService.message(body);
   }
 }

--- a/src/snippets/sensitive-info/reference/nestjs/WithinRoute.ts
+++ b/src/snippets/sensitive-info/reference/nestjs/WithinRoute.ts
@@ -55,6 +55,14 @@ export class PageController {
       }
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
+    }
+
     return this.pageService.message(body);
   }
 }

--- a/src/snippets/shield/reference/nestjs/DecisionLog.ts
+++ b/src/snippets/shield/reference/nestjs/DecisionLog.ts
@@ -81,6 +81,14 @@ export class PageController {
       }
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
+    }
+
     return this.pageService.message();
   }
 }

--- a/src/snippets/signup-protection/quick-start/nestjs/Step3Controller.ts
+++ b/src/snippets/signup-protection/quick-start/nestjs/Step3Controller.ts
@@ -119,6 +119,14 @@ export class SignupController {
       }
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
+    }
+
     return this.signupService.signup(body.email);
   }
 }

--- a/src/snippets/signup-protection/reference/nestjs/CustomVerification.ts
+++ b/src/snippets/signup-protection/reference/nestjs/CustomVerification.ts
@@ -150,6 +150,14 @@ export class SignupController {
       }
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
+    }
+
     // At this point the signup is allowed, but we may want to take additional
     // verification steps
 

--- a/src/snippets/signup-protection/reference/nestjs/Errors.ts
+++ b/src/snippets/signup-protection/reference/nestjs/Errors.ts
@@ -133,6 +133,14 @@ export class SignupController {
       }
     }
 
+    // Arcjet Pro plan verifies the authenticity of common bots using IP data.
+    // Verification isn't always possible, so we recommend checking the decision
+    // separately.
+    // https://docs.arcjet.com/bot-protection/reference#bot-verification
+    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+      throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
+    }
+
     return this.signupService.signup(body.email);
   }
 }


### PR DESCRIPTION
Adds more examples of using bot verification and include it as part of the quick starts.