### PR TITLE
chore: Disable root user in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,5 +28,5 @@
   // Configure tool-specific properties.
   // "customizations": {},
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-  "remoteUser": "root"
+  // "remoteUser": "root",
 }


### PR DESCRIPTION
I found that the json file was invalid due to a missing comma. However, the root user is not needed so I just disabled it in the devcontainer.