### PR TITLE
chore(ci): Group nosecone with Arcjet updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,8 +21,10 @@ updates:
       # Arcjet packages are grouped alone due to not being major/minor/patch yet
       arcjet-js:
         patterns:
-          - "arcjet"
+          - arcjet
           - "@arcjet/*"
+          - nosecone
+          - "@nosecone/*"
     ignore:
       # Ignore Connect RPC updates until merged in arcjet-js
       - dependency-name: "@connectrpc/connect-node"


### PR DESCRIPTION
The nosecone updates should be applied with the Arcjet updates because we version everything together right now.