### PR TITLE
fix: Re-enable prettier formatting

### DIFF
--- a/src/components/DisplayType.astro
+++ b/src/components/DisplayType.astro
@@ -20,9 +20,7 @@ let types = [];
 for (const query of result.queries) {
     types.push(query.text);
 }
-// Breaks in Astro 5
-//let code = await format(types.join("\n"), { parser: "typescript" });
-let code = types.join("\n")
+let code = await format(types.join("\n"), { parser: "typescript" });
 ---
 
 <Code code={code} lang="ts" />


### PR DESCRIPTION
Closes #371 

Disabling the formatter made the Nosecone API docs pretty miserable to read due to no text wrapping.

Need to check in deploy preview because it doesn't crash in the dev server.