### PR TITLE
chore: Ensure `isDenied()` blocks never fall through.

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -215,6 +215,8 @@ if (decision.isDenied()) {
     console.error("Rate limit exceeded", decision.reason);
   } else if (decision.reason.isBot()) {
     console.error("Bot detected", decision.reason);
+  } else {
+    console.error("Forbidden", decision.reason);
   }
 }
 ```

--- a/src/snippets/bot-protection/reference/nextjs/FilteringApp.js
+++ b/src/snippets/bot-protection/reference/nextjs/FilteringApp.js
@@ -21,8 +21,8 @@ const aj = arcjet({
 export async function POST(req) {
   const decision = await aj.protect(req);
 
-  if (decision.reason.isBot()) {
-    if (decision.isDenied()) {
+  if (decision.isDenied()) {
+    if (decision.reason.isBot()) {
       return NextResponse.json(
         {
           error: "You are a bot!",
@@ -33,6 +33,12 @@ export async function POST(req) {
         { status: 403 },
       );
     }
+    return NextResponse.json(
+      {
+        error: "Forbidden",
+      },
+      { status: 403 },
+    );
   }
 
   return NextResponse.json({


### PR DESCRIPTION
This is a follow-on from our internal discussion. I've checked every instance where code matched this regexp: /if\s*\(\w+\.isDenied\(\)\)/.