### PR TITLE
chore: Add note about @arcjet/bun compatibility with Bun's HTTP server

### DIFF
--- a/src/content/docs/reference/bun.mdx
+++ b/src/content/docs/reference/bun.mdx
@@ -57,7 +57,7 @@ Our `@arcjet/bun` package is built for
 Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
 on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
 (uses `node:http` or a Node.js framework like express) you should instead
-review our [Node.js SDK reference](./nodejs).
+review our [Node.js SDK reference](/reference/nodejs).
 :::
 
 ### Requirements

--- a/src/content/docs/reference/bun.mdx
+++ b/src/content/docs/reference/bun.mdx
@@ -52,6 +52,14 @@ In your project root, run the following command to install the SDK:
 bun add @arcjet/bun
 ```
 
+:::note
+Our `@arcjet/bun` package is built for
+Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
+on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
+(uses `node:http` or a Node.js framework like express) you should instead
+review our [Node.js SDK reference](./nodejs).
+:::
+
 ### Requirements
 
 <Requirements />

--- a/src/snippets/bot-protection/quick-start/bun/Step1.mdx
+++ b/src/snippets/bot-protection/quick-start/bun/Step1.mdx
@@ -14,5 +14,5 @@ Our `@arcjet/bun` package is built for
 Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
 on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
 (uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](?f=node-js).
+follow [our guide for Node.js](/bot-protection/quick-start?f=node-js).
 :::

--- a/src/snippets/bot-protection/quick-start/bun/Step1.mdx
+++ b/src/snippets/bot-protection/quick-start/bun/Step1.mdx
@@ -8,3 +8,11 @@ bun add @arcjet/bun @arcjet/inspect
 ```
 </div>
 </SelectableContent>
+
+:::note
+Our `@arcjet/bun` package is built for
+Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
+on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
+(uses `node:http` or a Node.js framework like express) you should instead
+follow [our guide for Node.js](?f=node-js).
+:::

--- a/src/snippets/email-validation/quick-start/bun/Step1.mdx
+++ b/src/snippets/email-validation/quick-start/bun/Step1.mdx
@@ -14,5 +14,5 @@ Our `@arcjet/bun` package is built for
 Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
 on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
 (uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](?f=node-js).
+follow [our guide for Node.js](/email-validation/quick-start?f=node-js).
 :::

--- a/src/snippets/email-validation/quick-start/bun/Step1.mdx
+++ b/src/snippets/email-validation/quick-start/bun/Step1.mdx
@@ -8,3 +8,11 @@ bun add @arcjet/bun @arcjet/inspect
 ```
 </div>
 </SelectableContent>
+
+:::note
+Our `@arcjet/bun` package is built for
+Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
+on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
+(uses `node:http` or a Node.js framework like express) you should instead
+follow [our guide for Node.js](?f=node-js).
+:::

--- a/src/snippets/get-started/bun-hono/Step1.mdx
+++ b/src/snippets/get-started/bun-hono/Step1.mdx
@@ -10,11 +10,3 @@ bun add @arcjet/bun @arcjet/inspect
 
 </div>
 </SelectableContent>
-
-:::note
-Our `@arcjet/bun` package is built for
-Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
-on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
-(uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](?f=node-js).
-:::

--- a/src/snippets/get-started/bun-hono/Step1.mdx
+++ b/src/snippets/get-started/bun-hono/Step1.mdx
@@ -10,3 +10,11 @@ bun add @arcjet/bun @arcjet/inspect
 
 </div>
 </SelectableContent>
+
+:::note
+Our `@arcjet/bun` package is built for
+Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
+on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
+(uses `node:http` or a Node.js framework like express) you should instead
+follow [our guide for Node.js](?f=node-js).
+:::

--- a/src/snippets/get-started/bun/Step1.mdx
+++ b/src/snippets/get-started/bun/Step1.mdx
@@ -16,5 +16,5 @@ Our `@arcjet/bun` package is built for
 Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
 on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
 (uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](?f=node-js).
+follow [our guide for Node.js](/get-started?f=node-js).
 :::

--- a/src/snippets/get-started/bun/Step1.mdx
+++ b/src/snippets/get-started/bun/Step1.mdx
@@ -10,3 +10,11 @@ bun add @arcjet/bun @arcjet/inspect
 
 </div>
 </SelectableContent>
+
+:::note
+Our `@arcjet/bun` package is built for
+Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
+on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
+(uses `node:http` or a Node.js framework like express) you should instead
+follow [our guide for Node.js](?f=node-js).
+:::

--- a/src/snippets/rate-limiting/quick-start/bun/Step1.mdx
+++ b/src/snippets/rate-limiting/quick-start/bun/Step1.mdx
@@ -16,5 +16,5 @@ Our `@arcjet/bun` package is built for
 Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
 on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
 (uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](?f=node-js).
+follow [our guide for Node.js](/rate-limiting/quick-start?f=node-js).
 :::

--- a/src/snippets/rate-limiting/quick-start/bun/Step1.mdx
+++ b/src/snippets/rate-limiting/quick-start/bun/Step1.mdx
@@ -10,3 +10,11 @@ bun add @arcjet/bun @arcjet/inspect
 
 </div>
 </SelectableContent>
+
+:::note
+Our `@arcjet/bun` package is built for
+Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
+on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
+(uses `node:http` or a Node.js framework like express) you should instead
+follow [our guide for Node.js](?f=node-js).
+:::

--- a/src/snippets/sensitive-info/quick-start/bun/Step1.mdx
+++ b/src/snippets/sensitive-info/quick-start/bun/Step1.mdx
@@ -10,3 +10,11 @@ bun add @arcjet/bun @arcjet/inspect
 
 </div>
 </SelectableContent>
+
+:::note
+Our `@arcjet/bun` package is built for
+Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
+on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
+(uses `node:http` or a Node.js framework like express) you should instead
+follow [our guide for Node.js](?f=node-js).
+:::

--- a/src/snippets/sensitive-info/quick-start/bun/Step1.mdx
+++ b/src/snippets/sensitive-info/quick-start/bun/Step1.mdx
@@ -16,5 +16,5 @@ Our `@arcjet/bun` package is built for
 Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
 on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
 (uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](?f=node-js).
+follow [our guide for Node.js](/sensitive-info/quick-start?f=node-js).
 :::

--- a/src/snippets/shield/quick-start/bun/Step1.mdx
+++ b/src/snippets/shield/quick-start/bun/Step1.mdx
@@ -10,3 +10,11 @@ bun add @arcjet/bun @arcjet/inspect
 
 </div>
 </SelectableContent>
+
+:::note
+Our `@arcjet/bun` package is built for
+Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
+on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
+(uses `node:http` or a Node.js framework like express) you should instead
+follow [our guide for Node.js](?f=node-js).
+:::

--- a/src/snippets/shield/quick-start/bun/Step1.mdx
+++ b/src/snippets/shield/quick-start/bun/Step1.mdx
@@ -16,5 +16,5 @@ Our `@arcjet/bun` package is built for
 Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
 on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
 (uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](?f=node-js).
+follow [our guide for Node.js](/shield/quick-start?f=node-js).
 :::

--- a/src/snippets/signup-protection/quick-start/bun/Step1.mdx
+++ b/src/snippets/signup-protection/quick-start/bun/Step1.mdx
@@ -16,5 +16,5 @@ Our `@arcjet/bun` package is built for
 Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
 on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
 (uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](?f=node-js).
+follow [our guide for Node.js](/signup-protection/quick-start?f=node-js).
 :::

--- a/src/snippets/signup-protection/quick-start/bun/Step1.mdx
+++ b/src/snippets/signup-protection/quick-start/bun/Step1.mdx
@@ -1,3 +1,20 @@
+import SelectableContent from "@/components/SelectableContent";
+
+{/* prettier-ignore */}
+<SelectableContent client:load frameworkSwitcher>
+<div>
+
 ```bash
 bun add @arcjet/bun @arcjet/inspect
 ```
+
+</div>
+</SelectableContent>
+
+:::note
+Our `@arcjet/bun` package is built for
+Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
+on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
+(uses `node:http` or a Node.js framework like express) you should instead
+follow [our guide for Node.js](?f=node-js).
+:::


### PR DESCRIPTION
Closes #486

I've added a note below everywhere `bun add @arcjet/bun` appears in the docs (except hono getting started). Let me know if this placement & wording makes sense.

It's a fair amount of duplication at the moment but I didn't want to reinvent the wheel here.

<img width="881" alt="Screenshot 2025-05-23 at 5 22 06 PM" src="https://github.com/user-attachments/assets/d933f41a-8a24-4c4d-8e54-f0d9a9f5c156" />
