### PR TITLE
chore: Change remaining `decision.reason.isSpoofed()` examples

### DIFF
--- a/src/content/docs/blueprints/payment-form.mdx
+++ b/src/content/docs/blueprints/payment-form.mdx
@@ -101,11 +101,22 @@ if (decision.isDenied()) {
   }
 }
 
+function isSpoofed(result) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
+
 // Arcjet Pro plan verifies the authenticity of common bots using IP data.
 // Verification isn't always possible, so we recommend checking the decision
 // separately.
 // https://docs.arcjet.com/bot-protection/reference#bot-verification
-if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+if (decision.results.some(isSpoofed)) {
   console.error("Spoofed bot detected", decision);
   // Return 403
 }
@@ -280,6 +291,7 @@ The form submission is processed by the following API route:
 
 ```tsx title="/app/api/process-payment/route.ts"
 import arcjet, {
+  type ArcjetRuleResult,
   detectBot,
   shield,
   slidingWindow,
@@ -315,6 +327,17 @@ const aj = arcjet({
     }),
   ],
 });
+
+function isSpoofed(result: ArcjetRuleResult) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
 
 export async function POST(request: Request) {
   try {
@@ -356,7 +379,7 @@ export async function POST(request: Request) {
     // Verification isn't always possible, so we recommend checking the decision
     // separately.
     // https://docs.arcjet.com/bot-protection/reference#bot-verification
-    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    if (decision.results.some(isSpoofed)) {
       console.error("Spoofed bot detected", decision);
       return NextResponse.json(
         { success: false, message: "Forbidden" },

--- a/src/content/docs/bot-protection/reference.mdx
+++ b/src/content/docs/bot-protection/reference.mdx
@@ -382,9 +382,11 @@ This will check if the bot is spoofed. You would usually return a 403 or similar
 response to block the request.
 
 ```ts
-if (decision.reason.isBot() && decision.reason.isSpoofed()) {
-  console.log("Detected spoofed bot", decision.reason.spoofed);
-  // Return a 403 or similar response
+for (const { reason } of decision.results) {
+  if (reason.isBot() && reason.isSpoofed()) {
+    console.log("Detected spoofed bot", reason.spoofed);
+    // Return a 403 or similar response
+  }
 }
 ```
 
@@ -393,9 +395,11 @@ if (decision.reason.isBot() && decision.reason.isSpoofed()) {
 This will check if the bot is verified.
 
 ```ts
-if (decision.reason.isBot() && decision.reason.isVerified()) {
-  console.log("Verified bot", decision.reason.verified);
-  // Allow the request
+for (const { reason } of decision.results) {
+  if (reason.isBot() && reason.isVerified()) {
+    console.log("Verified bot", reason.verified);
+    // Allow the request
+  }
 }
 ```
 

--- a/src/snippets/get-started/bun-hono/Step3.ts
+++ b/src/snippets/get-started/bun-hono/Step3.ts
@@ -1,4 +1,9 @@
-import arcjet, { detectBot, shield, tokenBucket } from "@arcjet/bun";
+import arcjet, {
+  type ArcjetRuleResult,
+  detectBot,
+  shield,
+  tokenBucket,
+} from "@arcjet/bun";
 import { Hono } from "hono";
 import { env } from "bun";
 
@@ -30,6 +35,17 @@ const aj = arcjet({
   ],
 });
 
+function isSpoofed(result: ArcjetRuleResult) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
+
 const app = new Hono();
 
 app.get("/", async (c) => {
@@ -50,7 +66,7 @@ app.get("/", async (c) => {
   // Verification isn't always possible, so we recommend checking the decision
   // separately.
   // https://docs.arcjet.com/bot-protection/reference#bot-verification
-  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+  if (decision.results.some(isSpoofed)) {
     return c.json({ error: "Forbidden" }, 403);
   }
 

--- a/src/snippets/get-started/bun/Step3.js
+++ b/src/snippets/get-started/bun/Step3.js
@@ -29,6 +29,17 @@ const aj = arcjet({
   ],
 });
 
+function isSpoofed(result) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
+
 export default {
   port: 3000,
   fetch: aj.handler(async (req) => {
@@ -49,7 +60,7 @@ export default {
     // Verification isn't always possible, so we recommend checking the decision
     // separately.
     // https://docs.arcjet.com/bot-protection/reference#bot-verification
-    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    if (decision.results.some(isSpoofed)) {
       return new Response("Forbidden", { status: 403 });
     }
 

--- a/src/snippets/get-started/bun/Step3.ts
+++ b/src/snippets/get-started/bun/Step3.ts
@@ -1,4 +1,9 @@
-import arcjet, { detectBot, shield, tokenBucket } from "@arcjet/bun";
+import arcjet, {
+  type ArcjetRuleResult,
+  detectBot,
+  shield,
+  tokenBucket,
+} from "@arcjet/bun";
 import { env } from "bun";
 
 const aj = arcjet({
@@ -29,6 +34,17 @@ const aj = arcjet({
   ],
 });
 
+function isSpoofed(result: ArcjetRuleResult) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
+
 export default {
   port: 3000,
   fetch: aj.handler(async (req) => {
@@ -49,7 +65,7 @@ export default {
     // Verification isn't always possible, so we recommend checking the decision
     // separately.
     // https://docs.arcjet.com/bot-protection/reference#bot-verification
-    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    if (decision.results.some(isSpoofed)) {
       return new Response("Forbidden", { status: 403 });
     }
 

--- a/src/snippets/get-started/deno/Step3.ts
+++ b/src/snippets/get-started/deno/Step3.ts
@@ -1,6 +1,11 @@
 import "jsr:@std/dotenv/load";
 
-import arcjet, { detectBot, shield, tokenBucket } from "npm:@arcjet/deno";
+import arcjet, {
+  type ArcjetRuleResult,
+  detectBot,
+  shield,
+  tokenBucket,
+} from "npm:@arcjet/deno";
 
 const aj = arcjet({
   key: Deno.env.get("ARCJET_KEY")!, // Get your site key from https://app.arcjet.com
@@ -30,6 +35,17 @@ const aj = arcjet({
   ],
 });
 
+function isSpoofed(result: ArcjetRuleResult) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
+
 Deno.serve(
   { port: 3000 },
   aj.handler(async (req) => {
@@ -50,7 +66,7 @@ Deno.serve(
     // Verification isn't always possible, so we recommend checking the decision
     // separately.
     // https://docs.arcjet.com/bot-protection/reference#bot-verification
-    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    if (decision.results.some(isSpoofed)) {
       return new Response("Forbidden", { status: 403 });
     }
 

--- a/src/snippets/get-started/next-js/Step3App.js
+++ b/src/snippets/get-started/next-js/Step3App.js
@@ -29,6 +29,17 @@ const aj = arcjet({
   ],
 });
 
+function isSpoofed(result) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
+
 export async function GET(req) {
   const decision = await aj.protect(req, { requested: 5 }); // Deduct 5 tokens from the bucket
   console.log("Arcjet decision", decision);
@@ -56,7 +67,7 @@ export async function GET(req) {
   // Verification isn't always possible, so we recommend checking the decision
   // separately.
   // https://docs.arcjet.com/bot-protection/reference#bot-verification
-  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+  if (decision.results.some(isSpoofed)) {
     return NextResponse.json(
       { error: "Forbidden", reason: decision.reason },
       { status: 403 },

--- a/src/snippets/get-started/next-js/Step3App.ts
+++ b/src/snippets/get-started/next-js/Step3App.ts
@@ -1,4 +1,9 @@
-import arcjet, { detectBot, shield, tokenBucket } from "@arcjet/next";
+import arcjet, {
+  type ArcjetRuleResult,
+  detectBot,
+  shield,
+  tokenBucket,
+} from "@arcjet/next";
 import { NextResponse } from "next/server";
 
 const aj = arcjet({
@@ -29,6 +34,17 @@ const aj = arcjet({
   ],
 });
 
+function isSpoofed(result: ArcjetRuleResult) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
+
 export async function GET(req: Request) {
   const decision = await aj.protect(req, { requested: 5 }); // Deduct 5 tokens from the bucket
   console.log("Arcjet decision", decision);
@@ -56,7 +72,7 @@ export async function GET(req: Request) {
   // Verification isn't always possible, so we recommend checking the decision
   // separately.
   // https://docs.arcjet.com/bot-protection/reference#bot-verification
-  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+  if (decision.results.some(isSpoofed)) {
     return NextResponse.json(
       { error: "Forbidden", reason: decision.reason },
       { status: 403 },

--- a/src/snippets/get-started/next-js/Step3Pages.js
+++ b/src/snippets/get-started/next-js/Step3Pages.js
@@ -28,6 +28,17 @@ const aj = arcjet({
   ],
 });
 
+function isSpoofed(result) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
+
 export default async function handler(req, res) {
   const decision = await aj.protect(req, { requested: 5 }); // Deduct 5 tokens from the bucket
   console.log("Arcjet decision", decision);
@@ -52,7 +63,7 @@ export default async function handler(req, res) {
   // Verification isn't always possible, so we recommend checking the decision
   // separately.
   // https://docs.arcjet.com/bot-protection/reference#bot-verification
-  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+  if (decision.results.some(isSpoofed)) {
     return res
       .status(403)
       .json({ error: "Forbidden", reason: decision.reason });

--- a/src/snippets/get-started/next-js/Step3Pages.ts
+++ b/src/snippets/get-started/next-js/Step3Pages.ts
@@ -1,4 +1,9 @@
-import arcjet, { detectBot, shield, tokenBucket } from "@arcjet/next";
+import arcjet, {
+  type ArcjetRuleResult,
+  detectBot,
+  shield,
+  tokenBucket,
+} from "@arcjet/next";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 const aj = arcjet({
@@ -29,6 +34,17 @@ const aj = arcjet({
   ],
 });
 
+function isSpoofed(result: ArcjetRuleResult) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
@@ -56,7 +72,7 @@ export default async function handler(
   // Verification isn't always possible, so we recommend checking the decision
   // separately.
   // https://docs.arcjet.com/bot-protection/reference#bot-verification
-  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+  if (decision.results.some(isSpoofed)) {
     return res
       .status(403)
       .json({ error: "Forbidden", reason: decision.reason });

--- a/src/snippets/get-started/node-js/Step3.js
+++ b/src/snippets/get-started/node-js/Step3.js
@@ -29,6 +29,17 @@ const aj = arcjet({
   ],
 });
 
+function isSpoofed(result) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
+
 const server = http.createServer(async function (req, res) {
   const decision = await aj.protect(req, { requested: 5 }); // Deduct 5 tokens from the bucket
   console.log("Arcjet decision", decision);
@@ -44,7 +55,7 @@ const server = http.createServer(async function (req, res) {
       res.writeHead(403, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Forbidden" }));
     }
-  } else if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+  } else if (decision.results.some(isSpoofed)) {
     // Arcjet Pro plan verifies the authenticity of common bots using IP data.
     // Verification isn't always possible, so we recommend checking the decision
     // separately.

--- a/src/snippets/get-started/node-js/Step3.ts
+++ b/src/snippets/get-started/node-js/Step3.ts
@@ -1,4 +1,9 @@
-import arcjet, { detectBot, shield, tokenBucket } from "@arcjet/node";
+import arcjet, {
+  type ArcjetRuleResult,
+  detectBot,
+  shield,
+  tokenBucket,
+} from "@arcjet/node";
 import http from "node:http";
 
 const aj = arcjet({
@@ -29,6 +34,17 @@ const aj = arcjet({
   ],
 });
 
+function isSpoofed(result: ArcjetRuleResult) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
+
 const server = http.createServer(async function (
   req: http.IncomingMessage,
   res: http.ServerResponse,
@@ -47,7 +63,7 @@ const server = http.createServer(async function (
       res.writeHead(403, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Forbidden" }));
     }
-  } else if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+  } else if (decision.results.some(isSpoofed)) {
     // Arcjet Pro plan verifies the authenticity of common bots using IP data.
     // Verification isn't always possible, so we recommend checking the decision
     // separately.

--- a/src/snippets/get-started/sveltekit/Step3.js
+++ b/src/snippets/get-started/sveltekit/Step3.js
@@ -30,6 +30,17 @@ const aj = arcjet({
   ],
 });
 
+function isSpoofed(result) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
+
 export async function GET(event) {
   const decision = await aj.protect(event, { requested: 5 }); // Deduct 5 tokens from the bucket
   console.log("Arcjet decision", decision);
@@ -48,7 +59,7 @@ export async function GET(event) {
   // Verification isn't always possible, so we recommend checking the decision
   // separately.
   // https://docs.arcjet.com/bot-protection/reference#bot-verification
-  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+  if (decision.results.some(isSpoofed)) {
     return error(403, "Forbidden");
   }
 

--- a/src/snippets/get-started/sveltekit/Step3.ts
+++ b/src/snippets/get-started/sveltekit/Step3.ts
@@ -1,5 +1,10 @@
 import { env } from "$env/dynamic/private";
-import arcjet, { detectBot, shield, tokenBucket } from "@arcjet/sveltekit";
+import arcjet, {
+  type ArcjetRuleResult,
+  detectBot,
+  shield,
+  tokenBucket,
+} from "@arcjet/sveltekit";
 import { error, json, type RequestEvent } from "@sveltejs/kit";
 
 const aj = arcjet({
@@ -30,6 +35,17 @@ const aj = arcjet({
   ],
 });
 
+function isSpoofed(result: ArcjetRuleResult) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
+
 export async function GET(event: RequestEvent) {
   const decision = await aj.protect(event, { requested: 5 }); // Deduct 5 tokens from the bucket
   console.log("Arcjet decision", decision);
@@ -48,7 +64,7 @@ export async function GET(event: RequestEvent) {
   // Verification isn't always possible, so we recommend checking the decision
   // separately.
   // https://docs.arcjet.com/bot-protection/reference#bot-verification
-  if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+  if (decision.results.some(isSpoofed)) {
     return error(403, "Forbidden");
   }
 

--- a/src/snippets/sensitive-info/reference/nestjs/DecisionLog.ts
+++ b/src/snippets/sensitive-info/reference/nestjs/DecisionLog.ts
@@ -1,6 +1,7 @@
 import {
   ARCJET,
   type ArcjetNest,
+  type ArcjetRuleResult,
   detectBot,
   sensitiveInfo,
 } from "@arcjet/nest";
@@ -27,6 +28,17 @@ export class PageService {
       submittedContent: content,
     };
   }
+}
+
+function isSpoofed(result: ArcjetRuleResult) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
 }
 
 // This would normally go in your controller file e.g.
@@ -100,7 +112,7 @@ export class PageController {
     // Verification isn't always possible, so we recommend checking the decision
     // separately.
     // https://docs.arcjet.com/bot-protection/reference#bot-verification
-    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    if (decision.results.some(isSpoofed)) {
       return new HttpException("Forbidden", HttpStatus.FORBIDDEN);
     }
 

--- a/src/snippets/signup-protection/quick-start/nestjs/Step3Controller.ts
+++ b/src/snippets/signup-protection/quick-start/nestjs/Step3Controller.ts
@@ -1,4 +1,9 @@
-import { ARCJET, type ArcjetNest, protectSignup } from "@arcjet/nest";
+import {
+  ARCJET,
+  type ArcjetNest,
+  type ArcjetRuleResult,
+  protectSignup,
+} from "@arcjet/nest";
 import {
   Body,
   Controller,
@@ -14,6 +19,17 @@ import {
 import { NoFilesInterceptor } from "@nestjs/platform-express";
 import { IsNotEmpty } from "class-validator";
 import type { Request } from "express";
+
+function isSpoofed(result: ArcjetRuleResult) {
+  return (
+    // You probably don't want DRY_RUN rules resulting in a denial
+    // since they are generally used for evaluation purposes but you
+    // could log here.
+    result.state !== "DRY_RUN" &&
+    result.reason.isBot() &&
+    result.reason.isSpoofed()
+  );
+}
 
 // Validation class as described at
 // https://docs.nestjs.com/techniques/validation. We're not using the IsEmail
@@ -123,7 +139,7 @@ export class SignupController {
     // Verification isn't always possible, so we recommend checking the decision
     // separately.
     // https://docs.arcjet.com/bot-protection/reference#bot-verification
-    if (decision.reason.isBot() && decision.reason.isSpoofed()) {
+    if (decision.results.some(isSpoofed)) {
       throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
     }
 


### PR DESCRIPTION
This changes the remaining calls to `decision.reason.isSpoofed()`. While these are possible to use, they only make sense in a 1-rule context but all our examples show multiple rules being configured. To reduce footguns in our exampels, Spoofed and Verified checks should always be done against `results`.

Ref https://github.com/arcjet/arcjet-js/pull/3066#discussion_r1939951457