### PR TITLE
docs: misc reference docs improvements

### DIFF
--- a/src/snippets/reference/bun/ClientOverride.js
+++ b/src/snippets/reference/bun/ClientOverride.js
@@ -31,10 +31,10 @@ export default {
     const decision = await aj.protect(req);
 
     for (const result of decision.results) {
-      console.log("Rule Result", result);
-
       if (result.reason.isRateLimit()) {
         console.log("Rate limit rule", result);
+      } else {
+        console.log("Rule Result", result);
       }
     }
 

--- a/src/snippets/reference/bun/ClientOverride.js
+++ b/src/snippets/reference/bun/ClientOverride.js
@@ -36,10 +36,6 @@ export default {
       if (result.reason.isRateLimit()) {
         console.log("Rate limit rule", result);
       }
-
-      if (result.reason.isBot()) {
-        console.log("Bot protection rule", result);
-      }
     }
 
     return new Response("Hello world");

--- a/src/snippets/reference/bun/ClientOverride.js
+++ b/src/snippets/reference/bun/ClientOverride.js
@@ -32,9 +32,9 @@ export default {
 
     for (const result of decision.results) {
       if (result.reason.isRateLimit()) {
-        console.log("Rate limit rule", result);
+        console.log("Rate limit rule result", result);
       } else {
-        console.log("Rule Result", result);
+        console.log("Rule result", result);
       }
     }
 

--- a/src/snippets/reference/bun/ClientOverride.ts
+++ b/src/snippets/reference/bun/ClientOverride.ts
@@ -31,10 +31,10 @@ export default {
     const decision = await aj.protect(req);
 
     for (const result of decision.results) {
-      console.log("Rule Result", result);
-
       if (result.reason.isRateLimit()) {
         console.log("Rate limit rule", result);
+      } else {
+        console.log("Rule Result", result);
       }
     }
 

--- a/src/snippets/reference/bun/ClientOverride.ts
+++ b/src/snippets/reference/bun/ClientOverride.ts
@@ -36,10 +36,6 @@ export default {
       if (result.reason.isRateLimit()) {
         console.log("Rate limit rule", result);
       }
-
-      if (result.reason.isBot()) {
-        console.log("Bot protection rule", result);
-      }
     }
 
     return new Response("Hello world");

--- a/src/snippets/reference/bun/ClientOverride.ts
+++ b/src/snippets/reference/bun/ClientOverride.ts
@@ -32,9 +32,9 @@ export default {
 
     for (const result of decision.results) {
       if (result.reason.isRateLimit()) {
-        console.log("Rate limit rule", result);
+        console.log("Rate limit rule result", result);
       } else {
-        console.log("Rule Result", result);
+        console.log("Rule result", result);
       }
     }
 

--- a/src/snippets/reference/bun/DecisionLog.js
+++ b/src/snippets/reference/bun/DecisionLog.js
@@ -25,7 +25,7 @@ export default {
 
     for (const result of decision.results) {
       if (result.reason.isRateLimit()) {
-        console.log("Rate limit rule", result);
+        console.log("Rate limit rule result", result);
       } else if (result.reason.isBot()) {
         console.log("Bot protection rule result", result);
       } else {

--- a/src/snippets/reference/bun/DecisionLog.js
+++ b/src/snippets/reference/bun/DecisionLog.js
@@ -24,14 +24,12 @@ export default {
     const decision = await aj.protect(req);
 
     for (const result of decision.results) {
-      console.log("Rule Result", result);
-
       if (result.reason.isRateLimit()) {
         console.log("Rate limit rule", result);
-      }
-
-      if (result.reason.isBot()) {
+      } else if (result.reason.isBot()) {
         console.log("Bot protection rule", result);
+      } else {
+        console.log("Rule Result", result);
       }
     }
 

--- a/src/snippets/reference/bun/DecisionLog.js
+++ b/src/snippets/reference/bun/DecisionLog.js
@@ -27,9 +27,9 @@ export default {
       if (result.reason.isRateLimit()) {
         console.log("Rate limit rule", result);
       } else if (result.reason.isBot()) {
-        console.log("Bot protection rule", result);
+        console.log("Bot protection rule result", result);
       } else {
-        console.log("Rule Result", result);
+        console.log("Rule result", result);
       }
     }
 

--- a/src/snippets/reference/bun/DecisionLog.ts
+++ b/src/snippets/reference/bun/DecisionLog.ts
@@ -25,11 +25,11 @@ export default {
 
     for (const result of decision.results) {
       if (result.reason.isRateLimit()) {
-        console.log("Rate limit rule", result);
+        console.log("Rate limit rule result", result);
       } else if (result.reason.isBot()) {
-        console.log("Bot protection rule", result);
+        console.log("Bot protection rule result", result);
       } else {
-        console.log("Rule Result", result);
+        console.log("Rule result", result);
       }
     }
 

--- a/src/snippets/reference/bun/DecisionLog.ts
+++ b/src/snippets/reference/bun/DecisionLog.ts
@@ -24,14 +24,12 @@ export default {
     const decision = await aj.protect(req);
 
     for (const result of decision.results) {
-      console.log("Rule Result", result);
-
       if (result.reason.isRateLimit()) {
         console.log("Rate limit rule", result);
-      }
-
-      if (result.reason.isBot()) {
+      } else if (result.reason.isBot()) {
         console.log("Bot protection rule", result);
+      } else {
+        console.log("Rule Result", result);
       }
     }
 

--- a/src/snippets/reference/nestjs/IPLocation.ts
+++ b/src/snippets/reference/nestjs/IPLocation.ts
@@ -44,12 +44,12 @@ export class PageController {
   async index(@Req() req: Request) {
     const decision = await this.arcjet.protect(req);
 
-    if (decision.ip.hasCountry()) {
-      this.logger.log("Visitor from", decision.ip.countryName);
-    }
-
     if (decision.isDenied()) {
       throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
+    }
+
+    if (decision.ip.hasCountry()) {
+      this.logger.log("Visitor from", decision.ip.countryName);
     }
 
     return this.pageService.message();

--- a/src/snippets/reference/nestjs/IPLocation.ts
+++ b/src/snippets/reference/nestjs/IPLocation.ts
@@ -44,12 +44,12 @@ export class PageController {
   async index(@Req() req: Request) {
     const decision = await this.arcjet.protect(req);
 
-    if (decision.isDenied()) {
-      throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
-    }
-
     if (decision.ip.hasCountry()) {
       this.logger.log("Visitor from", decision.ip.countryName);
+    }
+
+    if (decision.isDenied()) {
+      throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
     }
 
     return this.pageService.message();

--- a/src/snippets/reference/nextjs/IPLocationApp.js
+++ b/src/snippets/reference/nextjs/IPLocationApp.js
@@ -14,15 +14,15 @@ const aj = arcjet({
 export async function POST(req) {
   const decision = await aj.protect(req);
 
+  if (decision.isDenied()) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
   if (decision.ip.hasCountry()) {
     return NextResponse.json({
       message: `Hello ${decision.ip.countryName}!`,
       country: decision.ip,
     });
-  }
-
-  if (decision.isDenied()) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   return NextResponse.json({

--- a/src/snippets/reference/nextjs/IPLocationApp.ts
+++ b/src/snippets/reference/nextjs/IPLocationApp.ts
@@ -14,15 +14,15 @@ const aj = arcjet({
 export async function POST(req: Request) {
   const decision = await aj.protect(req);
 
+  if (decision.isDenied()) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
   if (decision.ip.hasCountry()) {
     return NextResponse.json({
       message: `Hello ${decision.ip.countryName}!`,
       country: decision.ip,
     });
-  }
-
-  if (decision.isDenied()) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   return NextResponse.json({

--- a/src/snippets/reference/nextjs/IPLocationPages.js
+++ b/src/snippets/reference/nextjs/IPLocationPages.js
@@ -13,17 +13,17 @@ const aj = arcjet({
 export default async function handler(req, res) {
   const decision = await aj.protect(req);
 
+  if (decision.isDenied()) {
+    return res
+      .status(403)
+      .json({ error: "Forbidden", reason: decision.reason });
+  }
+
   if (decision.ip.hasCountry()) {
     return res.status(200).json({
       message: `Hello ${decision.ip.countryName}!`,
       country: decision.ip,
     });
-  }
-
-  if (decision.isDenied()) {
-    return res
-      .status(403)
-      .json({ error: "Forbidden", reason: decision.reason });
   }
 
   res.status(200).json({ name: "Hello world" });

--- a/src/snippets/reference/nextjs/IPLocationPages.ts
+++ b/src/snippets/reference/nextjs/IPLocationPages.ts
@@ -17,17 +17,17 @@ export default async function handler(
 ) {
   const decision = await aj.protect(req);
 
+  if (decision.isDenied()) {
+    return res
+      .status(403)
+      .json({ error: "Forbidden", reason: decision.reason });
+  }
+
   if (decision.ip.hasCountry()) {
     return res.status(200).json({
       message: `Hello ${decision.ip.countryName}!`,
       country: decision.ip,
     });
-  }
-
-  if (decision.isDenied()) {
-    return res
-      .status(403)
-      .json({ error: "Forbidden", reason: decision.reason });
   }
 
   res.status(200).json({ name: "Hello world" });

--- a/src/snippets/reference/nodejs/IPLocation.js
+++ b/src/snippets/reference/nodejs/IPLocation.js
@@ -16,6 +16,7 @@ const server = http.createServer(async function (req, res) {
   if (decision.isDenied()) {
     res.writeHead(403, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "Forbidden", reason: decision.reason }));
+    return;
   }
 
   if (decision.ip.hasCountry()) {

--- a/src/snippets/reference/nodejs/IPLocation.js
+++ b/src/snippets/reference/nodejs/IPLocation.js
@@ -13,6 +13,11 @@ const aj = arcjet({
 const server = http.createServer(async function (req, res) {
   const decision = await aj.protect(req);
 
+  if (decision.isDenied()) {
+    res.writeHead(403, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Forbidden", reason: decision.reason }));
+  }
+
   if (decision.ip.hasCountry()) {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(
@@ -21,11 +26,6 @@ const server = http.createServer(async function (req, res) {
         country: decision.ip,
       }),
     );
-  }
-
-  if (decision.isDenied()) {
-    res.writeHead(403, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error: "Forbidden", reason: decision.reason }));
   } else {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ message: "Hello world" }));

--- a/src/snippets/reference/nodejs/IPLocation.ts
+++ b/src/snippets/reference/nodejs/IPLocation.ts
@@ -19,6 +19,7 @@ const server = http.createServer(async function (
   if (decision.isDenied()) {
     res.writeHead(403, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "Forbidden", reason: decision.reason }));
+    return;
   }
 
   if (decision.ip.hasCountry()) {

--- a/src/snippets/reference/nodejs/IPLocation.ts
+++ b/src/snippets/reference/nodejs/IPLocation.ts
@@ -16,6 +16,11 @@ const server = http.createServer(async function (
 ) {
   const decision = await aj.protect(req);
 
+  if (decision.isDenied()) {
+    res.writeHead(403, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Forbidden", reason: decision.reason }));
+  }
+
   if (decision.ip.hasCountry()) {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(
@@ -24,11 +29,6 @@ const server = http.createServer(async function (
         country: decision.ip,
       }),
     );
-  }
-
-  if (decision.isDenied()) {
-    res.writeHead(403, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error: "Forbidden", reason: decision.reason }));
   } else {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ message: "Hello world" }));

--- a/src/snippets/reference/remix/IPLocation.js
+++ b/src/snippets/reference/remix/IPLocation.js
@@ -14,12 +14,12 @@ const aj = arcjet({
 export async function loader(args) {
   const decision = await aj.protect(args);
 
-  if (decision.isDenied()) {
-    throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
-  }
-
   if (decision.ip.hasCountry()) {
     console.log("Visitor from", decision.ip.countryName);
+  }
+
+  if (decision.isDenied()) {
+    throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }
 
   // We don't need to use the decision elsewhere, but you could return it to

--- a/src/snippets/reference/remix/IPLocation.ts
+++ b/src/snippets/reference/remix/IPLocation.ts
@@ -15,12 +15,12 @@ const aj = arcjet({
 export async function loader(args: LoaderFunctionArgs) {
   const decision = await aj.protect(args);
 
-  if (decision.isDenied()) {
-    throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
-  }
-
   if (decision.ip.hasCountry()) {
     console.log("Visitor from", decision.ip.countryName);
+  }
+
+  if (decision.isDenied()) {
+    throw new Response("Forbidden", { status: 403, statusText: "Forbidden" });
   }
 
   // We don't need to use the decision elsewhere, but you could return it to

--- a/src/snippets/reference/sveltekit/DecisionLog.js
+++ b/src/snippets/reference/sveltekit/DecisionLog.js
@@ -23,14 +23,12 @@ export async function handle({ event, resolve }) {
   const decision = await aj.protect(event);
 
   for (const result of decision.results) {
-    console.log("Rule Result", result);
-
     if (result.reason.isRateLimit()) {
       console.log("Rate limit rule", result);
-    }
-
-    if (result.reason.isBot()) {
+    } else if (result.reason.isBot()) {
       console.log("Bot protection rule", result);
+    } else {
+      console.log("Rule Result", result);
     }
   }
 

--- a/src/snippets/reference/sveltekit/DecisionLog.js
+++ b/src/snippets/reference/sveltekit/DecisionLog.js
@@ -24,11 +24,11 @@ export async function handle({ event, resolve }) {
 
   for (const result of decision.results) {
     if (result.reason.isRateLimit()) {
-      console.log("Rate limit rule", result);
+      console.log("Rate limit rule result", result);
     } else if (result.reason.isBot()) {
-      console.log("Bot protection rule", result);
+      console.log("Bot protection rule result", result);
     } else {
-      console.log("Rule Result", result);
+      console.log("Rule result", result);
     }
   }
 

--- a/src/snippets/reference/sveltekit/DecisionLog.ts
+++ b/src/snippets/reference/sveltekit/DecisionLog.ts
@@ -30,11 +30,11 @@ export async function handle({
 
   for (const result of decision.results) {
     if (result.reason.isRateLimit()) {
-      console.log("Rate limit rule", result);
+      console.log("Rate limit rule result", result);
     } else if (result.reason.isBot()) {
-      console.log("Bot protection rule", result);
+      console.log("Bot protection rule result", result);
     } else {
-      console.log("Rule Result", result);
+      console.log("Rule result", result);
     }
   }
 

--- a/src/snippets/reference/sveltekit/DecisionLog.ts
+++ b/src/snippets/reference/sveltekit/DecisionLog.ts
@@ -29,14 +29,12 @@ export async function handle({
   const decision = await aj.protect(event);
 
   for (const result of decision.results) {
-    console.log("Rule Result", result);
-
     if (result.reason.isRateLimit()) {
       console.log("Rate limit rule", result);
-    }
-
-    if (result.reason.isBot()) {
+    } else if (result.reason.isBot()) {
       console.log("Bot protection rule", result);
+    } else {
+      console.log("Rule Result", result);
     }
   }
 


### PR DESCRIPTION
I did a quick pass of the reference docs to see if any improvements could be made.

The ones I found were:
- We were checking for `.isBot()` in examples where there was no bot rule configured.
- We were returning a happy path response in some of our ip location examples before checking `isDenied`, I've changed these so that now we always check the decision first as you should do.