### PR TITLE
chore: Migrate typescript patch to avoid warning

### DIFF
--- a/patches/typescript+5.7.3.patch
+++ b/patches/typescript+5.7.3.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/typescript/lib/typescript.js b/node_modules/typescript/lib/typescript.js
-index 33387ea..2429417 100644
+index fa7c62f..df786ff 100644
 --- a/node_modules/typescript/lib/typescript.js
 +++ b/node_modules/typescript/lib/typescript.js
-@@ -16114,7 +16114,7 @@ function isInternalDeclaration(node, sourceFile) {
+@@ -16116,7 +16116,7 @@ function isInternalDeclaration(node, sourceFile) {
  // src/compiler/utilities.ts
  var resolvingEmptyArray = [];
  var externalHelpersModuleNameText = "tslib";


### PR DESCRIPTION
TypeScript was updated so `patch-package` was showing a warning on install. This migrates the patch.