### PR TITLE
docs(bots): replace known bots structure with reference

### DIFF
--- a/src/content/docs/bot-protection/identifying-bots.mdx
+++ b/src/content/docs/bot-protection/identifying-bots.mdx
@@ -118,34 +118,7 @@ updates will be included in the next SDK release. Since bot detection is handled
 within the Arcjet WebAssembly module bundled with the SDK, new patterns must be
 compiled into the module as part of the release process.
 
-Each entry in the known bots JSON represents a specific bot or crawler and
-includes the following fields:
-
-- `id`: A unique identifier for the bot
-- `categories`: An array of categories the bot belongs to (e.g. "search-engine",
-  "advertising")
-- `pattern`: A regular expression pattern used to identify the bot in user agent
-  strings
-- `url`: (optional) A URL with more information about the bot
-- `verification`: A list of supported methods for verifying the bot's identity
-  (if the bot is not verifiable it should be empty).
-- `instances`: An array of example user agent strings for the bot that are
-  validated against the `pattern`
-
-#### Verification
-
-Each verification entry contains the following fields:
-
-- `type`: The method of verification (currently only `dns` is supported)
-- `masks`: An array of mask patterns used for verification
-
-#### Verification mask patterns
-
-The mask patterns use the following special characters:
-
-- `\*`: Represents 0 or 1 of any character
-- `@`: Acts as a wildcard, matching any number of characters
-
-All other characters in the mask require an exact match.
+Please read the repository's [README.md](https://github.com/arcjet/well-known-bots/blob/main/README.md)
+for specific instructions on how to contribute to our bot detection.
 
 <Comments />


### PR DESCRIPTION
I was going to update these docs with changes to the structure that have occured (notably adding aliases, and ip verification).
However I realised that it is probably more effective to just link to the README.md since potential contributors
will need to go to the repo anyways, and having the same content in two places is likely to result in drift.
