### PR TITLE
feat: Add API documentation for `@arcjet/inspect` library

### DIFF
--- a/src/components/badges/Free.astro
+++ b/src/components/badges/Free.astro
@@ -1,0 +1,5 @@
+---
+import { Badge } from "@astrojs/starlight/components";
+---
+
+<Badge text="Free" variant="caution" />

--- a/src/content/docs/inspect.mdx
+++ b/src/content/docs/inspect.mdx
@@ -1,0 +1,130 @@
+---
+title: "Arcjet decision inspection reference"
+description: "Reference for the @arcjet/inspect library"
+prev: false
+next: false
+---
+
+import { Code } from "@astrojs/starlight/components";
+import DisplayType from "@/components/DisplayType.astro";
+
+The Arcjet decision inspection library provides a set of utilities to more
+easily interact with the decision returned from an Arcjet SDK.
+
+import WhatAreArcjetUtilities from "@/components/WhatAreArcjetUtilities.astro";
+
+<WhatAreArcjetUtilities />
+
+## Why
+
+In addition to providing an easy-to-consume security recommendation, each Arcjet
+SDK also provides a lot of metadata attached to every decision. Users can use
+all of these signals to inform application logic, but it can be quite verbose to
+extract the information.
+
+As we notice common patterns, we provide optional utilities in the
+`@arcjet/inspect` package to streamline these operations.
+
+## Install
+
+```sh
+npm install -S @arcjet/inspect
+```
+
+## Usage
+
+import InspectUsage from "@/snippets/inspect/usage.ts?raw";
+
+<Code code={InspectUsage} lang="ts" />
+
+## API
+
+import Free from "@/components/badges/Free.astro";
+
+### `isSpoofedBot(result: ArcjetRuleResult)`
+
+Determines if a non-`"DRY_RUN"` bot rule detected a spoofed request. If `true`,
+the request was likely spoofed and you may want to block it.
+
+For `allow` rules, Arcjet verifies the authenticity of detected bots by checking
+IP data and performing reverse DNS lookups. This helps protect against spoofed
+bots where malicious clients pretend to be a well-behaving bot.
+
+Returns `true` if the bot rule result was not `"DRY_RUN"` and a spoofed bot was
+detected, `false` if the bot rule result was not `"DRY_RUN"` and a spoofed bot
+was not detected, or `undefined` if the rule result was from a `"DRY_RUN"` bot
+rule or a non-bot rule.
+
+:::note
+Spoofed bot detection is not available on <Free /> plans.
+:::
+
+**Types:**
+
+<DisplayType type="ArcjetRuleResult" from="@arcjet/protocol" />
+
+### `isVerifiedBot(result: ArcjetRuleResult)`
+
+Determines if a non-`"DRY_RUN"` bot rule detected a request from a verified bot.
+If `true`, the bot was verified as legitimate and you may want to ignore other
+signals.
+
+For `allow` rules, Arcjet verifies the authenticity of detected bots by checking
+IP data and performing reverse DNS lookups. A verified bot is a bot that has
+passed these checks.
+
+Returns `true` if the bot rule result was not `"DRY_RUN"` and a verified bot was
+detected, `false` if the bot rule result was not `"DRY_RUN"` and a verified bot
+was not detected, or `undefined` if the rule result was from a `"DRY_RUN"` bot
+rule or a non-bot rule.
+
+:::note
+Verified bot detection is not available on <Free /> plans.
+:::
+
+**Types:**
+
+<DisplayType type="ArcjetRuleResult" from="@arcjet/protocol" />
+
+### `isMissingUserAgent(result: ArcjetRuleResult)`
+
+Determines if a non-`"DRY_RUN"` bot rule errored due to a missing User-Agent
+header on the request. If `true`, you may want to block the request because a
+missing User-Agent header is a good indicator of a malicious request since it is
+recommended by
+[RFC9110](https://datatracker.ietf.org/doc/html/rfc9110#field.user-agent).
+
+Returns `true` if the rule result was not `"DRY_RUN"` and the request was
+missing a User-Agent header, `false` if the rule result was not `"DRY_RUN"` and
+the request had a User-Agent header, or `undefined` if the rule result was from
+a `"DRY_RUN"` bot rule or a non-bot rule.
+
+**Types:**
+
+<DisplayType type="ArcjetRuleResult" from="@arcjet/protocol" />
+
+## What next?
+
+Arcjet can protect your entire app or individual routes with just
+a few lines of code. Using the main Arcjet SDK you can setup bot protection,
+rate limiting for your API, minimize fraudulent registrations with the
+signup form protection and more.
+
+import { LinkCard, CardGrid } from "@astrojs/starlight/components";
+
+<CardGrid>
+  <LinkCard
+    title="Example apps"
+    href="https://github.com/arcjet/arcjet-js/tree/main/examples"
+    description="Check out the examples."
+  />
+  <LinkCard
+    title="Learn how Arcjet works"
+    href="/architecture"
+    description="Arcjet's architecture."
+  />
+</CardGrid>
+
+import Comments from "@/components/Comments.astro";
+
+<Comments />

--- a/src/lib/sidebars.ts
+++ b/src/lib/sidebars.ts
@@ -326,6 +326,10 @@ export const main = [
         ],
       },
       {
+        label: "@arcjet/inspect",
+        link: "/inspect",
+      },
+      {
         label: "@arcjet/ip",
         link: "/ip",
       },

--- a/src/snippets/inspect/usage.ts
+++ b/src/snippets/inspect/usage.ts
@@ -1,0 +1,53 @@
+// Replace with your SDK—every SDK provides a decision that can be inspected
+import arcjet, { detectBot } from "@arcjet/next";
+import {
+  isVerifiedBot,
+  isSpoofedBot,
+  isMissingUserAgent,
+} from "@arcjet/inspect";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const aj = arcjet({
+  key: process.env.ARCJET_KEY!,
+  rules: [
+    detectBot({
+      mode: "LIVE",
+      allow: ["CATEGORY:SEARCH_ENGINE"],
+    }),
+  ],
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const decision = await aj.protect(req);
+
+  // Allow any verified search engine bot without considering any other signals
+  if (decision.results.some(isVerifiedBot)) {
+    return res
+      .status(200)
+      .json({ name: "Hello bot! Here's some SEO optimized response" });
+  }
+
+  // Block a request if the SDK suggests it
+  if (decision.isDenied()) {
+    return res.status(403).json({ error: "Forbidden" });
+  }
+
+  // Blcok any request without a User-Agent header because we expect all
+  // well-behaved clients to have it
+  if (decision.results.some(isMissingUserAgent)) {
+    return res.status(400).json({ error: "You are a bot!" });
+  }
+
+  // Block any client pretending to be a search engine bot but using an IP
+  // address that doesn't satisfy the verification
+  if (decision.results.some(isSpoofedBot)) {
+    return res
+      .status(403)
+      .json({ error: "You are pretending to be a good bot!" });
+  }
+
+  res.status(200).json({ name: "Hello world" });
+}

--- a/src/snippets/inspect/usage.ts
+++ b/src/snippets/inspect/usage.ts
@@ -1,4 +1,4 @@
-// Replace with your SDK—every SDK provides a decision that can be inspected
+// Replace with the framework SDK you're using e.g. `@arcjet/node`
 import arcjet, { detectBot } from "@arcjet/next";
 import {
   isVerifiedBot,


### PR DESCRIPTION
Closes #437 

This adds API docs for the `@arcjet/inspect` utility package. I tried to highlight each function in the usage but that might become unwieldy as the package grows, but it should be fine for now.

I also added a `Free` component since we use this a lot in the project and the longer version causes MDX formatting problems. We can do some cleanup in a separate PR.

It was much easier to write these docs since we had already iterated on them in the doc comments of the PR so I see a lot of value in starting the docs in those blocks.