### PR TITLE
fix: Use correct url on sveltekit sdk reference link card

### DIFF
--- a/src/components/SdkReferenceLinkByFramework.astro
+++ b/src/components/SdkReferenceLinkByFramework.astro
@@ -61,7 +61,7 @@ import { LinkCard } from "@astrojs/starlight/components";
   <LinkCard
     slot="sveltekit"
     title="SDK reference"
-    href="/reference/remix"
+    href="/reference/sveltekit"
     description="SvelteKit SDK reference guide."
   />
 </SlotByFramework>


### PR DESCRIPTION
Updates the get-started sdk link for sveltekit.

Closes https://github.com/arcjet/arcjet-docs/issues/475