### PR TITLE
remove duplicate content from rate limiting reference section.

### DIFF
--- a/src/content/docs/rate-limiting/reference.mdx
+++ b/src/content/docs/rate-limiting/reference.mdx
@@ -122,14 +122,13 @@ import TokenBucketRequestNestJs from "@/snippets/rate-limiting/reference/nestjs/
 import NestJsGuardDecision from "@/snippets/rate-limiting/reference/nestjs/GuardDecision.mdx";
 import HeadersNestJs from "@/snippets/rate-limiting/reference/nestjs/Headers.mdx";
 
-import NextJsPerRouteVsMiddleware from "@/snippets/bot-protection/reference/nextjs/PerRouteVsMiddleware.mdx";
+import NextJsPerRouteVsMiddleware from "@/snippets/rate-limiting/reference/nextjs/PerRouteVsMiddleware.mdx";
 import ByUserIdNextJs from "@/snippets/rate-limiting/reference/nextjs/ByUserId.mdx";
 import DecisionLogNextJs from "@/snippets/rate-limiting/reference/nextjs/DecisionLog.mdx";
 import ErrorsNextJs from "@/snippets/rate-limiting/reference/nextjs/Errors.mdx";
 import ExamplesNextJs from "@/snippets/rate-limiting/reference/nextjs/Examples.mdx";
 import FixedWindowNextJs from "@/snippets/rate-limiting/reference/nextjs/FixedWindow.mdx";
 import HeadersNextJs from "@/snippets/rate-limiting/reference/nextjs/Headers.mdx";
-import PerRouteVsMiddlewareNextJs from "@/snippets/rate-limiting/reference/nextjs/PerRouteVsMiddleware.mdx";
 import NextJsPagesServerActions from "@/snippets/rate-limiting/reference/nextjs/PagesServerActions.mdx";
 import SlidingWindowNextJs from "@/snippets/rate-limiting/reference/nextjs/SlidingWindow.mdx";
 import TokenBucketNextJs from "@/snippets/rate-limiting/reference/nextjs/TokenBucket.mdx";
@@ -144,7 +143,7 @@ import SlidingWindowNodeJs from "@/snippets/rate-limiting/reference/nodejs/Slidi
 import TokenBucketNodeJs from "@/snippets/rate-limiting/reference/nodejs/TokenBucket.mdx";
 import TokenBucketRequestNodeJs from "@/snippets/rate-limiting/reference/nodejs/TokenBucketRequest.mdx";
 
-import RemixLoaderVsAction from "@/snippets/bot-protection/reference/remix/LoaderVsAction.mdx";
+import RemixLoaderVsAction from "@/snippets/rate-limiting/reference/remix/LoaderVsAction.mdx";
 import ByUserIdRemix from "@/snippets/rate-limiting/reference/remix/ByUserId.mdx";
 import DecisionLogRemix from "@/snippets/rate-limiting/reference/remix/DecisionLog.mdx";
 import ErrorsRemix from "@/snippets/rate-limiting/reference/remix/Errors.mdx";
@@ -154,7 +153,7 @@ import SlidingWindowRemix from "@/snippets/rate-limiting/reference/remix/Sliding
 import TokenBucketRemix from "@/snippets/rate-limiting/reference/remix/TokenBucket.mdx";
 import TokenBucketRequestRemix from "@/snippets/rate-limiting/reference/remix/TokenBucketRequest.mdx";
 
-import SvelteKitPerRouteVsHooks from "@/snippets/bot-protection/reference/sveltekit/PerRouteVsHooks.mdx";
+import SvelteKitPerRouteVsHooks from "@/snippets/rate-limiting/reference/sveltekit/PerRouteVsHooks.mdx";
 import ByUserIdSvelteKit from "@/snippets/rate-limiting/reference/sveltekit/ByUserId.mdx";
 import DecisionLogSvelteKit from "@/snippets/rate-limiting/reference/sveltekit/DecisionLog.mdx";
 import ErrorsSvelteKit from "@/snippets/rate-limiting/reference/sveltekit/Errors.mdx";

--- a/src/snippets/rate-limiting/reference/nextjs/PerRouteVsMiddleware.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/PerRouteVsMiddleware.mdx
@@ -37,7 +37,7 @@ You can use conditionals in your Next.js middleware to match multiple paths.
   <MiddlewareMatchingPaths slot="next-js" />
 </SlotByFramework>
 
-#### Rate limit on all routes
+#### Middleware
 
 <SlotByFramework client:load>
   <MiddlewareAllRoutes slot="next-js" />


### PR DESCRIPTION
Replaces incorrect bot limit snippet examples from the rate limiting reference. Towards #448.