### PR TITLE
chore: configure prettier to handle line wrap in md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Try an Arcjet protected app live at [https://example.arcjet.com][example-url].
 
 ## Commands
 
-These docs are built using [Astro][astro] and [Starlight][starlight]. All commands are run from the
-root of the project, from a terminal:
+These docs are built using [Astro][astro] and [Starlight][starlight]. All
+commands are run from the root of the project, from a terminal:
 
 | Command                   | Action                                           |
 | :------------------------ | :----------------------------------------------- |
@@ -39,9 +39,9 @@ This repository follows the [Arcjet Security Policy][arcjet-security].
 
 ## License
 
-All content in this repository is licensed under the [Creative Commons
-Attribution 4.0 International License](./LICENSE) and all code is licensed under
-the [Apache License, Version 2.0](./LICENSE-CODE).
+All content in this repository is licensed under the
+[Creative Commons Attribution 4.0 International License](./LICENSE) and all code
+is licensed under the [Apache License, Version 2.0](./LICENSE-CODE).
 
 [arcjet]: https://arcjet.com
 [astro]: https://astro.build

--- a/ec.config.mjs
+++ b/ec.config.mjs
@@ -4,13 +4,7 @@ import { defineEcConfig } from "astro-expressive-code";
 
 function lineNumbers() {
   // Only show line numbers on these languages
-  const lineNumberLanguages = [
-    "js",
-    "jsx",
-    "ts",
-    "tsx",
-    "ini",
-  ];
+  const lineNumberLanguages = ["js", "jsx", "ts", "tsx", "ini"];
 
   let plugin = pluginLineNumbers();
 
@@ -19,25 +13,26 @@ function lineNumbers() {
     name: `Line numbers (${lineNumberLanguages.join(", ")})`,
     hooks: {
       preprocessMetadata: (opt) => {
-        const { codeBlock: { language } } = opt;
+        const {
+          codeBlock: { language },
+        } = opt;
         if (lineNumberLanguages.includes(language)) {
           return plugin.hooks.preprocessMetadata(opt);
         }
       },
 
       postprocessRenderedBlock: (opt) => {
-        const { codeBlock: { language } } = opt;
+        const {
+          codeBlock: { language },
+        } = opt;
         if (lineNumberLanguages.includes(language)) {
           return plugin.hooks.postprocessRenderedBlock(opt);
         }
       },
-    }
+    },
   };
 }
 
 export default defineEcConfig({
-  plugins: [
-    lineNumbers(),
-    pluginCollapsibleSections(),
-  ],
+  plugins: [lineNumbers(), pluginCollapsibleSections()],
 });

--- a/package.json
+++ b/package.json
@@ -92,6 +92,9 @@
     },
     "rollup": "npm:@rollup/wasm-node"
   },
+  "prettier": {
+    "proseWrap": "always"
+  },
   "devDependencies": {
     "@types/bun": "1.2.18",
     "@types/deno": "2.3.0",

--- a/src/components/BlockShared.module.scss
+++ b/src/components/BlockShared.module.scss
@@ -149,13 +149,14 @@
 
   &.Level1 {
     &.Solid:before {
-      background: var(--aj-palette-block-level1-glare),
-        var(--aj-palette-block-level1-bg);
+      background:
+        var(--aj-palette-block-level1-glare), var(--aj-palette-block-level1-bg);
     }
 
     &.Blur {
       &.Solid:before {
-        background: var(--aj-palette-block-level1-glare),
+        background:
+          var(--aj-palette-block-level1-glare),
           var(--aj-palette-block-level1-blurBg);
       }
     }
@@ -225,13 +226,14 @@
 
   &.Level3 {
     &.Solid:before {
-      background: var(--aj-palette-block-level3-glare),
-        var(--aj-palette-block-level3-bg);
+      background:
+        var(--aj-palette-block-level3-glare), var(--aj-palette-block-level3-bg);
     }
 
     &.Blur {
       &.Solid:before {
-        background: var(--aj-palette-block-level3-glare),
+        background:
+          var(--aj-palette-block-level3-glare),
           var(--aj-palette-block-level3-blurBg);
       }
     }

--- a/src/components/Skeleton.module.scss
+++ b/src/components/Skeleton.module.scss
@@ -20,8 +20,8 @@
   overflow: hidden;
 
   &.Level1 {
-    background: var(--aj-palette-block-level1-glare),
-      var(--aj-palette-block-level1-bg);
+    background:
+      var(--aj-palette-block-level1-glare), var(--aj-palette-block-level1-bg);
 
     &.Fade {
       &:before {
@@ -36,8 +36,8 @@
   }
 
   &.Level3 {
-    background: var(--aj-palette-block-level3-glare),
-      var(--aj-palette-block-level3-bg);
+    background:
+      var(--aj-palette-block-level3-glare), var(--aj-palette-block-level3-bg);
   }
 
   &.Inline {

--- a/src/content/docs/architecture.mdx
+++ b/src/content/docs/architecture.mdx
@@ -46,8 +46,8 @@ pre-configured product.
   from a client over a period of time.
 - **[Bot Protection](/bot-protection/concepts)** - Detect and block automated
   clients.
-- **[Email Validation & Verification](/email-validation/concepts)** - Check
-  that an email address is valid.
+- **[Email Validation & Verification](/email-validation/concepts)** - Check that
+  an email address is valid.
 - **[Sensitive Information](/sensitive-info/concepts)** - Protect against
   clients sending you PII that you do not wish to handle.
 
@@ -254,8 +254,8 @@ network problem or outage and a call to the API is needed, the Arcjet SDK
 defaults to failing open so all requests will be allowed. This is a deliberate
 design decision to ensure that your application continues to function even if
 there is a problem, but you can configure the SDK to fail closed if you prefer.
-See an example of how to handle errors and fail open or closed in the [Node.js
-SDK reference](/reference/nodejs#error-handling).
+See an example of how to handle errors and fail open or closed in the
+[Node.js SDK reference](/reference/nodejs#error-handling).
 
 ## Fingerprinting
 
@@ -272,22 +272,21 @@ decision API.
 The fingerprint is configured based on the characteristics configured on the
 root of the SDK instance. If unspecified, the IP address is used by default. You
 can override this with any of the built-in or custom characteristics. The
-fingerprint can also be [configured on each rate limit
-rule](/rate-limiting/configuration) to apply a different rule to different
-clients based on their characteristics. If not specified, the root fingerprint
-is used.
+fingerprint can also be
+[configured on each rate limit rule](/rate-limiting/configuration) to apply a
+different rule to different clients based on their characteristics. If not
+specified, the root fingerprint is used.
 
 ### Built-in characteristics
 
 Built-in options are managed by the SDK and are always available. If multiple
 options are provided, they will be combined.
 
-:::caution
-If you specify different characteristics and do not include `ip.src`, you may
-inadvertently generate the same fingerprint for multiple users.
-Be sure to include a characteristic which can narrowly identify each client.
-For example, use a header value to limit based on a session token or authentication header.
-:::
+:::caution If you specify different characteristics and do not include `ip.src`,
+you may inadvertently generate the same fingerprint for multiple users. Be sure
+to include a characteristic which can narrowly identify each client. For
+example, use a header value to limit based on a session token or authentication
+header. :::
 
 | Option                                        |     Description      |
 | :-------------------------------------------- | :------------------: |
@@ -306,22 +305,20 @@ This will apply the limit to all requests made by that user regardless of their
 device and IP address.
 
 Custom characteristics are defined with a string key when configuring the sdk.
-The value is then passed as a `string`, `number` or `boolean` when
-calling the `protect` method. You can use any string value for the key.
+The value is then passed as a `string`, `number` or `boolean` when calling the
+`protect` method. You can use any string value for the key.
 
-:::caution
-Avoid passing personal information such as an email address as a custom
-characteristic. The value is hashed on Arcjet's servers, but it's still a best
-practice to avoid sending us sensitive information.
-:::
+:::caution Avoid passing personal information such as an email address as a
+custom characteristic. The value is hashed on Arcjet's servers, but it's still a
+best practice to avoid sending us sensitive information. :::
 
 ### IP address detection
 
 The client IP address is a key part of the fingerprint. The IP should not be
 trusted as it can be spoofed in most cases, especially when loaded via the
 `Headers` object. Each Arcjet SDK uses a native method to detect the IP address
-generally following the guidance provided by the [MDN X-Forwarded-For
-documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For).
+generally following the guidance provided by the
+[MDN X-Forwarded-For documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For).
 
 When choosing the IP address to use, Arcjet uses the first non-private IP that
 is a valid address. However, in non-production environments, we allow
@@ -342,8 +339,8 @@ decision for that client for a period of time.
 
 This threshold is dynamic and regularly updated based on the latest attack
 patterns. This protection is automatic and does not require any configuration.
-You can see the details of all requests, including those that are denied, in
-the [Arcjet dashboard](https://app.arcjet.com).
+You can see the details of all requests, including those that are denied, in the
+[Arcjet dashboard](https://app.arcjet.com).
 
 The results of this analysis are used regardless of the rules configured. This
 means Arcjet is continuously analyzing requests to your application and

--- a/src/content/docs/blueprints/ai-quota-control.mdx
+++ b/src/content/docs/blueprints/ai-quota-control.mdx
@@ -6,13 +6,20 @@ description: "Control your AI service tokens usage, categorized by user."
 import SelectableContent from "@/components/SelectableContent";
 import { Code, TabItem, Tabs } from "@astrojs/starlight/components";
 
-Arcjet can help you control usage quotas on your AI language model backed application. The goal is to limit the amount of requests from specific users, accounts, categories (you define the request characteristics) based on an estimate of token consumption. This will allow you to enforce user allowances and keep your costs under control.
+Arcjet can help you control usage quotas on your AI language model backed
+application. The goal is to limit the amount of requests from specific users,
+accounts, categories (you define the request characteristics) based on an
+estimate of token consumption. This will allow you to enforce user allowances
+and keep your costs under control.
 
-This is one of many possible approaches to track AI service use and is specific to language models. In different scenarios you could use other rate limiting algorithms on a request basis and on other conditions.
+This is one of many possible approaches to track AI service use and is specific
+to language models. In different scenarios you could use other rate limiting
+algorithms on a request basis and on other conditions.
 
 ### Rules
 
-We recommend using a Token bucket rate limit. This will be configured to match your category quota (eg: tokens/user) with the desired refill rate and interval.
+We recommend using a Token bucket rate limit. This will be configured to match
+your category quota (eg: tokens/user) with the desired refill rate and interval.
 
 ```ts
 const aj = arcjet({
@@ -34,7 +41,8 @@ const aj = arcjet({
 
 ### Checking the quota
 
-We retrieve the characteristic (eg: `userId`) and the user provided prompt and use it to withdraw the estimated amount of tokens from the bucket.
+We retrieve the characteristic (eg: `userId`) and the user provided prompt and
+use it to withdraw the estimated amount of tokens from the bucket.
 
 Once the bucket is empty, we issue a `DENY` decision.
 

--- a/src/content/docs/blueprints/cookie-banner.mdx
+++ b/src/content/docs/blueprints/cookie-banner.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Cookie Banner with Arcjet"
-description: "Use Arcjet's IP analysis to show a cookie banner in some jurisdictions."
+description:
+  "Use Arcjet's IP analysis to show a cookie banner in some jurisdictions."
 ---
 
 import { Aside, Badge } from "@astrojs/starlight/components";
@@ -16,8 +17,10 @@ banner's to users resident in jurisdictions that require them, without
 interfering with the experience of everyone else.
 
 Country data is available on the <Badge text="Free" variant="caution" /> plan,
-but the region data is only available on the <Badge text="Starter" variant="note" />
-or <Badge text="Business" variant="tip" /> plans.
+but the region data is only available on the
+
+<Badge text="Starter" variant="note" /> or
+<Badge text="Business" variant="tip" /> plans.
 
 <Aside type="caution">
   IP geolocation can be notoriously inaccurate, especially for mobile devices,

--- a/src/content/docs/blueprints/defining-custom-rules.mdx
+++ b/src/content/docs/blueprints/defining-custom-rules.mdx
@@ -7,10 +7,10 @@ import { Code } from "@astrojs/starlight/components";
 import CustomValidationRule from "@/snippets/blueprints/CustomValidationRule.ts?raw";
 
 The Arcjet SDK can be augmented with custom rules written by users, as long as
-they match the format defined by our [`@arcjet/protocol`
-package](https://github.com/arcjet/arcjet-js/tree/main/protocol). These rules
-will only be run locally since the Arcjet service doesn't know about them;
-however, they can still be useful for some use cases.
+they match the format defined by our
+[`@arcjet/protocol` package](https://github.com/arcjet/arcjet-js/tree/main/protocol).
+These rules will only be run locally since the Arcjet service doesn't know about
+them; however, they can still be useful for some use cases.
 
 The structure of a rule is:
 
@@ -30,8 +30,8 @@ interface ArcjetRule<Props extends { [key: string]: unknown } = {}> {
 }
 ```
 
-For example, you may want to [validate form
-input](https://blog.arcjet.com/next-js-security-checklist/#2-data-validation-and-sanitization)
+For example, you may want to
+[validate form input](https://blog.arcjet.com/next-js-security-checklist/#2-data-validation-and-sanitization)
 as part of your Arcjet protections before a request reaches your route handler,
 such as via Next.js middleware.
 
@@ -42,8 +42,8 @@ body, we need to create a new custom rule:
 
 <Code code={CustomValidationRule} lang="ts" />
 
-As long as it conforms to the rule interface, this rule can be consumed by
-the Arcjet SDK like any other rule!
+As long as it conforms to the rule interface, this rule can be consumed by the
+Arcjet SDK like any other rule!
 
 ```ts
 const aj = arcjet({
@@ -60,5 +60,5 @@ const aj = arcjet({
 ```
 
 When `aj.protect()` is called, inside middleware or directly inside a route,
-this custom rule will be executed and deny the request if the body doesn't
-pass validation.
+this custom rule will be executed and deny the request if the body doesn't pass
+validation.

--- a/src/content/docs/blueprints/ip-geolocation.mdx
+++ b/src/content/docs/blueprints/ip-geolocation.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Arcjet IP geolocation"
-description: "Use Arcjet's IP analysis to customize the response based on the IP location."
+description:
+  "Use Arcjet's IP analysis to customize the response based on the IP location."
 ---
 
 import { Aside, Badge } from "@astrojs/starlight/components";

--- a/src/content/docs/blueprints/payment-form.mdx
+++ b/src/content/docs/blueprints/payment-form.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Payment form protection"
-description: "How to protect a payment form from fraudulent transactions using Arcjet."
+description:
+  "How to protect a payment form from fraudulent transactions using Arcjet."
 ---
 
 import SelectableContent from "@/components/SelectableContent";
@@ -17,8 +18,8 @@ to block the most obvious fraud attempts.
 ## Pre-checkout protection
 
 A common approach for handling payments is to generate a unique payment or
-checkout link e.g. [Stripe
-Checkout](https://docs.stripe.com/checkout/quickstart?lang=node&client=next).
+checkout link e.g.
+[Stripe Checkout](https://docs.stripe.com/checkout/quickstart?lang=node&client=next).
 This avoids having to collect credit card details on your own servers.
 
 In this example, Arcjet will analyze the user request before checkout. If the
@@ -71,10 +72,10 @@ const aj = arcjet({
 
 ### Additional checks
 
-If the base rules pass then you can use [IP
-geolocation](/blueprints/ip-geolocation) and [VPN & proxy
-detection](/blueprints/vpn-proxy-detection) checks to further validate the
-transaction.
+If the base rules pass then you can use
+[IP geolocation](/blueprints/ip-geolocation) and
+[VPN & proxy detection](/blueprints/vpn-proxy-detection) checks to further
+validate the transaction.
 
 This example only allows users from the US and UK, and blocks users from hosting
 providers, VPNs, and proxies.

--- a/src/content/docs/blueprints/sampling.mdx
+++ b/src/content/docs/blueprints/sampling.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Sampling traffic"
-description: "How to write a sampling function to test your Arcjet security rules on a subset of your traffic."
+description:
+  "How to write a sampling function to test your Arcjet security rules on a
+  subset of your traffic."
 ---
 
 import { Code, TabItem, Tabs } from "@astrojs/starlight/components";

--- a/src/content/docs/blueprints/vpn-proxy-detection.mdx
+++ b/src/content/docs/blueprints/vpn-proxy-detection.mdx
@@ -10,11 +10,12 @@ to detect VPNs and proxies.
 
 ## Available fields
 
-- **IP AS type.** This is the [Autonomous
-  System](<https://en.wikipedia.org/wiki/Autonomous_system_(Internet)>)
+- **IP AS type.** This is the
+  [Autonomous System](<https://en.wikipedia.org/wiki/Autonomous_system_(Internet)>)
   associated with the IP, which can be used to identify VPNs and proxies. This
   can be one of `isp`, `hosting`, `business` or `education`. This field is only
-  available on <Badge text="Starter" variant="note" /> and <Badge text="Business" variant="tip" /> plans.
+  available on <Badge text="Starter" variant="note" /> and
+  <Badge text="Business" variant="tip" /> plans.
 - **IP type.** Arcjet adds one or more categories to the IP address to help you
   identify VPNs and proxies. The categories are `vpn`, `proxy`, `tor`,
   `hosting`, `relay`. This field is available on all pricing plans.

--- a/src/content/docs/bot-protection/concepts.mdx
+++ b/src/content/docs/bot-protection/concepts.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Arcjet bot protection"
-description: "Arcjet bot protection allows you to manage traffic by automated clients and bots."
+description:
+  "Arcjet bot protection allows you to manage traffic by automated clients and
+  bots."
 prev: false
 ---
 
@@ -29,15 +31,17 @@ those are often not the bots you wish to block! Bad bots pretend to be real
 clients and use various mechanisms to evade bot detection.
 
 {/* prettier-ignore */}
-The Arcjet <Badge text="Starter" variant="note" /> or <Badge text="Business" variant="tip" />
-plans provides additional [bot verification](/bot-protection/reference#bot-verification) using
-IP analysis, which can help if you are under attack from bots pretending to be
-good bots e.g. clients pretending to be Google (who you usually want to allow).
+The Arcjet <Badge text="Starter" variant="note" /> or
 
-Arcjet's bot protect works best when combined with [rate
-limiting](/rate-limiting/concepts). This allows you to block clients that are
-causing problems whilst minimizing the impact on real users. See [an example of
-this in the Node.js SDK reference](/reference/nodejs#multiple-rules).
+<Badge text="Business" variant="tip" /> plans provides additional [bot
+verification](/bot-protection/reference#bot-verification) using IP analysis,
+which can help if you are under attack from bots pretending to be good bots e.g.
+clients pretending to be Google (who you usually want to allow).
+
+Arcjet's bot protect works best when combined with
+[rate limiting](/rate-limiting/concepts). This allows you to block clients that
+are causing problems whilst minimizing the impact on real users. See
+[an example of this in the Node.js SDK reference](/reference/nodejs#multiple-rules).
 
 Arcjet will help you reduce bot traffic and give you more control over which
 requests reach your application, but it's important to understand that it's not

--- a/src/content/docs/bot-protection/identifying-bots.mdx
+++ b/src/content/docs/bot-protection/identifying-bots.mdx
@@ -59,8 +59,8 @@ We provide the following categories:
 - `CATEGORY:VERCEL`: Scrape data for Vercel products and services
 - `CATEGORY:YAHOO`: Scrape data for Yahoo products and services
 
-The [bot
-list](https://github.com/arcjet/arcjet-js/blob/24d2ee3139f277499ef3cb65f1f1eab998647819/protocol/well-known-bots.ts#L596)
+The
+[bot list](https://github.com/arcjet/arcjet-js/blob/24d2ee3139f277499ef3cb65f1f1eab998647819/protocol/well-known-bots.ts#L596)
 contains a list of categories and which bots are in each category.
 
 ```ts
@@ -90,25 +90,26 @@ For basic detection on the <Badge text="Free" variant="caution" /> plan, Arcjet
 uses the `User-Agent` header to identify specific bots.
 
 {/* prettier-ignore */}
-The Arcjet <Badge text="Starter" variant="note" /> or <Badge text="Business" variant="tip" />
-plans provides additional [bot verification](/bot-protection/reference#bot-verification) using
-IP analysis, which can help if you are under attack from bots pretending to be
-good bots e.g. clients pretending to be Google (who you usually want to allow).
+The Arcjet <Badge text="Starter" variant="note" /> or
 
-:::note
-Requests without `User-Agent` headers might not be identified as any particular
-bot and could be marked as an errored result. Our recommendation is to block
-requests without `User-Agent` headers because most legitimate clients send this
-header.
+<Badge text="Business" variant="tip" /> plans provides additional [bot
+verification](/bot-protection/reference#bot-verification) using IP analysis,
+which can help if you are under attack from bots pretending to be good bots e.g.
+clients pretending to be Google (who you usually want to allow).
+
+:::note Requests without `User-Agent` headers might not be identified as any
+particular bot and could be marked as an errored result. Our recommendation is
+to block requests without `User-Agent` headers because most legitimate clients
+send this header.
 
 See [an example of how to do this](/bot-protection/concepts#user-agent-header).
 :::
 
 ### Known bots structure
 
-The identifiers on the bot list are generated from [a collection of known
-bots](https://github.com/arcjet/well-known-bots) which includes details of their
-owner and any variations.
+The identifiers on the bot list are generated from
+[a collection of known bots](https://github.com/arcjet/well-known-bots) which
+includes details of their owner and any variations.
 
 We welcome contributions to the
 [arcjet/well-known-bots](https://github.com/arcjet/well-known-bots) repository,
@@ -117,7 +118,8 @@ updates will be included in the next SDK release. Since bot detection is handled
 within the Arcjet WebAssembly module bundled with the SDK, new patterns must be
 compiled into the module as part of the release process.
 
-Please read the repository's [README.md](https://github.com/arcjet/well-known-bots/blob/main/README.md)
-for specific instructions on how to contribute to our bot detection.
+Please read the repository's
+[README.md](https://github.com/arcjet/well-known-bots/blob/main/README.md) for
+specific instructions on how to contribute to our bot detection.
 
 <Comments />

--- a/src/content/docs/bot-protection/quick-start.mdx
+++ b/src/content/docs/bot-protection/quick-start.mdx
@@ -10,7 +10,9 @@ titleByFramework:
   node-js: "Bot protection for Node.js"
   remix: "Bot protection for Remix"
   sveltekit: "Bot protection for SvelteKit"
-description: "Quick start guide for adding Arcjet bot protection to your Next.js, NestJS, Node.js, Bun, Remix, or SvelteKit app."
+description:
+  "Quick start guide for adding Arcjet bot protection to your Next.js, NestJS,
+  Node.js, Bun, Remix, or SvelteKit app."
 frameworks:
   - astro
   - bun
@@ -107,8 +109,9 @@ Arcjet bot detection allows you to manage traffic by automated clients and bots.
 
 ## Quick start
 
-This guide will show you how to protect your entire <FrameworkName client:load />
-application from bots and automated clients.
+This guide will show you how to protect your entire
+
+<FrameworkName client:load /> application from bots and automated clients.
 
 ### 1. Install Arcjet
 
@@ -169,9 +172,9 @@ The requests will also show in the [Arcjet dashboard](https://app.arcjet.com).
 
 ### 5. Choose bots to allow or deny
 
-Arcjet maintains a list of known bots so you can choose to either only [allow
-specific bots](/bot-protection/reference#allowing-specific-bots) or only [deny
-specific bots](/bot-protection/reference#denying-specific-bots).
+Arcjet maintains a list of known bots so you can choose to either only
+[allow specific bots](/bot-protection/reference#allowing-specific-bots) or only
+[deny specific bots](/bot-protection/reference#denying-specific-bots).
 
 Check out our [full list of bots](https://arcjet.com/bot-list).
 
@@ -197,8 +200,8 @@ Check out our [full list of bots](https://arcjet.com/bot-list).
 ### Explore
 
 Arcjet can be used with specific rules on individual routes or as general
-protection on your entire application. You can setup rate limiting for your
-API, minimize fraudulent registrations with the signup form protection and more.
+protection on your entire application. You can setup rate limiting for your API,
+minimize fraudulent registrations with the signup form protection and more.
 
 <CardGrid>
   <LinkCard

--- a/src/content/docs/bot-protection/reference.mdx
+++ b/src/content/docs/bot-protection/reference.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Bot protection reference"
-description: "Reference guide for adding Arcjet bot protection to your Next.js, NestJS, Node.js, Bun, Remix, or SvelteKit app."
+description:
+  "Reference guide for adding Arcjet bot protection to your Next.js, NestJS,
+  Node.js, Bun, Remix, or SvelteKit app."
 frameworks:
   - bun
   - deno
@@ -153,8 +155,8 @@ Arcjet bot detection allows you to manage traffic by automated clients and bots.
 
 ## Plan availability
 
-Arcjet bot detection functionality depends on your [pricing
-plan](https://arcjet.com/pricing).
+Arcjet bot detection functionality depends on your
+[pricing plan](https://arcjet.com/pricing).
 
 | Plan                                                                             | Bot protection                                                                     |
 | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
@@ -195,25 +197,23 @@ type BotOptionsDeny = {
 The `arcjet` client is configured with one or more `detectBot` rules which take
 one or many `BotOptions`.
 
-:::note
-When specifying multiple rules, the order of the rules is ignored. Rule
-execution ordering is automatically optimized for performance. See below for
-how to examine the execution results.
-:::
+:::note When specifying multiple rules, the order of the rules is ignored. Rule
+execution ordering is automatically optimized for performance. See below for how
+to examine the execution results. :::
 
 ### Allowing specific bots
 
 Most applications want to block almost all bots. However, it is common to allow
-some bots to access your system, such as bots for search indexing or API
-access from the command line.
+some bots to access your system, such as bots for search indexing or API access
+from the command line.
 
-When allowing specific bots we recommend that you also [check the verification
-status](#bot-verification) after an allow decision is returned to ensure that the bots are who they
-say they are.
+When allowing specific bots we recommend that you also
+[check the verification status](#bot-verification) after an allow decision is
+returned to ensure that the bots are who they say they are.
 
-This behavior is configured with an `allow` list from our [full list of
-bots](https://arcjet.com/bot-list) and/or [bot
-categories](/bot-protection/identifying-bots#bot-categories).
+This behavior is configured with an `allow` list from our
+[full list of bots](https://arcjet.com/bot-list) and/or
+[bot categories](/bot-protection/identifying-bots#bot-categories).
 
 <SlotByFramework client:load>
   <BunAllowingBots slot="bun" />
@@ -231,9 +231,9 @@ Some applications may only want to block a small subset of bots, while allowing
 the majority continued access. This may be due to many reasons, such as
 misconfigured or high-traffic bots.
 
-This behavior is configured with a `deny` list from our [full list of
-bots](https://arcjet.com/bot-list) and/or [bot
-categories](/bot-protection/identifying-bots#bot-categories).
+This behavior is configured with a `deny` list from our
+[full list of bots](https://arcjet.com/bot-list) and/or
+[bot categories](/bot-protection/identifying-bots#bot-categories).
 
 <SlotByFramework client:load>
   <BunDenyingBots slot="bun" />
@@ -266,8 +266,8 @@ context as passed to the request handler.
   <NestJsGuardDecision slot="nest-js" />
 </SlotByFramework>
 
-This function returns a `Promise` that resolves to an
-`ArcjetDecision` object. This contains the following properties:
+This function returns a `Promise` that resolves to an `ArcjetDecision` object.
+This contains the following properties:
 
 - `id` (`string`) - The unique ID for the request. This can be used to look up
   the request in the Arcjet dashboard. It is prefixed with `req_` for decisions
@@ -276,8 +276,8 @@ This function returns a `Promise` that resolves to an
 - `conclusion` (`ArcjetConclusion`) - The final conclusion based on evaluating
   each of the configured rules. If you wish to accept Arcjet's recommended
   action based on the configured rules then you can use this property.
-- `reason` (`ArcjetReason`) - An object containing more detailed
-  information about the conclusion.
+- `reason` (`ArcjetReason`) - An object containing more detailed information
+  about the conclusion.
 - `results` (`ArcjetRuleResult[]`) - An array of `ArcjetRuleResult` objects
   containing the results of each rule that was executed.
 - `ip` (`ArcjetIpDetails`) - An object containing Arcjet's analysis of the
@@ -307,11 +307,11 @@ for (const result of decision.results) {
 
 ### Identified bots
 
-The decision also contains all of the [identified
-bots and matched categories](/bot-protection/identifying-bots) detected from the
-request. A request may be identified as zero, one, or more bots/categories—all
-of which will be available on the `decision.allowed` and `decision.denied`
-properties.
+The decision also contains all of the
+[identified bots and matched categories](/bot-protection/identifying-bots)
+detected from the request. A request may be identified as zero, one, or more
+bots/categories—all of which will be available on the `decision.allowed` and
+`decision.denied` properties.
 
 <SlotByFramework client:load>
   <BunIdentifiedBots slot="bun" />
@@ -331,17 +331,16 @@ when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
 in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition when processing the rule, Arcjet will return an
-`ERROR` result for that rule and you can check the `message` property on the rule's
-error result for more information.
+`ERROR` result for that rule and you can check the `message` property on the
+rule's error result for more information.
 
-If all other rules that were run returned an `ALLOW` result, then the final Arcjet
-conclusion will be `ERROR`.
+If all other rules that were run returned an `ALLOW` result, then the final
+Arcjet conclusion will be `ERROR`.
 
-:::note
-Requests without `User-Agent` headers might not be identified as any particular
-bot and could be marked as an errored result. Our recommendation is to block
-requests without `User-Agent` headers because most legitimate clients send this
-header.
+:::note Requests without `User-Agent` headers might not be identified as any
+particular bot and could be marked as an errored result. Our recommendation is
+to block requests without `User-Agent` headers because most legitimate clients
+send this header.
 
 See [an example of how to do this](/bot-protection/concepts#user-agent-header).
 :::
@@ -381,11 +380,9 @@ of detected bots by checking IP data and performing reverse DNS lookups.
 This helps protect against spoofed bots where clients pretend to be someone
 else.
 
-:::note
-Because verification is only helpful when you want to specifically `allow`
-certain bots, any `deny` rules bypass verification and simply block bots
-matching the `deny` list.
-:::
+:::note Because verification is only helpful when you want to specifically
+`allow` certain bots, any `deny` rules bypass verification and simply block bots
+matching the `deny` list. :::
 
 ### Example: Allowing verified bots
 

--- a/src/content/docs/email-validation/concepts.mdx
+++ b/src/content/docs/email-validation/concepts.mdx
@@ -1,6 +1,9 @@
 ---
 title: "Arcjet email validation"
-description: "Arcjet allows you to validate & verify an email address. This is useful for preventing users from signing up with fake email addresses and can significantly reduce the amount of spam or fraudulent accounts."
+description:
+  "Arcjet allows you to validate & verify an email address. This is useful for
+  preventing users from signing up with fake email addresses and can
+  significantly reduce the amount of spam or fraudulent accounts."
 prev: false
 next: false
 ---
@@ -16,11 +19,10 @@ reduce the amount of spam or fraudulent accounts.
 
 ## Step 1: Validation
 
-The first step is to validate the email address syntax. This runs locally
-within the SDK and validates the email address is in the correct format.
-Validation is performed against several RFCs with modifications to exclude email
-addresses you wouldn't expect signing up to a real application e.g. local
-domains.
+The first step is to validate the email address syntax. This runs locally within
+the SDK and validates the email address is in the correct format. Validation is
+performed against several RFCs with modifications to exclude email addresses you
+wouldn't expect signing up to a real application e.g. local domains.
 
 Two of the validation options are configurable: whether 2 parts of the domain
 are required (defaults to being required) and whether domain literals in the
@@ -54,8 +56,7 @@ provided:
 - `DomainEmpty`: The domain of the email address must contain at least 1
   character.
 - `DomainTooLong`: The domain has a max-length of 254 characters, as per
-  [RFC3696 errata
-  1690](https://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690)
+  [RFC3696 errata 1690](https://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690)
 - `SubDomainEmpty` One or more domain segments, separated by the `.` character,
   are empty.
 - `SubDomainTooLong` One or more domain segments, separated by the `.`
@@ -84,15 +85,15 @@ manually review those from free email providers.
 The Arcjet SDK will provide an analysis of the email type, returning one or
 several of the following:
 
-- **Disposable:** The email address is disposable, which means it's registered to a
-  service that allows throwaway email addresses. Although these are sometimes
-  used for privacy, they are also often used for spam signups or fraudulent
-  activity when combined with a transaction e.g. attempting to use a credit
-  card. We recommend blocking these in higher risk scenarios.
-- **Free:** The email address is registered to a free email service. These are very
-  common, such as GMail or Yahoo Mail, so we do not recommend blocking these.
-  However, you may wish to flag these for review the first time they attempt a
-  transaction.
+- **Disposable:** The email address is disposable, which means it's registered
+  to a service that allows throwaway email addresses. Although these are
+  sometimes used for privacy, they are also often used for spam signups or
+  fraudulent activity when combined with a transaction e.g. attempting to use a
+  credit card. We recommend blocking these in higher risk scenarios.
+- **Free:** The email address is registered to a free email service. These are
+  very common, such as GMail or Yahoo Mail, so we do not recommend blocking
+  these. However, you may wish to flag these for review the first time they
+  attempt a transaction.
 - **No MX records:** This email address is registered to a domain name which has
   no MX records configured. This means it cannot receive email. We recommend
   blocking these.
@@ -104,26 +105,34 @@ several of the following:
 
 The email validation stage considers the following RFCs:
 
-1. RFC 1123: [_Requirements for Internet Hosts -- Application and
-   Support_](https://tools.ietf.org/html/rfc1123), IETF, Oct 1989.
-2. RFC 3629: [_UTF-8, a transformation format of ISO
-   10646_](https://tools.ietf.org/html/rfc3629), IETF, Nov 2003.
-3. RFC 3696: [_Application Techniques for Checking and Transformation of
-   Names_](https://tools.ietf.org/html/rfc3696), IETF, Feb 2004.
-4. RFC 4291: [_IP Version 6 Addressing
-   Architecture_](https://tools.ietf.org/html/rfc4291), IETF, Feb 2006.
-5. RFC 5234: [_Augmented BNF for Syntax Specifications:
-   ABNF_](https://tools.ietf.org/html/rfc5234), IETF, Jan 2008.
-6. RFC 5321: [_Simple Mail Transfer
-   Protocol_](https://tools.ietf.org/html/rfc5321), IETF, Oct 2008.
+1. RFC 1123:
+   [_Requirements for Internet Hosts -- Application and Support_](https://tools.ietf.org/html/rfc1123),
+   IETF, Oct 1989.
+2. RFC 3629:
+   [_UTF-8, a transformation format of ISO 10646_](https://tools.ietf.org/html/rfc3629),
+   IETF, Nov 2003.
+3. RFC 3696:
+   [_Application Techniques for Checking and Transformation of Names_](https://tools.ietf.org/html/rfc3696),
+   IETF, Feb 2004.
+4. RFC 4291:
+   [_IP Version 6 Addressing Architecture_](https://tools.ietf.org/html/rfc4291),
+   IETF, Feb 2006.
+5. RFC 5234:
+   [_Augmented BNF for Syntax Specifications: ABNF_](https://tools.ietf.org/html/rfc5234),
+   IETF, Jan 2008.
+6. RFC 5321:
+   [_Simple Mail Transfer Protocol_](https://tools.ietf.org/html/rfc5321), IETF,
+   Oct 2008.
 7. RFC 5322: [_Internet Message Format_](https://tools.ietf.org/html/rfc5322), I
    ETF, Oct 2008.
-8. RFC 5890: [_Internationalized Domain Names for Applications (IDNA):
-   Definitions and Document Framework_](https://tools.ietf.org/html/rfc5890),
+8. RFC 5890:
+   [_Internationalized Domain Names for Applications (IDNA): Definitions and Document Framework_](https://tools.ietf.org/html/rfc5890),
    IETF, Aug 2010.
-9. RFC 6531: [_SMTP Extension for Internationalized
-   Email_](https://tools.ietf.org/html/rfc6531), IETF, Feb 2012.
-10. RFC 6532: [_Internationalized Email
-    Headers_](https://tools.ietf.org/html/rfc6532), IETF, Feb 2012.
+9. RFC 6531:
+   [_SMTP Extension for Internationalized Email_](https://tools.ietf.org/html/rfc6531),
+   IETF, Feb 2012.
+10. RFC 6532:
+    [_Internationalized Email Headers_](https://tools.ietf.org/html/rfc6532),
+    IETF, Feb 2012.
 
 <Comments />

--- a/src/content/docs/email-validation/quick-start.mdx
+++ b/src/content/docs/email-validation/quick-start.mdx
@@ -8,7 +8,9 @@ titleByFramework:
   node-js: "Email validation for Node.js"
   remix: "Email validation for Remix"
   sveltekit: "Email validation for SvelteKit"
-description: "Quick start guide for adding Arcjet email validation to your Next.js, NestJS, Node.js, Bun, or SvelteKit app."
+description:
+  "Quick start guide for adding Arcjet email validation to your Next.js, NestJS,
+  Node.js, Bun, or SvelteKit app."
 frameworks:
   - bun
   - nest-js
@@ -83,8 +85,9 @@ reduce the amount of spam or fraudulent accounts.
 
 ## Quick start
 
-This guide will show you how to add email validation and verification to
-your <FrameworkName client:load /> app.
+This guide will show you how to add email validation and verification to your
+
+<FrameworkName client:load /> app.
 
 ### 1. Install Arcjet
 

--- a/src/content/docs/email-validation/reference.mdx
+++ b/src/content/docs/email-validation/reference.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Email validation reference"
-description: "Reference guide for adding Arcjet email validation to your Next.js, NestJS, Node.js, Bun, Remix, or SvelteKit app."
+description:
+  "Reference guide for adding Arcjet email validation to your Next.js, NestJS,
+  Node.js, Bun, Remix, or SvelteKit app."
 frameworks:
   - bun
   - nest-js
@@ -58,8 +60,8 @@ reduce the amount of spam or fraudulent accounts.
 
 ## Plan availability
 
-Arcjet email validation availability depends depends on your [pricing
-plan](https://arcjet.com/pricing).
+Arcjet email validation availability depends depends on your
+[pricing plan](https://arcjet.com/pricing).
 
 | Plan                                                                             | Email validation                                       |
 | -------------------------------------------------------------------------------- | ------------------------------------------------------ |
@@ -122,8 +124,8 @@ rule it also requires an additional `email` prop.
   <NestJsGuardDecision slot="nest-js" />
 </SlotByFramework>
 
-This function returns a `Promise` that resolves to an
-`ArcjetDecision` object. This contains the following properties:
+This function returns a `Promise` that resolves to an `ArcjetDecision` object.
+This contains the following properties:
 
 - `id` (`string`) - The unique ID for the request. This can be used to look up
   the request in the Arcjet dashboard. It is prefixed with `req_` for decisions
@@ -132,8 +134,8 @@ This function returns a `Promise` that resolves to an
 - `conclusion` (`ArcjetConclusion`) - The final conclusion based on evaluating
   each of the configured rules. If you wish to accept Arcjet's recommended
   action based on the configured rules then you can use this property.
-- `reason` (`ArcjetReason`) - An object containing more detailed
-  information about the conclusion.
+- `reason` (`ArcjetReason`) - An object containing more detailed information
+  about the conclusion.
 - `results` (`ArcjetRuleResult[]`) - An array of `ArcjetRuleResult` objects
   containing the results of each rule that was executed.
 - `ip` (`ArcjetIpDetails`) - An object containing Arcjet's analysis of the
@@ -179,7 +181,8 @@ Arcjet to only allow specific email types and all other types will be blocked.
 ## Checking the email type
 
 Arcjet will return the type of email address that was verified. This will be one
-or several of the [reported email types](/email-validation/concepts#email-types).
+or several of the
+[reported email types](/email-validation/concepts#email-types).
 
 ```ts
 // See https://docs.arcjet.com/email-validation/concepts#email-types
@@ -220,11 +223,11 @@ when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
 in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition when processing the rule, Arcjet will return an
-`ERROR` result for that rule and you can check the `message` property on the rule's
-error result for more information.
+`ERROR` result for that rule and you can check the `message` property on the
+rule's error result for more information.
 
-If all other rules that were run returned an `ALLOW` result, then the final Arcjet
-conclusion will be `ERROR`.
+If all other rules that were run returned an `ALLOW` result, then the final
+Arcjet conclusion will be `ERROR`.
 
 <SlotByFramework client:load>
   <ErrorsBun slot="bun" />

--- a/src/content/docs/get-started.mdx
+++ b/src/content/docs/get-started.mdx
@@ -14,7 +14,10 @@ titleByFramework:
   node-js-hono: "Get started with Node.js + Hono"
   remix: "Get started with Remix"
   sveltekit: "Get started with SvelteKit"
-description: "Getting started with Arcjet. Quick start guide to protect your app from attacks, apply a rate limit, and prevent bots from accessing your Astro, Bun, Deno, Fastify, NestJS, Next.js, Node.js, Remix, or SvelteKit app."
+description:
+  "Getting started with Arcjet. Quick start guide to protect your app from
+  attacks, apply a rate limit, and prevent bots from accessing your Astro, Bun,
+  Deno, Fastify, NestJS, Next.js, Node.js, Remix, or SvelteKit app."
 prev: false
 next: false
 frameworks:
@@ -292,9 +295,9 @@ The requests will also show in the [Arcjet dashboard](https://app.arcjet.com).
 ### Explore
 
 Arcjet can be used with specific rules on individual routes or as general
-protection on your entire application. You can defend from clients sending
-you sensitive information, minimize fraudulent registrations with
-the signup form protection and more.
+protection on your entire application. You can defend from clients sending you
+sensitive information, minimize fraudulent registrations with the signup form
+protection and more.
 
 <CardGrid>
   <LinkCard
@@ -312,5 +315,6 @@ the signup form protection and more.
 
 ## Get help
 
-Need help with anything? [Email us](mailto:support@arcjet.com) or [join our
-Discord](https://arcjet.com/discord) to get support from our engineering team.
+Need help with anything? [Email us](mailto:support@arcjet.com) or
+[join our Discord](https://arcjet.com/discord) to get support from our
+engineering team.

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -6,7 +6,9 @@ head:
     content: Arcjet docs
 tableOfContents: false
 hero:
-  tagline: Bot detection. Rate limiting. Email validation. Attack protection. Data redaction. A developer-first approach to security.
+  tagline:
+    Bot detection. Rate limiting. Email validation. Attack protection. Data
+    redaction. A developer-first approach to security.
   image:
     alt: Arcjet space object.
     dark: "/src/assets/arcjet-space-obj-v2-5-dark.png"

--- a/src/content/docs/inspect.mdx
+++ b/src/content/docs/inspect.mdx
@@ -55,9 +55,7 @@ detected, `false` if the bot rule result was not `"DRY_RUN"` and a spoofed bot
 was not detected, or `undefined` if the rule result was from a `"DRY_RUN"` bot
 rule or a non-bot rule.
 
-:::note
-Spoofed bot detection is not available on <Free /> plans.
-:::
+:::note Spoofed bot detection is not available on <Free /> plans. :::
 
 **Types:**
 
@@ -78,9 +76,7 @@ detected, `false` if the bot rule result was not `"DRY_RUN"` and a verified bot
 was not detected, or `undefined` if the rule result was from a `"DRY_RUN"` bot
 rule or a non-bot rule.
 
-:::note
-Verified bot detection is not available on <Free /> plans.
-:::
+:::note Verified bot detection is not available on <Free /> plans. :::
 
 **Types:**
 
@@ -105,10 +101,10 @@ a `"DRY_RUN"` bot rule or a non-bot rule.
 
 ## What next?
 
-Arcjet can protect your entire app or individual routes with just
-a few lines of code. Using the main Arcjet SDK you can setup bot protection,
-rate limiting for your API, minimize fraudulent registrations with the
-signup form protection and more.
+Arcjet can protect your entire app or individual routes with just a few lines of
+code. Using the main Arcjet SDK you can setup bot protection, rate limiting for
+your API, minimize fraudulent registrations with the signup form protection and
+more.
 
 import { LinkCard, CardGrid } from "@astrojs/starlight/components";
 

--- a/src/content/docs/integrations/authjs.mdx
+++ b/src/content/docs/integrations/authjs.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Arcjet / Auth.js integration"
-description: "Integrating Auth.js and Arcjet. Add rate limits to Auth.js login endpoints."
+description:
+  "Integrating Auth.js and Arcjet. Add rate limits to Auth.js login endpoints."
 prev: false
 next: false
 ---
@@ -31,13 +32,13 @@ authenticated user ID to implement user-specific rate limits.
 
 ## Example use case
 
-- Protect your Auth.js route handlers by rate limiting requests and
-  blocking bots.
-- Provide a higher rate limit for authenticated clients based on their
-  Auth.js user ID.
+- Protect your Auth.js route handlers by rate limiting requests and blocking
+  bots.
+- Provide a higher rate limit for authenticated clients based on their Auth.js
+  user ID.
 
-See an [example Next.js implementation on
-GitHub](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-authjs-5).
+See an
+[example Next.js implementation on GitHub](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-authjs-5).
 
 ## Protect Auth.js route handlers
 
@@ -76,8 +77,8 @@ within a 60 second window and also prevents bots from making requests.
 
 ## Rate limits using Auth.js user ID
 
-Arcjet rate limits allow [custom
-characteristics](/rate-limiting/configuration#custom-characteristics) to
+Arcjet rate limits allow
+[custom characteristics](/rate-limiting/configuration#custom-characteristics) to
 identify the client and apply the limit. Using the Auth.js
 [`auth`](https://authjs.dev/reference/nextjs#auth) helper you can pass through a
 user ID.

--- a/src/content/docs/integrations/better-auth.mdx
+++ b/src/content/docs/integrations/better-auth.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Arcjet / Better Auth integration"
-description: "Integrating Better Auth and Arcjet. Add bot protection and spam signup protection to Better Auth endpoints."
+description:
+  "Integrating Better Auth and Arcjet. Add bot protection and spam signup
+  protection to Better Auth endpoints."
 prev: false
 next: false
 ---
@@ -9,21 +11,21 @@ import { Aside, Code, TabItem, Tabs } from "@astrojs/starlight/components";
 import WhatIsArcjet from "/src/components/WhatIsArcjet.astro";
 import Comments from "/src/components/Comments.astro";
 
-Arcjet can protect your [Better Auth](https://www.better-auth.com/) routes from brute
-force attacks, signup spam and other abuse. You can also use the authenticated
-user ID to implement user-specific rate limits.
+Arcjet can protect your [Better Auth](https://www.better-auth.com/) routes from
+brute force attacks, signup spam and other abuse. You can also use the
+authenticated user ID to implement user-specific rate limits.
 
 <WhatIsArcjet />
 
 ## Example app
 
-See an [example Next.js + Better Auth implementation on
-GitHub](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-better-auth).
+See an
+[example Next.js + Better Auth implementation on GitHub](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-better-auth).
 
 ## Better Auth hook
 
-We recommend integrating Arcjet in the [auth route
-handler](https://github.com/arcjet/arcjet-js/blob/main/examples/nextjs-better-auth/app/api/auth/%5B...all%5D/route.ts)
+We recommend integrating Arcjet in the
+[auth route handler](https://github.com/arcjet/arcjet-js/blob/main/examples/nextjs-better-auth/app/api/auth/%5B...all%5D/route.ts)
 rather than a Better Auth Hook because hooks do not provide sufficient request
 context in server-only environments.
 

--- a/src/content/docs/integrations/clerk.mdx
+++ b/src/content/docs/integrations/clerk.mdx
@@ -31,13 +31,13 @@ and Arcjet provides the rate limiting.
 - Providing a higher rate limit for authenticated clients based on their Clerk
   user ID.
 
-See an [example Next.js implementation on
-GitHub](https://github.com/arcjet/arcjet-js/blob/main/examples/nextjs-clerk-rate-limit).
+See an
+[example Next.js implementation on GitHub](https://github.com/arcjet/arcjet-js/blob/main/examples/nextjs-clerk-rate-limit).
 
 ## Rate limits using Clerk user ID
 
-Arcjet rate limits allow [custom
-characteristics](/rate-limiting/configuration#custom-characteristics) to
+Arcjet rate limits allow
+[custom characteristics](/rate-limiting/configuration#custom-characteristics) to
 identify the client and apply the limit. Using Clerk's
 [`currentUser()`](https://clerk.com/docs/references/nextjs/current-user) (app
 router) or [`getAuth()`](https://clerk.com/docs/references/nextjs/get-auth)
@@ -80,8 +80,8 @@ If you want to protect every page with [Arcjet Shield](/shield/concepts)
 automatically you can run it through Next.js middleware. Clerk also uses
 middleware to add authentication to your pages. You can chain the two together.
 
-See an [example Next.js implementation on
-GitHub](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-clerk-shield).
+See an
+[example Next.js implementation on GitHub](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-clerk-shield).
 
 <Code code={NextJSClerkAJMiddleware} lang="ts" title="/middleware.ts" />
 

--- a/src/content/docs/integrations/langchain.mdx
+++ b/src/content/docs/integrations/langchain.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Arcjet / LangChain Integration"
-description: "How to Redact sensitive information before it is sent to a third-party AI LLM or Chat Model"
+description:
+  "How to Redact sensitive information before it is sent to a third-party AI LLM
+  or Chat Model"
 prev: false
 next: false
 ---
@@ -17,13 +19,13 @@ LLM or Chat Model.
 <WhatIsArcjet />
 
 The Arcjet LangChain integration wraps your
-[LLM](https://js.langchain.com/v0.2/docs/concepts/#llms) and [Chat
-Model](https://js.langchain.com/v0.2/docs/concepts/#chat-models) calls to
+[LLM](https://js.langchain.com/v0.2/docs/concepts/#llms) and
+[Chat Model](https://js.langchain.com/v0.2/docs/concepts/#chat-models) calls to
 perform redaction and un-redaction on sensitive information that is being sent
 to and from third party AI services.
 
-This currently works with the [LangChain JS
-SDK](https://js.langchain.com/v0.2/docs/introduction/).
+This currently works with the
+[LangChain JS SDK](https://js.langchain.com/v0.2/docs/introduction/).
 
 ## Installation
 

--- a/src/content/docs/integrations/nextauth.mdx
+++ b/src/content/docs/integrations/nextauth.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Arcjet / NextAuth integration"
-description: "Integrating NextAuth and Arcjet. Add rate limits to NextAuth login endpoints."
+description:
+  "Integrating NextAuth and Arcjet. Add rate limits to NextAuth login endpoints."
 prev: false
 next: false
 ---
@@ -29,14 +30,14 @@ authenticated user ID to implement user-specific rate limits.
 
 ## Example use case
 
-- Protect your NextAuth route handlers by rate limiting requests and
-  blocking bots.
+- Protect your NextAuth route handlers by rate limiting requests and blocking
+  bots.
 - Limit access to a free API endpoint based on the client IP address.
-- Provide a higher rate limit for authenticated clients based on their
-  NextAuth user ID.
+- Provide a higher rate limit for authenticated clients based on their NextAuth
+  user ID.
 
-See an [example Next.js implementation on
-GitHub](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-14-nextauth-4).
+See an
+[example Next.js implementation on GitHub](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-14-nextauth-4).
 
 ## Protect NextAuth route handlers
 
@@ -76,8 +77,8 @@ within a 60 second window and also prevents bots from making requests.
 
 ## Rate limits using NextAuth user ID
 
-Arcjet rate limits allow [custom
-characteristics](/rate-limiting/configuration#custom-characteristics) to
+Arcjet rate limits allow
+[custom characteristics](/rate-limiting/configuration#custom-characteristics) to
 identify the client and apply the limit. Using NextAuth's
 [`getServerSession()`](https://next-auth.js.org/configuration/nextjs#getserversession)
 helpers you can pass through a user ID.

--- a/src/content/docs/integrations/openai.mdx
+++ b/src/content/docs/integrations/openai.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Protect your OpenAI application with Arcjet"
-description: "Protect your OpenAI chat interface from abuse with Arcjet rate limiting and bot protection."
+description:
+  "Protect your OpenAI chat interface from abuse with Arcjet rate limiting and
+  bot protection."
 prev: false
 next: false
 ---
@@ -28,10 +30,10 @@ developer token budget.
 
 ## How it works
 
-- Arcjet rate limits allow [custom
-  characteristics](/rate-limiting/configuration#custom-characteristics) to
-  identify the client and apply the limit. We provide the user ID to identify the
-  user. This can use any authentication system you have in place, such as
+- Arcjet rate limits allow
+  [custom characteristics](/rate-limiting/configuration#custom-characteristics)
+  to identify the client and apply the limit. We provide the user ID to identify
+  the user. This can use any authentication system you have in place, such as
   [Clerk](/integrations/clerk).
 - Define a rate limit of `2,000` tokens per hour with a maximum of `5,000`
   tokens in the bucket. This allows for a reasonable conversation length without
@@ -43,8 +45,8 @@ developer token budget.
   the user's rate limit.
 
 The example below shows the API route for a Next.js application with a
-`gpt-3.5-turbo` AI chatbot. See the full [example Next.js implementation on
-GitHub](https://github.com/arcjet/arcjet-js/blob/main/examples/nextjs-clerk-rate-limit).
+`gpt-3.5-turbo` AI chatbot. See the full
+[example Next.js implementation on GitHub](https://github.com/arcjet/arcjet-js/blob/main/examples/nextjs-clerk-rate-limit).
 
 <Tabs>
 <TabItem label="TS (App)">
@@ -56,8 +58,8 @@ GitHub](https://github.com/arcjet/arcjet-js/blob/main/examples/nextjs-clerk-rate
 
 The Next.js pages router does not support streaming responses so you should use
 the app router for this example. You can still use the `pages/` directory for
-the rest of your application. See the [Next.js AI docs for
-details](https://sdk.vercel.ai/docs/guides/frameworks/nextjs-pages).
+the rest of your application. See the
+[Next.js AI docs for details](https://sdk.vercel.ai/docs/guides/frameworks/nextjs-pages).
 
 </TabItem>
 </Tabs>

--- a/src/content/docs/ip.mdx
+++ b/src/content/docs/ip.mdx
@@ -23,14 +23,12 @@ specific mechanisms for accessing it—such as the `X-Real-IP` header added or
 overwritten by Vercel. The `@arcjet/ip` library provides a streamlined API over
 these mechanisms based on the current platform.
 
-:::caution[Considerations]
-The IP should not be trusted as it can be spoofed in most cases, especially when
-loaded via the `Headers` object. We apply additional platform guards if a
-platform is supplied in the `options` argument.
+:::caution[Considerations] The IP should not be trusted as it can be spoofed in
+most cases, especially when loaded via the `Headers` object. We apply additional
+platform guards if a platform is supplied in the `options` argument.
 
 If a private/internal address is encountered, it will be skipped. If only those
-are detected, an empty string is returned.
-:::
+are detected, an empty string is returned. :::
 
 ## Install
 
@@ -57,8 +55,8 @@ import IpPlatform from "@/snippets/ip/platform.ts?raw";
 ### Proxy filtering
 
 Most proxies will add themselves in the chain of public IP addresses. Trusted
-proxies may be specified with the `proxies` option, and they will be
-ignored when detecting a public IP.
+proxies may be specified with the `proxies` option, and they will be ignored
+when detecting a public IP.
 
 import IpProxies from "@/snippets/ip/proxies.ts?raw";
 
@@ -79,10 +77,10 @@ Look up an IP address in a Request-like object, such as `Request`, Node's
 
 ## What next?
 
-Arcjet can protect your entire app or individual routes with just
-a few lines of code. Using the main Arcjet SDK you can setup bot protection,
-rate limiting for your API, minimize fraudulent registrations with the
-signup form protection and more.
+Arcjet can protect your entire app or individual routes with just a few lines of
+code. Using the main Arcjet SDK you can setup bot protection, rate limiting for
+your API, minimize fraudulent registrations with the signup form protection and
+more.
 
 <CardGrid>
   <LinkCard

--- a/src/content/docs/nosecone/quick-start.mdx
+++ b/src/content/docs/nosecone/quick-start.mdx
@@ -7,7 +7,9 @@ titleByFramework:
   next-js: "Arcjet Nosecone: security headers for Next.js"
   node-js: "Arcjet Nosecone: security headers for Node.js"
   sveltekit: "Arcjet Nosecone: security headers for SvelteKit"
-description: "How to use the open source Arcjet Nosecone library to set security headers (CSP, HSTS, and others) in your Bun, Deno, Next.js, Node.js, or SvelteKit app."
+description:
+  "How to use the open source Arcjet Nosecone library to set security headers
+  (CSP, HSTS, and others) in your Bun, Deno, Next.js, Node.js, or SvelteKit app."
 prev: false
 next: false
 frameworks:
@@ -105,11 +107,9 @@ See the [reference guide](/nosecone/reference) for full details on each option.
   client:load
 />
 
-:::note
-If you are using Express, NestJS, or Remix we recommend using the excellent
-[Helmet](https://helmetjs.github.io/) library, which informed much of our work
-on Nosecone.
-:::
+:::note If you are using Express, NestJS, or Remix we recommend using the
+excellent [Helmet](https://helmetjs.github.io/) library, which informed much of
+our work on Nosecone. :::
 
 ## Quick start
 
@@ -175,10 +175,10 @@ ensure it continues to work as expected.
 
 ### Explore
 
-Arcjet can protect your entire app or individual routes with just
-a few lines of code. Using the main Arcjet SDK you can setup bot protection,
-rate limiting for your API, minimize fraudulent registrations with the
-signup form protection and more.
+Arcjet can protect your entire app or individual routes with just a few lines of
+code. Using the main Arcjet SDK you can setup bot protection, rate limiting for
+your API, minimize fraudulent registrations with the signup form protection and
+more.
 
 <CardGrid>
   <LinkCard
@@ -197,7 +197,7 @@ signup form protection and more.
 ## Get help
 
 Need help with anything? Email support@arcjet.com to get support from our
-engineering team, [join our Discord](https://arcjet.com/discord), or [open an
-issue on GitHub](https://github.com/arcjet/arcjet-js).
+engineering team, [join our Discord](https://arcjet.com/discord), or
+[open an issue on GitHub](https://github.com/arcjet/arcjet-js).
 
 <Comments />

--- a/src/content/docs/nosecone/reference.mdx
+++ b/src/content/docs/nosecone/reference.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Arcjet Nosecone reference"
-description: "Reference for the Nosecone library showing how to configure security headers (CSP, HSTS, and others) in your Bun, Deno, Next.js, Node.js, or SvelteKit app."
+description:
+  "Reference for the Nosecone library showing how to configure security headers
+  (CSP, HSTS, and others) in your Bun, Deno, Next.js, Node.js, or SvelteKit app."
 ---
 
 import SDKVersionNosecone from "@/components/SDKVersionNosecone.astro";
@@ -77,8 +79,8 @@ import StaticOptOut from "@/snippets/nosecone/reference/next-js/StaticOptOut.mdx
 
 This configuration applies the default Nosecone headers, but allows scripts from
 and connections to Plausible Analytics and YouTube embeds from the YouTube No
-Cookie domain ([privacy enhanced
-mode](https://support.google.com/youtube/answer/171780)).
+Cookie domain
+([privacy enhanced mode](https://support.google.com/youtube/answer/171780)).
 
 It also sets the upgrade insecure requests directive to `true` in production to
 ensure all requests are served with HTTPS.
@@ -194,8 +196,8 @@ If you have multiple middleware functions you will need to chain them together.
 We have written a small utility to help run different middleware for different
 paths.
 
-In [this example
-code](https://github.com/arcjet/arcjet-js/blob/121dc679c91dc6f9a6486fcad3f20013830332aa/examples/nosecone-nextjs-router/middleware.ts),
+In
+[this example code](https://github.com/arcjet/arcjet-js/blob/121dc679c91dc6f9a6486fcad3f20013830332aa/examples/nosecone-nextjs-router/middleware.ts),
 the Nosecone middleware is run on every route path. You can add other middleware
 into the array and add more paths to run different middleware.
 
@@ -237,8 +239,8 @@ yarn add @nosecone/sveltekit
 </div>
 </SelectableContent>
 
-This also provides the `csp(options?: ContentSecurityPolicyConfig)` function
-to translate Nosecone configuration to SvelteKit configuration in
+This also provides the `csp(options?: ContentSecurityPolicyConfig)` function to
+translate Nosecone configuration to SvelteKit configuration in
 `svelte.config.js`, and the `createHook(options?: NoseconeOptions)` function to
 create a SvelteKit hook that runs on every request.
 
@@ -348,12 +350,12 @@ interface NoseconeOptions {
 ### `withVercelToolbar(options: NoseconeOptions): NoseconeOptions`
 
 Nosecone provides the `withVercelToolbar` utility function to augment Nosecone
-options so the [Vercel
-Toolbar](https://vercel.com/docs/workflow-collaboration/vercel-toolbar) is
-allowed by the various headers.
+options so the
+[Vercel Toolbar](https://vercel.com/docs/workflow-collaboration/vercel-toolbar)
+is allowed by the various headers.
 
-This follows the guidelines documented by Vercel under [Using a Content Security
-Policy](https://vercel.com/docs/workflow-collaboration/vercel-toolbar/managing-toolbar#using-a-content-security-policy),
+This follows the guidelines documented by Vercel under
+[Using a Content Security Policy](https://vercel.com/docs/workflow-collaboration/vercel-toolbar/managing-toolbar#using-a-content-security-policy),
 but we recommend conditionally adding this based on `process.env.VERCEL_ENV`:
 
 import WithVercelToolbar from "@/snippets/nosecone/reference/WithVercelToolbar.mdx";
@@ -402,9 +404,8 @@ on your page which helps mitigate many attacks, such as cross-site scripting.
 }
 ```
 
-:::note
-In production environments, we recommend setting `upgradeInsecureRequests: true`
-to ensure all requests are served with HTTPS.
+:::note In production environments, we recommend setting
+`upgradeInsecureRequests: true` to ensure all requests are served with HTTPS.
 :::
 
 The defaults will produce the following header:
@@ -677,10 +678,8 @@ Additional resources:
 
 ### `X-Frame-Options` (legacy)
 
-:::note
-`X-Frame-Options` is superceded by the `frame-ancestors` directive in the
-`Content-Security-Policy` header.
-:::
+:::note `X-Frame-Options` is superceded by the `frame-ancestors` directive in
+the `Content-Security-Policy` header. :::
 
 The **legacy** `X-Frame-Options` header helped mitigate clickjacking attacks in
 older browsers.

--- a/src/content/docs/privacy.mdx
+++ b/src/content/docs/privacy.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Arcjet privacy"
-description: "Details about the data processed by Arcjet. What data does Arcjet collect?"
+description:
+  "Details about the data processed by Arcjet. What data does Arcjet collect?"
 ---
 
 Arcjet is designed to process data primarily within your environment to minimize

--- a/src/content/docs/rate-limiting/algorithms.mdx
+++ b/src/content/docs/rate-limiting/algorithms.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Arcjet rate limiting algorithms"
-description: "Arcjet rate limiting supports fixed window, sliding window, and token bucket algorithms."
+description:
+  "Arcjet rate limiting supports fixed window, sliding window, and token bucket
+  algorithms."
 prev: false
 ---
 
@@ -13,8 +15,8 @@ import Comments from "/src/components/Comments.astro";
 
 Arcjet rate limiting allows you to define rules which limit the number of
 requests a client can make over a period of time. It supports 3 different rate
-limit algorithms: [fixed window](#fixed-window), [sliding
-window](#sliding-window) and [token bucket](#token-bucket).
+limit algorithms: [fixed window](#fixed-window),
+[sliding window](#sliding-window) and [token bucket](#token-bucket).
 
 <WhatIsArcjet />
 

--- a/src/content/docs/rate-limiting/concepts.mdx
+++ b/src/content/docs/rate-limiting/concepts.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Arcjet rate limiting"
-description: "Arcjet rate limiting allows you to define rules which limit the number of requests a client can make over a period of time."
+description:
+  "Arcjet rate limiting allows you to define rules which limit the number of
+  requests a client can make over a period of time."
 prev: false
 ---
 
@@ -26,10 +28,10 @@ It can be used to:
 
 ## Rate limit algorithms
 
-Arcjet supports 3 different rate limit algorithms: [fixed
-window](/rate-limiting/algorithms#fixed-window), [sliding
-window](/rate-limiting/algorithms#sliding-window) and [token
-bucket](/rate-limiting/algorithms#token-bucket).
+Arcjet supports 3 different rate limit algorithms:
+[fixed window](/rate-limiting/algorithms#fixed-window),
+[sliding window](/rate-limiting/algorithms#sliding-window) and
+[token bucket](/rate-limiting/algorithms#token-bucket).
 
 ## Rate limit rules
 

--- a/src/content/docs/rate-limiting/configuration.mdx
+++ b/src/content/docs/rate-limiting/configuration.mdx
@@ -20,26 +20,25 @@ used.
 
 Defines how Arcjet will track the rate limit.
 
-If this is not set then the characteristics set on the root Arcjet object will be used.
+If this is not set then the characteristics set on the root Arcjet object will
+be used.
 
-:::note
-For most use cases it is better to use the [global characteristics set on the root Arcjet object.](/architecture#built-in-characteristics)
-This is because we cache rate limit decisions using a fingerprint that is generated with these characteristics.
-If the characteristics used to compute the fingerprint are different from those used to apply the rate limit
-it can result in cached rate limit decisions being applied to the wrong set of users.
-:::
+:::note For most use cases it is better to use the
+[global characteristics set on the root Arcjet object.](/architecture#built-in-characteristics)
+This is because we cache rate limit decisions using a fingerprint that is
+generated with these characteristics. If the characteristics used to compute the
+fingerprint are different from those used to apply the rate limit it can result
+in cached rate limit decisions being applied to the wrong set of users. :::
 
 ### Built-in characteristics
 
-The built-in options are managed by the SDK and are always available.
-If more than one option is provided, they will be combined.
+The built-in options are managed by the SDK and are always available. If more
+than one option is provided, they will be combined.
 
-:::caution
-If you specify different characteristics and do not include `ip.src`, you may
-inadvertently rate limit everyone. Be sure to include a characteristic which can
-narrowly identify each client. For example, use a header value to limit based on
-a session token or authentication header.
-:::
+:::caution If you specify different characteristics and do not include `ip.src`,
+you may inadvertently rate limit everyone. Be sure to include a characteristic
+which can narrowly identify each client. For example, use a header value to
+limit based on a session token or authentication header. :::
 
 | Option                                        |     Description      |
 | :-------------------------------------------- | :------------------: |
@@ -61,15 +60,14 @@ Custom characteristics are defined with a string key when configuring the rate
 limit rule. The value is then passed as a `string`, `number` or `boolean` when
 calling the `protect` method. You can use any string value for the key.
 
-:::caution
-Avoid passing personal information such as an email address as a custom
-characteristic. The value is hashed on Arcjet's servers, but it's still a best
-practice to avoid sending us sensitive information.
-:::
+:::caution Avoid passing personal information such as an email address as a
+custom characteristic. The value is hashed on Arcjet's servers, but it's still a
+best practice to avoid sending us sensitive information. :::
 
 #### User ID
 
-In this example we create a custom characteristic called `userId`, but you can call it anything you like:
+In this example we create a custom characteristic called `userId`, but you can
+call it anything you like:
 
 <Code code={FixedWindowCustomCharacteristicRule} lang="ts" />
 
@@ -137,8 +135,8 @@ Valid string time units are:
 
 **Algorithms:** `slidingWindow`, `tokenBucket`.
 
-For `slidingWindow`, the time interval for the rate limit. For example, if you set
-the interval to `60` the sliding window will be 60 seconds.
+For `slidingWindow`, the time interval for the rate limit. For example, if you
+set the interval to `60` the sliding window will be 60 seconds.
 
 For `tokenBucket`, the time interval for the refill rate (see below). For
 example, if you set the interval to `60` and the refill rate to `10`, the bucket

--- a/src/content/docs/rate-limiting/quick-start.mdx
+++ b/src/content/docs/rate-limiting/quick-start.mdx
@@ -8,7 +8,9 @@ titleByFramework:
   node-js: "Rate limiting for Node.js"
   remix: "Rate limiting for Remix"
   sveltekit: "Rate limiting for SvelteKit"
-description: "Quick start guide for adding Arcjet rate limiting to your Next.js, NestJS, Node.js, Bun, Remix, or SvelteKit app."
+description:
+  "Quick start guide for adding Arcjet rate limiting to your Next.js, NestJS,
+  Node.js, Bun, Remix, or SvelteKit app."
 frameworks:
   - bun
   - nest-js
@@ -100,7 +102,9 @@ requests a client can make over a period of time.
 
 ## Quick start
 
-This guide will show you how to add a simple rate limit to your <FrameworkName client:load /> app.
+This guide will show you how to add a simple rate limit to your
+
+<FrameworkName client:load /> app.
 
 ### 1. Install Arcjet
 
@@ -133,8 +137,8 @@ instructions to add a site and get a key.
 
 The example below applies a token bucket rate limit rule to a route where we
 identify the user based on their ID e.g. if they are logged in. The bucket is
-configured with a maximum capacity of 10 tokens and refills by 5 tokens every
-10 seconds. Each request consumes 5 tokens.
+configured with a maximum capacity of 10 tokens and refills by 5 tokens every 10
+seconds. Each request consumes 5 tokens.
 
 <SlotByFramework client:load>
   <BunStep3 slot="bun" />
@@ -183,8 +187,8 @@ The requests will also show in the [Arcjet dashboard](https://app.arcjet.com).
 ### Explore
 
 Arcjet can be used with specific rules on individual routes or as general
-protection on your entire application. You can setup bot protection,
-minimize fraudulent registrations with the signup form protection and more.
+protection on your entire application. You can setup bot protection, minimize
+fraudulent registrations with the signup form protection and more.
 
 <CardGrid>
   <LinkCard

--- a/src/content/docs/rate-limiting/reference.mdx
+++ b/src/content/docs/rate-limiting/reference.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Rate limiting reference"
-description: "Reference guide for adding Arcjet rate limiting to your Next.js, NestJS, Node.js, Bun, Remix, or SvelteKit app."
+description:
+  "Reference guide for adding Arcjet rate limiting to your Next.js, NestJS,
+  Node.js, Bun, Remix, or SvelteKit app."
 frameworks:
   - bun
   - nest-js
@@ -169,8 +171,8 @@ requests a client can make over a period of time.
 
 ## Plan availability
 
-Arcjet rate limiting is available on all [pricing
-plans](https://arcjet.com/pricing).
+Arcjet rate limiting is available on all
+[pricing plans](https://arcjet.com/pricing).
 
 | Plan                                                                             | Rate limiting |
 | -------------------------------------------------------------------------------- | ------------- |
@@ -201,9 +203,9 @@ characteristics and algorithm specific options.
 
 Tracks the number of requests made by a client over a fixed time window. Options
 are explained in the [Configuration](/rate-limiting/configuration)
-documentation. See the [fixed window algorithm
-description](/rate-limiting/algorithms#fixed-window) for more details about how
-the algorithm works.
+documentation. See the
+[fixed window algorithm description](/rate-limiting/algorithms#fixed-window) for
+more details about how the algorithm works.
 
 ```ts
 // Options for fixed window rate limit
@@ -237,9 +239,9 @@ type FixedWindowRateLimitOptions = {
 
 Tracks the number of requests made by a client over a sliding window so that the
 window moves with time. Options are explained in the
-[Configuration](/rate-limiting/configuration) documentation. See the [sliding
-window algorithm description](/rate-limiting/algorithms#sliding-window) for more
-details about how the algorithm works.
+[Configuration](/rate-limiting/configuration) documentation. See the
+[sliding window algorithm description](/rate-limiting/algorithms#sliding-window)
+for more details about how the algorithm works.
 
 ```ts
 // Options for sliding window rate limit
@@ -275,9 +277,9 @@ Based on a bucket filled with a specific number of tokens. Each request
 withdraws a token from the bucket and the bucket is refilled at a fixed rate.
 Once the bucket is empty, the client is blocked until the bucket refills.
 Options are explained in the [Configuration](/rate-limiting/configuration)
-documentation. See the [token bucket algorithm
-description](/rate-limiting/algorithms#token-bucket) for more details about how
-the algorithm works.
+documentation. See the
+[token bucket algorithm description](/rate-limiting/algorithms#token-bucket) for
+more details about how the algorithm works.
 
 ```ts
 // Options for token bucket rate limit
@@ -320,11 +322,9 @@ you can specify other
 [characteristics](/rate-limiting/configuration#characteristics) such as a user
 ID or other metadata from your application.
 
-:::caution
-Avoid passing personal information such as an email address as a custom
-characteristic. The value is hashed on Arcjet's servers, but it's still a best
-practice to avoid sending us sensitive information.
-:::
+:::caution Avoid passing personal information such as an email address as a
+custom characteristic. The value is hashed on Arcjet's servers, but it's still a
+best practice to avoid sending us sensitive information. :::
 
 In this example we define a rate limit rule that applies to a specific user ID.
 The custom characteristic is `userId` with the value passed as a prop on the
@@ -342,8 +342,8 @@ The custom characteristic is `userId` with the value passed as a prop on the
 
 To identify users with different characteristics e.g. IP address for anonymous
 users and a user ID for logged in users, you can create a custom fingerprint.
-See the [example in the custom characteristics
-section](/rate-limiting/configuration#ip-address--user-id).
+See the
+[example in the custom characteristics section](/rate-limiting/configuration#ip-address--user-id).
 
 <SlotByFramework client:load>
   <NestJsDecoratorRoutes slot="nest-js" />
@@ -363,8 +363,8 @@ context as passed to the request handler.
   <NestJsGuardDecision slot="nest-js" />
 </SlotByFramework>
 
-This function returns a `Promise` that resolves to an
-`ArcjetDecision` object. This contains the following properties:
+This function returns a `Promise` that resolves to an `ArcjetDecision` object.
+This contains the following properties:
 
 - `id` (`string`) - The unique ID for the request. This can be used to look up
   the request in the Arcjet dashboard. It is prefixed with `req_` for decisions
@@ -373,8 +373,8 @@ This function returns a `Promise` that resolves to an
 - `conclusion` (`ArcjetConclusion`) - The final conclusion based on evaluating
   each of the configured rules. If you wish to accept Arcjet's recommended
   action based on the configured rules then you can use this property.
-- `reason` (`ArcjetReason`) - An object containing more detailed
-  information about the conclusion.
+- `reason` (`ArcjetReason`) - An object containing more detailed information
+  about the conclusion.
 - `results` (`ArcjetRuleResult[]`) - An array of `ArcjetRuleResult` objects
   containing the results of each rule that was executed.
 - `ip` (`ArcjetIpDetails`) - An object containing Arcjet's analysis of the
@@ -430,13 +430,14 @@ Arcjet decision result:
   counted.
 - `reset` (`number`): The remaining amount of seconds in the window.
 
-These can be used to return `RateLimit` HTTP headers ([draft
-RFC](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers-08)) to
-offer the client more detail.
+These can be used to return `RateLimit` HTTP headers
+([draft RFC](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers-08))
+to offer the client more detail.
 
-We provide the [@arcjet/decorate
-package](https://github.com/arcjet/arcjet-js/tree/main/decorate) for decorating
-your responses with appropriate `RateLimit` headers based on a decision.
+We provide the
+[@arcjet/decorate package](https://github.com/arcjet/arcjet-js/tree/main/decorate)
+for decorating your responses with appropriate `RateLimit` headers based on a
+decision.
 
 <SlotByFramework client:load>
   <HeadersBun slot="bun" />
@@ -447,8 +448,8 @@ your responses with appropriate `RateLimit` headers based on a decision.
   <HeadersSvelteKit slot="sveltekit" />
 </SlotByFramework>
 
-This would result in [draft
-RFC](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers-08)
+This would result in
+[draft RFC](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers-08)
 response headers similar to the following:
 
 ```http
@@ -466,11 +467,11 @@ when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
 in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition when processing the rule, Arcjet will return an
-`ERROR` result for that rule and you can check the `message` property on the rule's
-error result for more information.
+`ERROR` result for that rule and you can check the `message` property on the
+rule's error result for more information.
 
-If all other rules that were run returned an `ALLOW` result, then the final Arcjet
-conclusion will be `ERROR`.
+If all other rules that were run returned an `ALLOW` result, then the final
+Arcjet conclusion will be `ERROR`.
 
 <SlotByFramework client:load>
   <ErrorsBun slot="bun" />

--- a/src/content/docs/redact/quick-start.mdx
+++ b/src/content/docs/redact/quick-start.mdx
@@ -34,15 +34,16 @@ npm i @arcjet/redact
 
 Now all you have to do to Redact text is to call the `redact` function. It can
 be configured to redact a number of built-in entity types, or else you can
-provide a custom detect function to redact your own types. The types that we support
-by default are: `email`, `phone-number`, `ip-address`, `credit-card`.
+provide a custom detect function to redact your own types. The types that we
+support by default are: `email`, `phone-number`, `ip-address`, `credit-card`.
 
 <Code code={QuickStartRedact} lang="ts" />
 
 ### 3. Unredact a response
 
-If you want to un-redact some text that contains the replacements from the redact
-function just call `unredact`, it is passed as the value in the return array.
+If you want to un-redact some text that contains the replacements from the
+redact function just call `unredact`, it is passed as the value in the return
+array.
 
 <Code code={QuickStartUnredact} lang="ts" />
 
@@ -56,10 +57,10 @@ function just call `unredact`, it is passed as the value in the return array.
 
 ### Explore
 
-Arcjet can protect your entire app or individual routes with just
-a few lines of code. Using the main Arcjet SDK you can setup bot protection,
-rate limiting for your API, minimize fraudulent registrations with the
-signup form protection and more.
+Arcjet can protect your entire app or individual routes with just a few lines of
+code. Using the main Arcjet SDK you can setup bot protection, rate limiting for
+your API, minimize fraudulent registrations with the signup form protection and
+more.
 
 <CardGrid>
   <LinkCard
@@ -81,7 +82,8 @@ signup form protection and more.
 
 ## Get help
 
-Need help with anything? [Email us](mailto:support@arcjet.com) or [join our
-Discord](https://arcjet.com/discord) to get support from our engineering team.
+Need help with anything? [Email us](mailto:support@arcjet.com) or
+[join our Discord](https://arcjet.com/discord) to get support from our
+engineering team.
 
 <Comments />

--- a/src/content/docs/redact/reference.mdx
+++ b/src/content/docs/redact/reference.mdx
@@ -29,8 +29,8 @@ type RedactOptions = {
 };
 ```
 
-- `entities`: The list of entities that you wish to redact. If undefined then all
-  entities are redacted. Valid values are: `email`, `phone-number`,
+- `entities`: The list of entities that you wish to redact. If undefined then
+  all entities are redacted. Valid values are: `email`, `phone-number`,
   `ip-address`, '`credit-card`, or any string returned from `detect`.
 - `contextWindowSize` - How many tokens to pass to the `detect` function at a
   time. Setting this to a higher value allows for more context to be used when
@@ -77,9 +77,8 @@ requirements for the redacted entities. A common example of this is to use a
 library such as [faker.js](https://fakerjs.dev/) to generate redacted entities
 that look exactly like the real ones.
 
-:::note
-If you are using `unredact()` it is important that each redacted entity is unique. If many
-pieces of sensitive info are replaced by the same string then unredaction won't work correctly.
-:::
+:::note If you are using `unredact()` it is important that each redacted entity
+is unique. If many pieces of sensitive info are replaced by the same string then
+unredaction won't work correctly. :::
 
 <Code code={CustomRedact} lang="ts" />

--- a/src/content/docs/reference/astro.mdx
+++ b/src/content/docs/reference/astro.mdx
@@ -48,9 +48,9 @@ import IPAnalysis from "/src/snippets/reference/shared/IPAnalysis.mdx";
 
 [<SDKVersionAstro/>](https://www.npmjs.com/package/@arcjet/astro)
 
-This is the reference guide for the Arcjet Astro SDK, [available on
-GitHub](https://github.com/arcjet/arcjet-js) and licensed under the Apache 2.0
-license.
+This is the reference guide for the Arcjet Astro SDK,
+[available on GitHub](https://github.com/arcjet/arcjet-js) and licensed under
+the Apache 2.0 license.
 
 <WhatIsArcjet />
 
@@ -70,11 +70,14 @@ Check out the [quick start guide](/get-started?f=astro).
 
 ## Configuration
 
-Arcjet is configured as an integration in your `astro.config.mjs` file. You will need to add your Arcjet API key as an environment variable and configure the rules you want to apply.
+Arcjet is configured as an integration in your `astro.config.mjs` file. You will
+need to add your Arcjet API key as an environment variable and configure the
+rules you want to apply.
 
 ### API Key
 
-First, get your site key from the [Arcjet dashboard](https://app.arcjet.com). Set it as an environment variable called `ARCJET_KEY` in your `.env` file:
+First, get your site key from the [Arcjet dashboard](https://app.arcjet.com).
+Set it as an environment variable called `ARCJET_KEY` in your `.env` file:
 
 ```bash
 ARCJET_KEY=your_site_key_here
@@ -82,7 +85,8 @@ ARCJET_KEY=your_site_key_here
 
 ### Astro Integration
 
-The Arcjet integration is added to your `astro.config.mjs` file. Here's a basic configuration:
+The Arcjet integration is added to your `astro.config.mjs` file. Here's a basic
+configuration:
 
 <Code
   code={removeTSCCommentDirectives(ConfigurationJS)}
@@ -94,7 +98,8 @@ The required fields are:
 
 {/* #TODO(#395): uncomment once these docs are complete */}
 
-- `rules` - The rules to apply to the request. {/* See the various sections of the */}
+- `rules` - The rules to apply to the request.
+  {/* See the various sections of the */}
   {/* docs for how to configure these e.g. [shield](/shield/reference?f=next-js), [rate */}
   {/* limiting](/rate-limiting/reference?f=next-js), [bot */}
   {/* protection](/bot-protection/reference?f=next-js), [email */}
@@ -108,8 +113,8 @@ The optional fields are:
 - `proxies` (`string[]`) - A list of one or more trusted proxies. These
   addresses will be excluded when Arcjet is determining the client IP address.
   This is useful if you are behind a load balancer or proxy that sets the client
-  IP address in a header. See [Load balancers &
-  proxies](#load-balancers--proxies) below for an example.
+  IP address in a header. See
+  [Load balancers & proxies](#load-balancers--proxies) below for an example.
 
 ### Single instance
 
@@ -159,10 +164,8 @@ You can combine rules to create a more complex protection strategy. For example,
 you can combine rate limiting and bot protection rules to protect your API from
 automated clients.
 
-:::note
-When specifying multiple rules, the order of the rules is ignored. Rule
-execution ordering is automatically optimized for performance.
-:::
+:::note When specifying multiple rules, the order of the rules is ignored. Rule
+execution ordering is automatically optimized for performance. :::
 
 <Code
   code={removeTSCCommentDirectives(MultipleRulesJS)}
@@ -200,8 +203,8 @@ through.
 
 The problem with is that the `X-Forwarded-For` header can be spoofed by the
 client, so you should only trust it if you are sure that the load balancer is
-setting it correctly. See [the MDN
-docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
+setting it correctly. See
+[the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
 for more details.
 
 You can configure Arcjet to trust IP addresses in the `X-Forwarded-For` header
@@ -232,10 +235,10 @@ You can also specify CIDR ranges to match multiple IP addresses.
 ## Protect
 
 Arcjet provides a single `protect` function that is used to execute your
-protection rules. This requires a `request` object which is the request
-argument as passed to the Astro request handler. Rules you add to the SDK may
-require additional details, such as the `validateEmail` rule requiring an
-additional `email` prop.
+protection rules. This requires a `request` object which is the request argument
+as passed to the Astro request handler. Rules you add to the SDK may require
+additional details, such as the `validateEmail` rule requiring an additional
+`email` prop.
 
 This function returns a `Promise` that resolves to an `ArcjetDecision` object,
 which provides a high-level conclusion and detailed explanations of the decision
@@ -280,11 +283,9 @@ Arcjet can be used in Astro middleware to protect multiple routes at once. This
 is useful for applying protection rules across your entire application or
 specific route patterns.
 
-:::note
-Some server Adapters, such as Vercel, only run middleware at build time for
-[Static routes](#static-routes). Only call `protect` when
-`context.isPrerendered === false`.
-:::
+:::note Some server Adapters, such as Vercel, only run middleware at build time
+for [Static routes](#static-routes). Only call `protect` when
+`context.isPrerendered === false`. :::
 
 <Tabs>
   <TabItem label="TS">
@@ -306,12 +307,12 @@ Some server Adapters, such as Vercel, only run middleware at build time for
 ### Static routes
 
 Arcjet can't protect Astro's **static routes** (pages pre-rendered at build
-time) because no HTTP request reaches your Astro server when the file is
-served. Arcjet's protections run **per request**, and without the request
-context (IP address, user-agent, headers) there's nothing to evaluate.
+time) because no HTTP request reaches your Astro server when the file is served.
+Arcjet's protections run **per request**, and without the request context (IP
+address, user-agent, headers) there's nothing to evaluate.
 
-To protect a static route, configure the route for **on-demand rendering**.
-That way every visitor triggers a normal request that Arcjet can inspect.
+To protect a static route, configure the route for **on-demand rendering**. That
+way every visitor triggers a normal request that Arcjet can inspect.
 
 This can be achieved by using Astro's `server` mode or using an override on the
 route you want to protect. Read more about how to enable on-demand rendering in
@@ -330,8 +331,8 @@ The `protect` function function returns a `Promise` that resolves to an
   conclusion based on evaluating each of the configured rules. If you wish to
   accept Arcjet's recommended action based on the configured rules then you can
   use this property.
-- `reason` (`ArcjetReason`) - An object containing more detailed
-  information about the conclusion.
+- `reason` (`ArcjetReason`) - An object containing more detailed information
+  about the conclusion.
 - `results` (`ArcjetRuleResult[]`) - An array of `ArcjetRuleResult` objects
   containing the results of each rule that was executed.
 - `ttl` (`uint32`) - The time-to-live for the decision in seconds. This is the
@@ -350,9 +351,9 @@ check the conclusion:
 - `isDenied()` (`bool`) - The request should be denied.
 - `isErrored()` (`bool`) - There was an unrecoverable error.
 
-The conclusion will be the highest-severity finding when evaluating the configured
-rules. `"DENY"` is the highest severity, followed by `"CHALLENGE"`, then `"ERROR"` and
-finally `"ALLOW"` as the lowest severity.
+The conclusion will be the highest-severity finding when evaluating the
+configured rules. `"DENY"` is the highest severity, followed by `"CHALLENGE"`,
+then `"ERROR"` and finally `"ALLOW"` as the lowest severity.
 
 For example, when a bot protection rule returns an error and a validate email
 rule returns a deny, the overall conclusion would be deny. To access the error
@@ -367,8 +368,9 @@ the final decision reason and is based on the configured rules.
 The `ArcjetReason` object has the following methods that can be used to check
 which rule caused the conclusion:
 
-It will always be the highest-priority rule that produced that conclusion,
-to inspect other rules consider iterating over the `results` property on the decision.
+It will always be the highest-priority rule that produced that conclusion, to
+inspect other rules consider iterating over the `results` property on the
+decision.
 
 - `isBot()` (`bool`) - Returns `true` if the bot protection rules have been
   applied and the request was considered to have been made by a bot.
@@ -551,11 +553,11 @@ when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
 in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition when processing the rule, Arcjet will return an
-`ERROR` result for that rule and you can check the `message` property on the rule's
-error result for more information.
+`ERROR` result for that rule and you can check the `message` property on the
+rule's error result for more information.
 
-If all other rules that were run returned an `ALLOW` result, then the final Arcjet
-conclusion will be `ERROR`.
+If all other rules that were run returned an `ALLOW` result, then the final
+Arcjet conclusion will be `ERROR`.
 
 <Tabs>
   <TabItem label="TS">
@@ -624,18 +626,19 @@ Astro SDK will automatically handle this for you.
 
 <NodeVersions />
 
-Arcjet supports the [Node.js versions supported by
-Astro](https://docs.astro.build/en/upgrade-astro/#nodejs-support-and-upgrade-policies).
+Arcjet supports the
+[Node.js versions supported by Astro](https://docs.astro.build/en/upgrade-astro/#nodejs-support-and-upgrade-policies).
 
 ### Astro
 
-Arcjet supports Astro v5.9.3 and above. We follow [Astro's support
-policy](https://docs.astro.build/en/upgrade-astro/#extended-maintenance) and
-provide support for all versions that are actively maintained by the Astro team.
+Arcjet supports Astro v5.9.3 and above. We follow
+[Astro's support policy](https://docs.astro.build/en/upgrade-astro/#extended-maintenance)
+and provide support for all versions that are actively maintained by the Astro
+team.
 
-[Technical support](/support) is provided for the current major
-version of the Arcjet SDK for all users and for the current and previous major
-versions for paid users. We will provide security fixes for the current and
-previous major versions.
+[Technical support](/support) is provided for the current major version of the
+Arcjet SDK for all users and for the current and previous major versions for
+paid users. We will provide security fixes for the current and previous major
+versions.
 
 <Comments />

--- a/src/content/docs/reference/bun.mdx
+++ b/src/content/docs/reference/bun.mdx
@@ -37,9 +37,9 @@ import IPAnalysis from "@/snippets/reference/shared/IPAnalysis.mdx";
 
 [<SDKVersionBun/>](https://www.npmjs.com/package/@arcjet/bun)
 
-This is the reference guide for the Arcjet Bun SDK, [available on
-GitHub](https://github.com/arcjet/arcjet-js) and licensed under the Apache 2.0
-license.
+This is the reference guide for the Arcjet Bun SDK,
+[available on GitHub](https://github.com/arcjet/arcjet-js) and licensed under
+the Apache 2.0 license.
 
 <WhatIsArcjet />
 
@@ -52,13 +52,11 @@ In your project root, run the following command to install the SDK:
 bun add @arcjet/bun
 ```
 
-:::note
-Our `@arcjet/bun` package is built for
-Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
-on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
-(uses `node:http` or a Node.js framework like express) you should instead
-review our [Node.js SDK reference](/reference/nodejs).
-:::
+:::note Our `@arcjet/bun` package is built for Bun's
+[HTTP server](https://bun.sh/docs/api/http). If your application relies on Bun's
+[Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis) (uses
+`node:http` or a Node.js framework like express) you should instead review our
+[Node.js SDK reference](/reference/nodejs). :::
 
 ### Requirements
 
@@ -75,13 +73,13 @@ Create a new `Arcjet` object with your API key and rules.
 The required fields are:
 
 - `key` (`string`) - Your Arcjet site key. This can be found in the SDK
-  Installation section for the site in the [Arcjet
-  Dashboard](https://app.arcjet.com).
+  Installation section for the site in the
+  [Arcjet Dashboard](https://app.arcjet.com).
 - `rules` - The rules to apply to the request. See the various sections of the
-  docs for how to configure these e.g. [shield](/shield/reference?f=bun), [rate
-  limiting](/rate-limiting/reference?f=bun), [bot
-  protection](/bot-protection/reference?f=bun), [email
-  validation](/email-validation/reference?f=bun).
+  docs for how to configure these e.g. [shield](/shield/reference?f=bun),
+  [rate limiting](/rate-limiting/reference?f=bun),
+  [bot protection](/bot-protection/reference?f=bun),
+  [email validation](/email-validation/reference?f=bun).
 
 The optional fields are:
 
@@ -91,8 +89,8 @@ The optional fields are:
 - `proxies` (`string[]`) - A list of one or more trusted proxies. These
   addresses will be excluded when Arcjet is determining the client IP address.
   This is useful if you are behind a load balancer or proxy that sets the client
-  IP address in a header. See [Load balancers &
-  proxies](#load-balancers--proxies) below for an example.
+  IP address in a header. See
+  [Load balancers & proxies](#load-balancers--proxies) below for an example.
 
 <Tabs>
   <TabItem label="TS">
@@ -167,10 +165,8 @@ You can combine rules to create a more complex protection strategy. For example,
 you can combine rate limiting and bot protection rules to protect your API from
 automated clients.
 
-:::note
-When specifying multiple rules, the order of the rules is ignored. Rule
-execution ordering is automatically optimized for performance.
-:::
+:::note When specifying multiple rules, the order of the rules is ignored. Rule
+execution ordering is automatically optimized for performance. :::
 
 <Tabs>
   <TabItem label="TS">
@@ -199,8 +195,8 @@ execution ordering is automatically optimized for performance.
 ### Custom logging
 
 The SDK uses a lightweight logger which mirrors the
-[Pino](https://github.com/pinojs/pino) [structured
-logger](https://github.com/pinojs/pino/blob/8db130eba0439e61c802448d31eb1998cebfbc98/docs/api.md#logger)
+[Pino](https://github.com/pinojs/pino)
+[structured logger](https://github.com/pinojs/pino/blob/8db130eba0439e61c802448d31eb1998cebfbc98/docs/api.md#logger)
 interface. You can use this to customize the logging output.
 
 First, install the required packages:
@@ -232,14 +228,14 @@ through.
 
 The problem with is that the `X-Forwarded-For` header can be spoofed by the
 client, so you should only trust it if you are sure that the load balancer is
-setting it correctly. See [the MDN
-docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
+setting it correctly. See
+[the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
 for more details.
 
 You can configure Arcjet to trust IP addresses in the `X-Forwarded-For` header
 by setting the `proxies` field in the configuration. This should be a list of
-the IP addresses or the CIDR range of your load balancers to be removed, so that the last IP
-address in the list is the real client IP address.
+the IP addresses or the CIDR range of your load balancers to be removed, so that
+the last IP address in the list is the real client IP address.
 
 #### Example
 
@@ -260,10 +256,10 @@ You can also specify CIDR ranges to match multiple IP addresses.
 ## Protect
 
 Arcjet provides a single `protect` function that is used to execute your
-protection rules. This requires a `request` object which is the request
-argument as passed to the Bun fetch method. Rules you add to the SDK may
-require additional details, such as the `validateEmail` rule requiring an
-additional `email` prop.
+protection rules. This requires a `request` object which is the request argument
+as passed to the Bun fetch method. Rules you add to the SDK may require
+additional details, such as the `validateEmail` rule requiring an additional
+`email` prop.
 
 This function returns a `Promise` that resolves to an `ArcjetDecision` object,
 which provides a high-level conclusion and detailed explanations of the decision
@@ -280,14 +276,16 @@ made by Arcjet.
 
 ### `aj.handler()`
 
-Arcjet uses client [IP addresses for fingerprinting](/architecture#ip-address-detection),
-but Bun doesn't provide the IP address in the request object. By wrapping the `fetch()`
-handler in `aj.handler()`, the Arcjet SDK will be able to perform some preprocessing on the
-request to include the IP address.
+Arcjet uses client
+[IP addresses for fingerprinting](/architecture#ip-address-detection), but Bun
+doesn't provide the IP address in the request object. By wrapping the `fetch()`
+handler in `aj.handler()`, the Arcjet SDK will be able to perform some
+preprocessing on the request to include the IP address.
 
-You don't need to use `aj.handler()` if you have another way of adding a proper IP
-address to the request object, or if there is an alternative way for the Arcjet SDK
-to detect the IP address, such as the `Fly-Client-IP` header on Fly.io.
+You don't need to use `aj.handler()` if you have another way of adding a proper
+IP address to the request object, or if there is an alternative way for the
+Arcjet SDK to detect the IP address, such as the `Fly-Client-IP` header on
+Fly.io.
 
 ## Decision
 
@@ -302,8 +300,8 @@ The `protect` function function returns a `Promise` that resolves to an
   conclusion based on evaluating each of the configured rules. If you wish to
   accept Arcjet's recommended action based on the configured rules then you can
   use this property.
-- `reason` (`ArcjetReason`) - An object containing more detailed
-  information about the conclusion.
+- `reason` (`ArcjetReason`) - An object containing more detailed information
+  about the conclusion.
 - `results` (`ArcjetRuleResult[]`) - An array of `ArcjetRuleResult` objects
   containing the results of each rule that was executed.
 - `ttl` (`uint32`) - The time-to-live for the decision in seconds. This is the
@@ -322,9 +320,9 @@ check the conclusion:
 - `isDenied()` (`bool`) - The request should be denied.
 - `isErrored()` (`bool`) - There was an unrecoverable error.
 
-The conclusion will be the highest-severity finding when evaluating the configured
-rules. `"DENY"` is the highest severity, followed by `"CHALLENGE"`, then `"ERROR"` and
-finally `"ALLOW"` as the lowest severity.
+The conclusion will be the highest-severity finding when evaluating the
+configured rules. `"DENY"` is the highest severity, followed by `"CHALLENGE"`,
+then `"ERROR"` and finally `"ALLOW"` as the lowest severity.
 
 For example, when a bot protection rule returns an error and a validate email
 rule returns a deny, the overall conclusion would be deny. To access the error
@@ -336,8 +334,9 @@ The `reason` property of the `ArcjetDecision` object contains an `ArcjetReason`
 object which provides more detailed information about the conclusion. This is
 the final decision reason and is based on the configured rules.
 
-It will always be the highest-priority rule that produced that conclusion,
-to inspect other rules consider iterating over the `results` property on the decision.
+It will always be the highest-priority rule that produced that conclusion, to
+inspect other rules consider iterating over the `results` property on the
+decision.
 
 The `ArcjetReason` object has the following methods that can be used to check
 which rule caused the conclusion:
@@ -479,11 +478,11 @@ when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
 in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition when processing the rule, Arcjet will return an
-`ERROR` result for that rule and you can check the `message` property on the rule's
-error result for more information.
+`ERROR` result for that rule and you can check the `message` property on the
+rule's error result for more information.
 
-If all other rules that were run returned an `ALLOW` result, then the final Arcjet
-conclusion will be `ERROR`.
+If all other rules that were run returned an `ALLOW` result, then the final
+Arcjet conclusion will be `ERROR`.
 
 <Tabs>
   <TabItem label="TS">
@@ -553,8 +552,8 @@ will automatically handle this for you.
 
 ### Bun
 
-As Bun is under active development, Arcjet aims to support [Bun
-releases](https://github.com/oven-sh/bun/releases) since v1.1.27.
+As Bun is under active development, Arcjet aims to support
+[Bun releases](https://github.com/oven-sh/bun/releases) since v1.1.27.
 
 When a Bun version goes end of life, we will bump the major version of the
 Arcjet SDK. [Technical support](/support) is provided for the current major

--- a/src/content/docs/reference/nestjs.mdx
+++ b/src/content/docs/reference/nestjs.mdx
@@ -20,9 +20,9 @@ import IPAnalysis from "/src/snippets/reference/shared/IPAnalysis.mdx";
 
 [<SDKVersionNestjs />](https://www.npmjs.com/package/@arcjet/nest)
 
-This is the reference guide for the Arcjet NestJS SDK, [available on
-GitHub](https://github.com/arcjet/arcjet-js) and licensed under the Apache 2.0
-license.
+This is the reference guide for the Arcjet NestJS SDK,
+[available on GitHub](https://github.com/arcjet/arcjet-js) and licensed under
+the Apache 2.0 license.
 
 <WhatIsArcjet />
 
@@ -60,20 +60,21 @@ Check out the [quick start guide](/get-started?f=nest-js).
 ## Configuration
 
 Create a new root `ArcjetModule.forRoot` object with your API key and any
-default rules you want to apply to every route. This is usually in the `app.module.ts` file.
+default rules you want to apply to every route. This is usually in the
+`app.module.ts` file.
 
 The required fields are:
 
 - `key` (`string`) - Your Arcjet site key. This can be found in the SDK
-  Installation section for the site in the [Arcjet
-  Dashboard](https://app.arcjet.com).
+  Installation section for the site in the
+  [Arcjet Dashboard](https://app.arcjet.com).
 - `rules` - The rules to apply to the request. This can be empty in the root
   object so you can set rules within each controller. See the various sections
   of the docs for how to configure these e.g.
-  [shield](/shield/reference?f=nest-js), [rate
-  limiting](/rate-limiting/reference?f=nest-js), [bot
-  protection](/bot-protection/reference?f=nest-js), [email
-  validation](/email-validation/reference?f=nest-js).
+  [shield](/shield/reference?f=nest-js),
+  [rate limiting](/rate-limiting/reference?f=nest-js),
+  [bot protection](/bot-protection/reference?f=nest-js),
+  [email validation](/email-validation/reference?f=nest-js).
 
 The optional fields are:
 
@@ -83,8 +84,8 @@ The optional fields are:
 - `proxies` (`string[]`) - A list of one or more trusted proxies. These
   addresses will be excluded when Arcjet is determining the client IP address.
   This is useful if you are behind a load balancer or proxy that sets the client
-  IP address in a header. See [Load balancers &
-  proxies](#load-balancers--proxies) below for an example.
+  IP address in a header. See
+  [Load balancers & proxies](#load-balancers--proxies) below for an example.
 
 <Code code={ConfigurationTS} lang="ts" title="src/app.module.ts" />
 
@@ -136,8 +137,8 @@ The following environment variables can be used to configure the SDK at runtime:
 
 ### Custom logging
 
-The Arcjet SDK can be integrated into the [NestJS
-logger](https://docs.nestjs.com/techniques/logger). You should define an
+The Arcjet SDK can be integrated into the
+[NestJS logger](https://docs.nestjs.com/techniques/logger). You should define an
 interface to extend the built-in logger and then use this within your
 controllers.
 
@@ -154,14 +155,14 @@ through.
 
 The problem with is that the `X-Forwarded-For` header can be spoofed by the
 client, so you should only trust it if you are sure that the load balancer is
-setting it correctly. See [the MDN
-docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
+setting it correctly. See
+[the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
 for more details.
 
 You can configure Arcjet to trust IP addresses in the `X-Forwarded-For` header
 by setting the `proxies` field in the configuration. This should be a list of
-the IP addresses or the CIDR range of your load balancers to be removed, so
-that the last IP address in the list is the real client IP address.
+the IP addresses or the CIDR range of your load balancers to be removed, so that
+the last IP address in the list is the real client IP address.
 
 #### Example
 
@@ -207,8 +208,8 @@ properties:
   conclusion based on evaluating each of the configured rules. If you wish to
   accept Arcjet's recommended action based on the configured rules then you can
   use this property.
-- `reason` (`ArcjetReason`) - An object containing more detailed
-  information about the conclusion.
+- `reason` (`ArcjetReason`) - An object containing more detailed information
+  about the conclusion.
 - `results` (`ArcjetRuleResult[]`) - An array of `ArcjetRuleResult` objects
   containing the results of each rule that was executed.
 - `ttl` (`uint32`) - The time-to-live for the decision in seconds. This is the
@@ -228,9 +229,9 @@ check the conclusion:
 - `isDenied()` (`bool`) - The request should be denied.
 - `isErrored()` (`bool`) - There was an unrecoverable error.
 
-The conclusion will be the highest-severity finding when evaluating the configured
-rules. `"DENY"` is the highest severity, followed by `"CHALLENGE"`, then `"ERROR"` and
-finally `"ALLOW"` as the lowest severity.
+The conclusion will be the highest-severity finding when evaluating the
+configured rules. `"DENY"` is the highest severity, followed by `"CHALLENGE"`,
+then `"ERROR"` and finally `"ALLOW"` as the lowest severity.
 
 For example, when a bot protection rule returns an error and a validate email
 rule returns a deny, the overall conclusion would be deny. To access the error
@@ -242,8 +243,9 @@ The `reason` property of the `ArcjetDecision` object contains an `ArcjetReason`
 object which provides more detailed information about the conclusion. This is
 the final decision reason and is based on the configured rules.
 
-It will always be the highest-priority rule that produced that conclusion,
-to inspect other rules consider iterating over the `results` property on the decision.
+It will always be the highest-priority rule that produced that conclusion, to
+inspect other rules consider iterating over the `results` property on the
+decision.
 
 The `ArcjetReason` object has the following methods that can be used to check
 which rule caused the conclusion:
@@ -342,8 +344,8 @@ window: number;
 reset: number;
 ```
 
-See the [rate limiting documentation](/rate-limiting/reference?f=node-js) for more
-information about these properties.
+See the [rate limiting documentation](/rate-limiting/reference?f=node-js) for
+more information about these properties.
 
 ##### Email validation & verification
 
@@ -359,8 +361,8 @@ An `ArcjetEmailType` is one of the following strings:
 "DISPOSABLE" | "FREE" | "NO_MX_RECORDS" | "NO_GRAVATAR" | "INVALID";
 ```
 
-See the [email validation documentation](/email-validation/reference?f=node-js) for more
-information about these properties.
+See the [email validation documentation](/email-validation/reference?f=node-js)
+for more information about these properties.
 
 ### IP analysis
 
@@ -396,11 +398,11 @@ when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
 in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition when processing the rule, Arcjet will return an
-`ERROR` result for that rule and you can check the `message` property on the rule's
-error result for more information.
+`ERROR` result for that rule and you can check the `message` property on the
+rule's error result for more information.
 
-If all other rules that were run returned an `ALLOW` result, then the final Arcjet
-conclusion will be `ERROR`.
+If all other rules that were run returned an `ALLOW` result, then the final
+Arcjet conclusion will be `ERROR`.
 
 <Tabs>
   <TabItem label="TS">

--- a/src/content/docs/reference/nextjs.mdx
+++ b/src/content/docs/reference/nextjs.mdx
@@ -57,9 +57,9 @@ import IPAnalysis from "/src/snippets/reference/shared/IPAnalysis.mdx";
 
 [<SDKVersionNextjs/>](https://www.npmjs.com/package/@arcjet/next)
 
-This is the reference guide for the Arcjet Next.js SDK, [available on
-GitHub](https://github.com/arcjet/arcjet-js) and licensed under the Apache 2.0
-license.
+This is the reference guide for the Arcjet Next.js SDK,
+[available on GitHub](https://github.com/arcjet/arcjet-js) and licensed under
+the Apache 2.0 license.
 
 <WhatIsArcjet />
 
@@ -102,13 +102,13 @@ of the request handler.
 The required fields are:
 
 - `key` (`string`) - Your Arcjet site key. This can be found in the SDK
-  Installation section for the site in the [Arcjet
-  Dashboard](https://app.arcjet.com).
+  Installation section for the site in the
+  [Arcjet Dashboard](https://app.arcjet.com).
 - `rules` - The rules to apply to the request. See the various sections of the
-  docs for how to configure these e.g. [shield](/shield/reference?f=next-js), [rate
-  limiting](/rate-limiting/reference?f=next-js), [bot
-  protection](/bot-protection/reference?f=next-js), [email
-  validation](/email-validation/reference?f=next-js).
+  docs for how to configure these e.g. [shield](/shield/reference?f=next-js),
+  [rate limiting](/rate-limiting/reference?f=next-js),
+  [bot protection](/bot-protection/reference?f=next-js),
+  [email validation](/email-validation/reference?f=next-js).
 
 The optional fields are:
 
@@ -118,8 +118,8 @@ The optional fields are:
 - `proxies` (`string[]`) - A list of one or more trusted proxies. These
   addresses will be excluded when Arcjet is determining the client IP address.
   This is useful if you are behind a load balancer or proxy that sets the client
-  IP address in a header. See [Load balancers &
-  proxies](#load-balancers--proxies) below for an example.
+  IP address in a header. See
+  [Load balancers & proxies](#load-balancers--proxies) below for an example.
 
 <Tabs>
   <TabItem label="TS">
@@ -137,9 +137,9 @@ throughout your application. This is because the SDK caches decisions and
 configuration to improve performance.
 
 The pattern we use is to create a utility file that exports the `Arcjet` object
-and then import it where you need it. See [our example Next.js
-app](https://github.com/arcjet/example-nextjs/blob/main/lib/arcjet.ts) for how
-this is done.
+and then import it where you need it. See
+[our example Next.js app](https://github.com/arcjet/example-nextjs/blob/main/lib/arcjet.ts)
+for how this is done.
 
 ### Rule modes
 
@@ -176,10 +176,8 @@ You can combine rules to create a more complex protection strategy. For example,
 you can combine rate limiting and bot protection rules to protect your API from
 automated clients.
 
-:::note
-When specifying multiple rules, the order of the rules is ignored. Rule
-execution ordering is automatically optimized for performance.
-:::
+:::note When specifying multiple rules, the order of the rules is ignored. Rule
+execution ordering is automatically optimized for performance. :::
 
 <Tabs>
   <TabItem label="TS">
@@ -210,8 +208,8 @@ The following environment variables can be used to configure the SDK at runtime:
 ### Custom logging
 
 The SDK uses a lightweight logger which mirrors the
-[Pino](https://github.com/pinojs/pino) [structured
-logger](https://github.com/pinojs/pino/blob/8db130eba0439e61c802448d31eb1998cebfbc98/docs/api.md#logger)
+[Pino](https://github.com/pinojs/pino)
+[structured logger](https://github.com/pinojs/pino/blob/8db130eba0439e61c802448d31eb1998cebfbc98/docs/api.md#logger)
 interface. You can use this to customize the logging output.
 
 First, install the required packages:
@@ -260,8 +258,8 @@ through.
 
 The problem with is that the `X-Forwarded-For` header can be spoofed by the
 client, so you should only trust it if you are sure that the load balancer is
-setting it correctly. See [the MDN
-docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
+setting it correctly. See
+[the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
 for more details.
 
 You can configure Arcjet to trust IP addresses in the `X-Forwarded-For` header
@@ -288,10 +286,10 @@ You can also specify CIDR ranges to match multiple IP addresses.
 ## Protect
 
 Arcjet provides a single `protect` function that is used to execute your
-protection rules. This requires a `request` object which is the request
-argument as passed to the Next.js request handler. Rules you add to the SDK may
-require additional details, such as the `validateEmail` rule requiring an
-additional `email` prop.
+protection rules. This requires a `request` object which is the request argument
+as passed to the Next.js request handler. Rules you add to the SDK may require
+additional details, such as the `validateEmail` rule requiring an additional
+`email` prop.
 
 This function returns a `Promise` that resolves to an `ArcjetDecision` object,
 which provides a high-level conclusion and detailed explanations of the decision
@@ -330,8 +328,8 @@ For example:
 
 #### Client component example
 
-In this example the server action is [passed as a prop to a client
-component](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations#client-components).
+In this example the server action is
+[passed as a prop to a client component](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations#client-components).
 
 <Code code={ServerActionProp} title="app/actions.ts" lang="ts" />
 
@@ -359,9 +357,8 @@ export default function Home() {
 
 #### Form example
 
-In this example the server action is handling a form submission, based on [the
-Next.js example form
-handler](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations#forms).
+In this example the server action is handling a form submission, based on
+[the Next.js example form handler](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations#forms).
 
 These examples will `throw` when there is an error
 ([docs](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations#error-handling)),
@@ -385,8 +382,8 @@ The `protect` function function returns a `Promise` that resolves to an
   conclusion based on evaluating each of the configured rules. If you wish to
   accept Arcjet's recommended action based on the configured rules then you can
   use this property.
-- `reason` (`ArcjetReason`) - An object containing more detailed
-  information about the conclusion.
+- `reason` (`ArcjetReason`) - An object containing more detailed information
+  about the conclusion.
 - `results` (`ArcjetRuleResult[]`) - An array of `ArcjetRuleResult` objects
   containing the results of each rule that was executed.
 - `ttl` (`uint32`) - The time-to-live for the decision in seconds. This is the
@@ -405,9 +402,9 @@ check the conclusion:
 - `isDenied()` (`bool`) - The request should be denied.
 - `isErrored()` (`bool`) - There was an unrecoverable error.
 
-The conclusion will be the highest-severity finding when evaluating the configured
-rules. `"DENY"` is the highest severity, followed by `"CHALLENGE"`, then `"ERROR"` and
-finally `"ALLOW"` as the lowest severity.
+The conclusion will be the highest-severity finding when evaluating the
+configured rules. `"DENY"` is the highest severity, followed by `"CHALLENGE"`,
+then `"ERROR"` and finally `"ALLOW"` as the lowest severity.
 
 For example, when a bot protection rule returns an error and a validate email
 rule returns a deny, the overall conclusion would be deny. To access the error
@@ -422,8 +419,9 @@ the final decision reason and is based on the configured rules.
 The `ArcjetReason` object has the following methods that can be used to check
 which rule caused the conclusion:
 
-It will always be the highest-priority rule that produced that conclusion,
-to inspect other rules consider iterating over the `results` property on the decision.
+It will always be the highest-priority rule that produced that conclusion, to
+inspect other rules consider iterating over the `results` property on the
+decision.
 
 - `isBot()` (`bool`) - Returns `true` if the bot protection rules have been
   applied and the request was considered to have been made by a bot.
@@ -536,8 +534,8 @@ window: number;
 reset: number;
 ```
 
-See the [rate limiting documentation](/rate-limiting/reference?f=next-js) for more
-information about these properties.
+See the [rate limiting documentation](/rate-limiting/reference?f=next-js) for
+more information about these properties.
 
 ##### Email validation & verification
 
@@ -553,8 +551,8 @@ An `ArcjetEmailType` is one of the following strings:
 "DISPOSABLE" | "FREE" | "NO_MX_RECORDS" | "NO_GRAVATAR" | "INVALID";
 ```
 
-See the [email validation documentation](/email-validation/reference?f=next-js) for
-more information about these properties.
+See the [email validation documentation](/email-validation/reference?f=next-js)
+for more information about these properties.
 
 ### IP analysis
 
@@ -603,11 +601,11 @@ when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
 in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition when processing the rule, Arcjet will return an
-`ERROR` result for that rule and you can check the `message` property on the rule's
-error result for more information.
+`ERROR` result for that rule and you can check the `message` property on the
+rule's error result for more information.
 
-If all other rules that were run returned an `ALLOW` result, then the final Arcjet
-conclusion will be `ERROR`.
+If all other rules that were run returned an `ALLOW` result, then the final
+Arcjet conclusion will be `ERROR`.
 
 <Tabs>
   <TabItem label="TS (App)">
@@ -740,19 +738,18 @@ Next.js SDK will automatically handle this for you, including when using the
 
 ### Next.js
 
-Arcjet supports the [active and maintenance LTS versions of
-Next.js](https://nextjs.org/support-policy) for both the app router and pages
-router. When a new major version of Next.js is released, we will bump the major
-version of the Arcjet SDK.
+Arcjet supports the
+[active and maintenance LTS versions of Next.js](https://nextjs.org/support-policy)
+for both the app router and pages router. When a new major version of Next.js is
+released, we will bump the major version of the Arcjet SDK.
 
-Maintenance LTS: Next.js 14.x
-Active LTS: Next.js 15.x
+Maintenance LTS: Next.js 14.x Active LTS: Next.js 15.x
 
 The pages router will be supported for as long as Next.js supports it.
 
-[Technical support](/support) is provided for the current major
-version of the Arcjet SDK for all users and for the current and previous major
-versions for paid users. We will provide security fixes for the current and
-previous major versions.
+[Technical support](/support) is provided for the current major version of the
+Arcjet SDK for all users and for the current and previous major versions for
+paid users. We will provide security fixes for the current and previous major
+versions.
 
 <Comments />

--- a/src/content/docs/reference/nodejs.mdx
+++ b/src/content/docs/reference/nodejs.mdx
@@ -32,9 +32,9 @@ import IPAnalysis from "@/snippets/reference/shared/IPAnalysis.mdx";
 
 [<SDKVersionNodejs />](https://www.npmjs.com/package/@arcjet/node)
 
-This is the reference guide for the Arcjet Node.js SDK, [available on
-GitHub](https://github.com/arcjet/arcjet-js) and licensed under the Apache 2.0
-license.
+This is the reference guide for the Arcjet Node.js SDK,
+[available on GitHub](https://github.com/arcjet/arcjet-js) and licensed under
+the Apache 2.0 license.
 
 <WhatIsArcjet />
 
@@ -77,13 +77,13 @@ of the request handler.
 The required fields are:
 
 - `key` (`string`) - Your Arcjet site key. This can be found in the SDK
-  Installation section for the site in the [Arcjet
-  Dashboard](https://app.arcjet.com).
+  Installation section for the site in the
+  [Arcjet Dashboard](https://app.arcjet.com).
 - `rules` - The rules to apply to the request. See the various sections of the
-  docs for how to configure these e.g. [shield](/shield/reference?f=node-js), [rate
-  limiting](/rate-limiting/reference?f=node-js), [bot
-  protection](/bot-protection/reference?f=node-js), [email
-  validation](/email-validation/reference?f=node-js).
+  docs for how to configure these e.g. [shield](/shield/reference?f=node-js),
+  [rate limiting](/rate-limiting/reference?f=node-js),
+  [bot protection](/bot-protection/reference?f=node-js),
+  [email validation](/email-validation/reference?f=node-js).
 
 The optional fields are:
 
@@ -93,8 +93,8 @@ The optional fields are:
 - `proxies` (`string[]`) - A list of one or more trusted proxies. These
   addresses will be excluded when Arcjet is determining the client IP address.
   This is useful if you are behind a load balancer or proxy that sets the client
-  IP address in a header. See [Load balancers &
-  proxies](#load-balancers--proxies) below for an example.
+  IP address in a header. See
+  [Load balancers & proxies](#load-balancers--proxies) below for an example.
 
 <Tabs>
   <TabItem label="TS">
@@ -140,10 +140,8 @@ You can combine rules to create a more complex protection strategy. For example,
 you can combine rate limiting and bot protection rules to protect your API from
 automated clients.
 
-:::note
-When specifying multiple rules, the order of the rules is ignored. Rule
-execution ordering is automatically optimized for performance.
-:::
+:::note When specifying multiple rules, the order of the rules is ignored. Rule
+execution ordering is automatically optimized for performance. :::
 
 <Tabs>
   <TabItem label="TS">
@@ -174,8 +172,8 @@ The following environment variables can be used to configure the SDK at runtime:
 ### Custom logging
 
 The SDK uses a lightweight logger which mirrors the
-[Pino](https://github.com/pinojs/pino) [structured
-logger](https://github.com/pinojs/pino/blob/8db130eba0439e61c802448d31eb1998cebfbc98/docs/api.md#logger)
+[Pino](https://github.com/pinojs/pino)
+[structured logger](https://github.com/pinojs/pino/blob/8db130eba0439e61c802448d31eb1998cebfbc98/docs/api.md#logger)
 interface. You can use this to customize the logging output.
 
 First, install the required packages:
@@ -207,8 +205,8 @@ through.
 
 The problem with is that the `X-Forwarded-For` header can be spoofed by the
 client, so you should only trust it if you are sure that the load balancer is
-setting it correctly. See [the MDN
-docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
+setting it correctly. See
+[the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
 for more details.
 
 You can configure Arcjet to trust IP addresses in the `X-Forwarded-For` header
@@ -265,8 +263,8 @@ The `protect` function function returns a `Promise` that resolves to an
   conclusion based on evaluating each of the configured rules. If you wish to
   accept Arcjet's recommended action based on the configured rules then you can
   use this property.
-- `reason` (`ArcjetReason`) - An object containing more detailed
-  information about the conclusion.
+- `reason` (`ArcjetReason`) - An object containing more detailed information
+  about the conclusion.
 - `results` (`ArcjetRuleResult[]`) - An array of `ArcjetRuleResult` objects
   containing the results of each rule that was executed.
 - `ttl` (`uint32`) - The time-to-live for the decision in seconds. This is the
@@ -286,9 +284,9 @@ check the conclusion:
 - `isDenied()` (`bool`) - The request should be denied.
 - `isErrored()` (`bool`) - There was an unrecoverable error.
 
-The conclusion will be the highest-severity finding when evaluating the configured
-rules. `"DENY"` is the highest severity, followed by `"CHALLENGE"`, then `"ERROR"` and
-finally `"ALLOW"` as the lowest severity.
+The conclusion will be the highest-severity finding when evaluating the
+configured rules. `"DENY"` is the highest severity, followed by `"CHALLENGE"`,
+then `"ERROR"` and finally `"ALLOW"` as the lowest severity.
 
 For example, when a bot protection rule returns an error and a validate email
 rule returns a deny, the overall conclusion would be deny. To access the error
@@ -300,8 +298,9 @@ The `reason` property of the `ArcjetDecision` object contains an `ArcjetReason`
 object which provides more detailed information about the conclusion. This is
 the final decision reason and is based on the configured rules.
 
-It will always be the highest-priority rule that produced that conclusion,
-to inspect other rules consider iterating over the `results` property on the decision.
+It will always be the highest-priority rule that produced that conclusion, to
+inspect other rules consider iterating over the `results` property on the
+decision.
 
 The `ArcjetReason` object has the following methods that can be used to check
 which rule caused the conclusion:
@@ -400,8 +399,8 @@ window: number;
 reset: number;
 ```
 
-See the [rate limiting documentation](/rate-limiting/reference?f=node-js) for more
-information about these properties.
+See the [rate limiting documentation](/rate-limiting/reference?f=node-js) for
+more information about these properties.
 
 ##### Email validation & verification
 
@@ -417,8 +416,8 @@ An `ArcjetEmailType` is one of the following strings:
 "DISPOSABLE" | "FREE" | "NO_MX_RECORDS" | "NO_GRAVATAR" | "INVALID";
 ```
 
-See the [email validation documentation](/email-validation/reference?f=node-js) for more
-information about these properties.
+See the [email validation documentation](/email-validation/reference?f=node-js)
+for more information about these properties.
 
 ### IP analysis
 
@@ -461,11 +460,11 @@ when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
 in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition when processing the rule, Arcjet will return an
-`ERROR` result for that rule and you can check the `message` property on the rule's
-error result for more information.
+`ERROR` result for that rule and you can check the `message` property on the
+rule's error result for more information.
 
-If all other rules that were run returned an `ALLOW` result, then the final Arcjet
-conclusion will be `ERROR`.
+If all other rules that were run returned an `ALLOW` result, then the final
+Arcjet conclusion will be `ERROR`.
 
 <Tabs>
   <TabItem label="TS">

--- a/src/content/docs/reference/remix.mdx
+++ b/src/content/docs/reference/remix.mdx
@@ -32,9 +32,9 @@ import IPAnalysis from "@/snippets/reference/shared/IPAnalysis.mdx";
 
 [<SDKVersionRemix />](https://www.npmjs.com/package/@arcjet/remix)
 
-This is the reference guide for the Arcjet Remix SDK, [available on
-GitHub](https://github.com/arcjet/arcjet-js) and licensed under the Apache 2.0
-license.
+This is the reference guide for the Arcjet Remix SDK,
+[available on GitHub](https://github.com/arcjet/arcjet-js) and licensed under
+the Apache 2.0 license.
 
 <WhatIsArcjet />
 
@@ -77,13 +77,13 @@ of the request handler.
 The required fields are:
 
 - `key` (`string`) - Your Arcjet site key. This can be found in the SDK
-  Installation section for the site in the [Arcjet
-  Dashboard](https://app.arcjet.com).
+  Installation section for the site in the
+  [Arcjet Dashboard](https://app.arcjet.com).
 - `rules` - The rules to apply to the request. See the various sections of the
   docs for how to configure these e.g. [shield](/shield/reference?f=remix),
-  [rate limiting](/rate-limiting/reference?f=remix), [bot
-  protection](/bot-protection/reference?f=remix), [email
-  validation](/email-validation/reference?f=remix).
+  [rate limiting](/rate-limiting/reference?f=remix),
+  [bot protection](/bot-protection/reference?f=remix),
+  [email validation](/email-validation/reference?f=remix).
 
 The optional fields are:
 
@@ -93,8 +93,8 @@ The optional fields are:
 - `proxies` (`string[]`) - A list of one or more trusted proxies. These
   addresses will be excluded when Arcjet is determining the client IP address.
   This is useful if you are behind a load balancer or proxy that sets the client
-  IP address in a header. See [Load balancers &
-  proxies](#load-balancers--proxies) below for an example.
+  IP address in a header. See
+  [Load balancers & proxies](#load-balancers--proxies) below for an example.
 
 <Tabs>
   <TabItem label="TS">
@@ -140,10 +140,8 @@ You can combine rules to create a more complex protection strategy. For example,
 you can combine rate limiting and bot protection rules to protect your API from
 automated clients.
 
-:::note
-When specifying multiple rules, the order of the rules is ignored. Rule
-execution ordering is automatically optimized for performance.
-:::
+:::note When specifying multiple rules, the order of the rules is ignored. Rule
+execution ordering is automatically optimized for performance. :::
 
 <Tabs>
   <TabItem label="TS">
@@ -174,8 +172,8 @@ The following environment variables can be used to configure the SDK at runtime:
 ### Custom logging
 
 The SDK uses a lightweight logger which mirrors the
-[Pino](https://github.com/pinojs/pino) [structured
-logger](https://github.com/pinojs/pino/blob/8db130eba0439e61c802448d31eb1998cebfbc98/docs/api.md#logger)
+[Pino](https://github.com/pinojs/pino)
+[structured logger](https://github.com/pinojs/pino/blob/8db130eba0439e61c802448d31eb1998cebfbc98/docs/api.md#logger)
 interface. You can use this to customize the logging output.
 
 First, install the required packages:
@@ -207,8 +205,8 @@ through.
 
 The problem with is that the `X-Forwarded-For` header can be spoofed by the
 client, so you should only trust it if you are sure that the load balancer is
-setting it correctly. See [the MDN
-docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
+setting it correctly. See
+[the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
 for more details.
 
 You can configure Arcjet to trust IP addresses in the `X-Forwarded-For` header
@@ -265,8 +263,8 @@ The `protect` function function returns a `Promise` that resolves to an
   conclusion based on evaluating each of the configured rules. If you wish to
   accept Arcjet's recommended action based on the configured rules then you can
   use this property.
-- `reason` (`ArcjetReason`) - An object containing more detailed
-  information about the conclusion.
+- `reason` (`ArcjetReason`) - An object containing more detailed information
+  about the conclusion.
 - `results` (`ArcjetRuleResult[]`) - An array of `ArcjetRuleResult` objects
   containing the results of each rule that was executed.
 - `ttl` (`uint32`) - The time-to-live for the decision in seconds. This is the
@@ -286,9 +284,9 @@ check the conclusion:
 - `isDenied()` (`bool`) - The request should be denied.
 - `isErrored()` (`bool`) - There was an unrecoverable error.
 
-The conclusion will be the highest-severity finding when evaluating the configured
-rules. `"DENY"` is the highest severity, followed by `"CHALLENGE"`, then `"ERROR"` and
-finally `"ALLOW"` as the lowest severity.
+The conclusion will be the highest-severity finding when evaluating the
+configured rules. `"DENY"` is the highest severity, followed by `"CHALLENGE"`,
+then `"ERROR"` and finally `"ALLOW"` as the lowest severity.
 
 For example, when a bot protection rule returns an error and a validate email
 rule returns a deny, the overall conclusion would be deny. To access the error
@@ -300,8 +298,9 @@ The `reason` property of the `ArcjetDecision` object contains an `ArcjetReason`
 object which provides more detailed information about the conclusion. This is
 the final decision reason and is based on the configured rules.
 
-It will always be the highest-priority rule that produced that conclusion,
-to inspect other rules consider iterating over the `results` property on the decision.
+It will always be the highest-priority rule that produced that conclusion, to
+inspect other rules consider iterating over the `results` property on the
+decision.
 
 The `ArcjetReason` object has the following methods that can be used to check
 which rule caused the conclusion:
@@ -417,8 +416,8 @@ An `ArcjetEmailType` is one of the following strings:
 "DISPOSABLE" | "FREE" | "NO_MX_RECORDS" | "NO_GRAVATAR" | "INVALID";
 ```
 
-See the [email validation documentation](/email-validation/reference?f=remix) for more
-information about these properties.
+See the [email validation documentation](/email-validation/reference?f=remix)
+for more information about these properties.
 
 ### IP analysis
 
@@ -461,11 +460,11 @@ when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
 in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition when processing the rule, Arcjet will return an
-`ERROR` result for that rule and you can check the `message` property on the rule's
-error result for more information.
+`ERROR` result for that rule and you can check the `message` property on the
+rule's error result for more information.
 
-If all other rules that were run returned an `ALLOW` result, then the final Arcjet
-conclusion will be `ERROR`.
+If all other rules that were run returned an `ALLOW` result, then the final
+Arcjet conclusion will be `ERROR`.
 
 <Tabs>
   <TabItem label="TS">

--- a/src/content/docs/reference/sveltekit.mdx
+++ b/src/content/docs/reference/sveltekit.mdx
@@ -38,9 +38,9 @@ import IPAnalysis from "@/snippets/reference/shared/IPAnalysis.mdx";
 
 [<SDKVersionSvelteKit/>](https://www.npmjs.com/package/@arcjet/sveltekit)
 
-This is the reference guide for the Arcjet SvelteKit SDK, [available on
-GitHub](https://github.com/arcjet/arcjet-js) and licensed under the Apache 2.0
-license.
+This is the reference guide for the Arcjet SvelteKit SDK,
+[available on GitHub](https://github.com/arcjet/arcjet-js) and licensed under
+the Apache 2.0 license.
 
 <WhatIsArcjet />
 
@@ -83,13 +83,13 @@ server-only module in `/src/lib/server/`.
 The required fields are:
 
 - `key` (`string`) - Your Arcjet site key. This can be found in the SDK
-  Installation section for the site in the [Arcjet
-  Dashboard](https://app.arcjet.com).
+  Installation section for the site in the
+  [Arcjet Dashboard](https://app.arcjet.com).
 - `rules` - The rules to apply to the request. See the various sections of the
   docs for how to configure these e.g. [shield](/shield/reference?f=sveltekit),
-  [rate limiting](/rate-limiting/reference?f=sveltekit), [bot
-  protection](/bot-protection/reference?f=sveltekit), [email
-  validation](/email-validation/reference?f=sveltekit).
+  [rate limiting](/rate-limiting/reference?f=sveltekit),
+  [bot protection](/bot-protection/reference?f=sveltekit),
+  [email validation](/email-validation/reference?f=sveltekit).
 
 The optional fields are:
 
@@ -99,8 +99,8 @@ The optional fields are:
 - `proxies` (`string[]`) - A list of one or more trusted proxies. These
   addresses will be excluded when Arcjet is determining the client IP address.
   This is useful if you are behind a load balancer or proxy that sets the client
-  IP address in a header. See [Load balancers &
-  proxies](#load-balancers--proxies) below for an example.
+  IP address in a header. See
+  [Load balancers & proxies](#load-balancers--proxies) below for an example.
 
 <Tabs>
   <TabItem label="TS">
@@ -118,9 +118,9 @@ throughout your application. This is because the SDK caches decisions and
 configuration to improve performance.
 
 The pattern we use is to create a utility file that exports the `Arcjet` object
-and then import it where you need it. See [our example Next.js
-app](https://github.com/arcjet/example-nextjs/blob/main/lib/arcjet.ts) for how
-this is done.
+and then import it where you need it. See
+[our example Next.js app](https://github.com/arcjet/example-nextjs/blob/main/lib/arcjet.ts)
+for how this is done.
 
 ### Rule modes
 
@@ -176,10 +176,8 @@ You can combine rules to create a more complex protection strategy. For example,
 you can combine rate limiting and bot protection rules to protect your API from
 automated clients.
 
-:::note
-When specifying multiple rules, the order of the rules is ignored. Rule
-execution ordering is automatically optimized for performance.
-:::
+:::note When specifying multiple rules, the order of the rules is ignored. Rule
+execution ordering is automatically optimized for performance. :::
 
 <Tabs>
   <TabItem label="TS">
@@ -210,8 +208,8 @@ The following environment variables can be used to configure the SDK at runtime:
 ### Custom logging
 
 The SDK uses a lightweight logger which mirrors the
-[Pino](https://github.com/pinojs/pino) [structured
-logger](https://github.com/pinojs/pino/blob/8db130eba0439e61c802448d31eb1998cebfbc98/docs/api.md#logger)
+[Pino](https://github.com/pinojs/pino)
+[structured logger](https://github.com/pinojs/pino/blob/8db130eba0439e61c802448d31eb1998cebfbc98/docs/api.md#logger)
 interface. You can use this to customize the logging output.
 
 First, install the required packages:
@@ -243,8 +241,8 @@ through.
 
 The problem with is that the `X-Forwarded-For` header can be spoofed by the
 client, so you should only trust it if you are sure that the load balancer is
-setting it correctly. See [the MDN
-docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
+setting it correctly. See
+[the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)
 for more details.
 
 You can configure Arcjet to trust IP addresses in the `X-Forwarded-For` header
@@ -272,8 +270,8 @@ You can also specify CIDR ranges to match multiple IP addresses.
 
 Arcjet provides a single `protect` function that is used to execute your
 protection rules. This requires a `RequestEvent` object which is the event
-argument as passed to the SvelteKit request handler. Rules you add to the SDK may
-require additional details, such as the `validateEmail` rule requiring an
+argument as passed to the SvelteKit request handler. Rules you add to the SDK
+may require additional details, such as the `validateEmail` rule requiring an
 additional `email` prop.
 
 This function returns a `Promise` that resolves to an `ArcjetDecision` object,
@@ -304,8 +302,8 @@ The `protect` function function returns a `Promise` that resolves to an
   conclusion based on evaluating each of the configured rules. If you wish to
   accept Arcjet's recommended action based on the configured rules then you can
   use this property.
-- `reason` (`ArcjetReason`) - An object containing more detailed
-  information about the conclusion.
+- `reason` (`ArcjetReason`) - An object containing more detailed information
+  about the conclusion.
 - `results` (`ArcjetRuleResult[]`) - An array of `ArcjetRuleResult` objects
   containing the results of each rule that was executed.
 - `ttl` (`uint32`) - The time-to-live for the decision in seconds. This is the
@@ -324,9 +322,9 @@ check the conclusion:
 - `isDenied()` (`bool`) - The request should be denied.
 - `isErrored()` (`bool`) - There was an unrecoverable error.
 
-The conclusion will be the highest-severity finding when evaluating the configured
-rules. `"DENY"` is the highest severity, followed by `"CHALLENGE"`, then `"ERROR"` and
-finally `"ALLOW"` as the lowest severity.
+The conclusion will be the highest-severity finding when evaluating the
+configured rules. `"DENY"` is the highest severity, followed by `"CHALLENGE"`,
+then `"ERROR"` and finally `"ALLOW"` as the lowest severity.
 
 For example, when a bot protection rule returns an error and a validate email
 rule returns a deny, the overall conclusion would be deny. To access the error
@@ -338,8 +336,9 @@ The `reason` property of the `ArcjetDecision` object contains an `ArcjetReason`
 object which provides more detailed information about the conclusion. This is
 the final decision reason and is based on the configured rules.
 
-It will always be the highest-priority rule that produced that conclusion,
-to inspect other rules consider iterating over the `results` property on the decision.
+It will always be the highest-priority rule that produced that conclusion, to
+inspect other rules consider iterating over the `results` property on the
+decision.
 
 The `ArcjetReason` object has the following methods that can be used to check
 which rule caused the conclusion:
@@ -433,8 +432,8 @@ The `ArcjetReason` object for shield rules has the following properties:
 shieldTriggered: boolean;
 ```
 
-See the [shield documentation](/shield/reference?f=sveltekit) for more information
-about these properties.
+See the [shield documentation](/shield/reference?f=sveltekit) for more
+information about these properties.
 
 ##### Bot protection
 
@@ -459,8 +458,8 @@ window: number;
 reset: number;
 ```
 
-See the [rate limiting documentation](/rate-limiting/reference?f=sveltekit) for more
-information about these properties.
+See the [rate limiting documentation](/rate-limiting/reference?f=sveltekit) for
+more information about these properties.
 
 ##### Email validation & verification
 
@@ -476,7 +475,8 @@ An `ArcjetEmailType` is one of the following strings:
 "DISPOSABLE" | "FREE" | "NO_MX_RECORDS" | "NO_GRAVATAR" | "INVALID";
 ```
 
-See the [email validation documentation](/email-validation/reference?f=sveltekit) for
+See the
+[email validation documentation](/email-validation/reference?f=sveltekit) for
 more information about these properties.
 
 ### IP analysis
@@ -491,11 +491,11 @@ when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
 in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition when processing the rule, Arcjet will return an
-`ERROR` result for that rule and you can check the `message` property on the rule's
-error result for more information.
+`ERROR` result for that rule and you can check the `message` property on the
+rule's error result for more information.
 
-If all other rules that were run returned an `ALLOW` result, then the final Arcjet
-conclusion will be `ERROR`.
+If all other rules that were run returned an `ALLOW` result, then the final
+Arcjet conclusion will be `ERROR`.
 
 <Tabs>
   <TabItem label="TS">
@@ -597,15 +597,14 @@ SvelteKit SDK will automatically handle this for you.
 
 ### SvelteKit
 
-Arcjet supports the current major version of SvelteKit. When a new major
-version of SvelteKit is released, we will bump the major version of the
-Arcjet SDK.
+Arcjet supports the current major version of SvelteKit. When a new major version
+of SvelteKit is released, we will bump the major version of the Arcjet SDK.
 
 - Current supported major version: SvelteKit 2.x.x
 
-[Technical support](/support) is provided for the current major
-version of the Arcjet SDK for all users and for the current and previous major
-versions for paid users. We will provide security fixes for the current and
-previous major versions.
+[Technical support](/support) is provided for the current major version of the
+Arcjet SDK for all users and for the current and previous major versions for
+paid users. We will provide security fixes for the current and previous major
+versions.
 
 <Comments />

--- a/src/content/docs/security.mdx
+++ b/src/content/docs/security.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Arcjet security"
-description: "Arcjet vulnerability & patch management policy and security contact details."
+description:
+  "Arcjet vulnerability & patch management policy and security contact details."
 ---
 
 ## Vulnerability & patch management policy

--- a/src/content/docs/sensitive-info/concepts.mdx
+++ b/src/content/docs/sensitive-info/concepts.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Arcjet Sensitive Information"
-description: "Arcjet Sensitive Information prevents clients unintentionally sending you sensitive data such as PII that you do not wish to process."
+description:
+  "Arcjet Sensitive Information prevents clients unintentionally sending you
+  sensitive data such as PII that you do not wish to process."
 prev: false
 next: false
 ---
@@ -16,8 +18,8 @@ sensitive information such as PII that you do not wish to handle.
 ## What does Arcjet Sensitive Info do?
 
 Arcjet's "block sensitive information" rule prevents detected sensitive
-information from reaching your application. The rule runs entirely locally so
-no data ever leaves your environment.
+information from reaching your application. The rule runs entirely locally so no
+data ever leaves your environment.
 
 ## What kinds of sensitive information can Arcjet detect?
 

--- a/src/content/docs/sensitive-info/quick-start.mdx
+++ b/src/content/docs/sensitive-info/quick-start.mdx
@@ -8,7 +8,9 @@ titleByFramework:
   node-js: "Sensitive information detection for Node.js"
   remix: "Sensitive information detection for Remix"
   sveltekit: "Sensitive information detection for SvelteKit"
-description: "Quick start guide for detecting sensitive information with Arcjet in your Next.js, Node.js, Bun, Remix, or SvelteKit app."
+description:
+  "Quick start guide for detecting sensitive information with Arcjet in your
+  Next.js, Node.js, Bun, Remix, or SvelteKit app."
 frameworks:
   - bun
   - nest-js
@@ -74,8 +76,8 @@ import Step4Remix from "@/snippets/sensitive-info/quick-start/remix/Step4.mdx";
 import Step4SvelteKit from "@/snippets/sensitive-info/quick-start/sveltekit/Step4.mdx";
 
 Arcjet Sensitive Information Detection protects against clients sending you
-sensitive information such as personally identifiable information (PII) that
-you do not wish to handle.
+sensitive information such as personally identifiable information (PII) that you
+do not wish to handle.
 
 <WhatIsArcjet />
 
@@ -87,8 +89,9 @@ you do not wish to handle.
 
 ## Quick start
 
-This guide will show you how to configure Arcjet for a <FrameworkName client:load />
-app.
+This guide will show you how to configure Arcjet for a
+
+<FrameworkName client:load /> app.
 
 ### 1. Install Arcjet
 

--- a/src/content/docs/sensitive-info/reference.mdx
+++ b/src/content/docs/sensitive-info/reference.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Sensitive information reference"
-description: "Reference guide for detecting sensitive information (PII) with Arcjet in your Next.js, Node.js, Bun, Remix, or SvelteKit app."
+description:
+  "Reference guide for detecting sensitive information (PII) with Arcjet in your
+  Next.js, Node.js, Bun, Remix, or SvelteKit app."
 frameworks:
   - bun
   - nest-js
@@ -152,11 +154,9 @@ type SensitiveInfoOptionsDeny = {
 
 <DisplayType type="ArcjetSensitiveInfoType" from="arcjet" />
 
-:::note
-When specifying multiple rules, the order of the rules is ignored. Rule
+:::note When specifying multiple rules, the order of the rules is ignored. Rule
 execution ordering is automatically optimized for performance. See
-[decision](#decision) below for details of examining the execution results.
-:::
+[decision](#decision) below for details of examining the execution results. :::
 
 <SlotByFramework client:load>
   <NestJsDecoratorRoutes slot="nest-js" />
@@ -174,8 +174,8 @@ protection rules.
   <NestJsGuardDecision slot="nest-js" />
 </SlotByFramework>
 
-This function returns a `Promise` that resolves to an
-`ArcjetDecision` object. This contains the following properties:
+This function returns a `Promise` that resolves to an `ArcjetDecision` object.
+This contains the following properties:
 
 - `id` (`string`) - The unique ID for the request. This can be used to look up
   the request in the Arcjet dashboard. It is prefixed with `req_` for decisions
@@ -184,17 +184,19 @@ This function returns a `Promise` that resolves to an
 - `conclusion` (`ArcjetConclusion`) - The final conclusion based on evaluating
   each of the configured rules. If you wish to accept Arcjet's recommended
   action based on the configured rules then you can use this property.
-- `reason` (`ArcjetReason`) - An object containing more detailed
-  information about the conclusion.
+- `reason` (`ArcjetReason`) - An object containing more detailed information
+  about the conclusion.
 - `results` (`ArcjetRuleResult[]`) - An array of `ArcjetRuleResult` objects
   containing the results of each rule that was executed.
 - `ip` (`ArcjetIpDetails`) - An object containing Arcjet's analysis of the
   client IP address. See the SDK reference for more information.
 
-You check if a deny conclusion has been returned by a sensitive info rule by using
-`decision.isDenied()` and `decision.reason.isSensitiveInfo()` respectively.
+You check if a deny conclusion has been returned by a sensitive info rule by
+using `decision.isDenied()` and `decision.reason.isSensitiveInfo()`
+respectively.
 
-You can iterate through the results and check whether a sensitive info rule was applied:
+You can iterate through the results and check whether a sensitive info rule was
+applied:
 
 ```ts
 for (const result of decision.results) {
@@ -243,11 +245,11 @@ when `NODE_ENV` is `production` and 1000ms otherwise. However, in most cases,
 the response time will be less than 20-30ms.
 
 If there is an error condition when processing the rule, Arcjet will return an
-`ERROR` result for that rule and you can check the `message` property on the rule's
-error result for more information.
+`ERROR` result for that rule and you can check the `message` property on the
+rule's error result for more information.
 
-If all other rules that were run returned an `ALLOW` result, then the final Arcjet
-conclusion will be `ERROR`.
+If all other rules that were run returned an `ALLOW` result, then the final
+Arcjet conclusion will be `ERROR`.
 
 <SlotByFramework client:load>
   <ErrorsBun slot="bun" />

--- a/src/content/docs/shield/concepts.mdx
+++ b/src/content/docs/shield/concepts.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Arcjet Shield WAF"
-description: "Arcjet Shield WAF protects your application against common attacks, including the OWASP Top 10."
+description:
+  "Arcjet Shield WAF protects your application against common attacks, including
+  the OWASP Top 10."
 prev: false
 ---
 
@@ -25,11 +27,13 @@ Arcjet implements a variety of detection rules. Basic protection from the most
 common attacks are available for all Arcjet users.
 
 {/* prettier-ignore */}
-Users on the <Badge text="Starter" variant="note" /> and <Badge text="Business" variant="tip" />
-plans can enable Shield Managed (WAF) which includes an Arcjet-managed set of
-rules that are automatically updated. This is a fully-managed service that
-requires no maintenance, and includes the latest rules from the [OWASP Core Rule Set](https://coreruleset.org/)
-to protect against common categories such as:
+Users on the <Badge text="Starter" variant="note" /> and
+
+<Badge text="Business" variant="tip" /> plans can enable Shield Managed (WAF)
+which includes an Arcjet-managed set of rules that are automatically updated.
+This is a fully-managed service that requires no maintenance, and includes the
+latest rules from the [OWASP Core Rule Set](https://coreruleset.org/) to protect
+against common categories such as:
 
 - SQL injection (SQLi)
 - Cross-site scripting (XSS)
@@ -86,9 +90,10 @@ developers to build with security in mind without sacrificing usability.
 ## How does Arcjet Shield WAF work?
 
 The Arcjet SDK communicates with the Arcjet API on every request as part of
-applying your configured rules. The request ([except the
-body](/limitations#shield-analysis-does-not-use-the-request-body)) is included
-as part of this process and rules are executed based on the request content.
+applying your configured rules. The request
+([except the body](/limitations#shield-analysis-does-not-use-the-request-body))
+is included as part of this process and rules are executed based on the request
+content.
 
 Analysis happens on the Arcjet platform so it requires no additional resources
 from your application and adds no overhead to the request processing. See

--- a/src/content/docs/shield/quick-start.mdx
+++ b/src/content/docs/shield/quick-start.mdx
@@ -8,7 +8,9 @@ titleByFramework:
   node-js: "Shield WAF for Node.js"
   remix: "Shield WAF for Remix"
   sveltekit: "Shield WAF for SvelteKit"
-description: "Quick start guide for adding protection to your Next.js, Node.js, Bun, Remix, or SvelteKit app with Arcjet Shield WAF."
+description:
+  "Quick start guide for adding protection to your Next.js, Node.js, Bun, Remix,
+  or SvelteKit app with Arcjet Shield WAF."
 frameworks:
   - bun
   - nest-js
@@ -91,8 +93,9 @@ the [OWASP Top 10](https://owasp.org/www-project-top-ten/).
 
 ## Quick start
 
-This guide will show you how to protect your entire <FrameworkName client:load />
-application from common attacks.
+This guide will show you how to protect your entire
+
+<FrameworkName client:load /> application from common attacks.
 
 ### 1. Install Arcjet
 
@@ -202,8 +205,8 @@ protection and more.
 
 ## Get help
 
-Need help with anything? [Email us](mailto:support@arcjet.com) or [join our
-Discord](https://discord.gg/VRtMdATWNE) to get support from our
+Need help with anything? [Email us](mailto:support@arcjet.com) or
+[join our Discord](https://discord.gg/VRtMdATWNE) to get support from our
 engineering team.
 
 <Comments />

--- a/src/content/docs/shield/reference.mdx
+++ b/src/content/docs/shield/reference.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Shield WAF reference"
-description: "Reference guide for adding Arcjet Shield WAF to your Next.js, Node.js, Bun, Remix, or SvelteKit app."
+description:
+  "Reference guide for adding Arcjet Shield WAF to your Next.js, Node.js, Bun,
+  Remix, or SvelteKit app."
 frameworks:
   - bun
   - nest-js
@@ -91,8 +93,8 @@ the [OWASP Top 10](https://owasp.org/www-project-top-ten/).
 
 ## Plan availability
 
-Arcjet Shield WAF functionality depends on your [pricing
-plan](https://arcjet.com/pricing).
+Arcjet Shield WAF functionality depends on your
+[pricing plan](https://arcjet.com/pricing).
 
 | Plan                                                                             | Shield                          |
 | -------------------------------------------------------------------------------- | ------------------------------- |
@@ -103,10 +105,10 @@ plan](https://arcjet.com/pricing).
 ### What is Shield Managed?
 
 Shield Managed is a fully-managed service that requires no maintenance, and
-includes the latest rules from the [OWASP Core Rule
-Set](https://coreruleset.org/). It is available as an optional extra on non-free
-plans. See [Concepts](/shield/concepts#what-does-arcjet-shield-waf-do) for more
-details.
+includes the latest rules from the
+[OWASP Core Rule Set](https://coreruleset.org/). It is available as an optional
+extra on non-free plans. See
+[Concepts](/shield/concepts#what-does-arcjet-shield-waf-do) for more details.
 
 <FrameworkLinks
   title="Choose a framework"
@@ -125,11 +127,9 @@ constructed with the `shield(options: ShieldOptions)` function and configured by
 <DisplayType type="ShieldOptions" from="arcjet" />
 <DisplayType type="ArcjetMode" from="arcjet" />
 
-:::note
-When specifying multiple rules, the order of the rules is ignored. Rule
+:::note When specifying multiple rules, the order of the rules is ignored. Rule
 execution ordering is automatically optimized for performance. See
-[decision](#decision) below for details of examining the execution results.
-:::
+[decision](#decision) below for details of examining the execution results. :::
 
 <SlotByFramework client:load>
   <NestJsDecoratorRoutes slot="nest-js" />
@@ -149,8 +149,8 @@ context as passed to the request handler.
   <NestJsGuardDecision slot="nest-js" />
 </SlotByFramework>
 
-This function returns a `Promise` that resolves to an
-`ArcjetDecision` object. This contains the following properties:
+This function returns a `Promise` that resolves to an `ArcjetDecision` object.
+This contains the following properties:
 
 - `id` (`string`) - The unique ID for the request. This can be used to look up
   the request in the Arcjet dashboard. It is prefixed with `req_` for decisions
@@ -159,8 +159,8 @@ This function returns a `Promise` that resolves to an
 - `conclusion` (`ArcjetConclusion`) - The final conclusion based on evaluating
   each of the configured rules. If you wish to accept Arcjet's recommended
   action based on the configured rules then you can use this property.
-- `reason` (`ArcjetReason`) - An object containing more detailed
-  information about the conclusion.
+- `reason` (`ArcjetReason`) - An object containing more detailed information
+  about the conclusion.
 - `results` (`ArcjetRuleResult[]`) - An array of `ArcjetRuleResult` objects
   containing the results of each rule that was executed.
 - `ip` (`ArcjetIpDetails`) - An object containing Arcjet's analysis of the
@@ -196,11 +196,11 @@ when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
 in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition when processing the rule, Arcjet will return an
-`ERROR` result for that rule and you can check the `message` property on the rule's
-error result for more information.
+`ERROR` result for that rule and you can check the `message` property on the
+rule's error result for more information.
 
-If all other rules that were run returned an `ALLOW` result, then the final Arcjet
-conclusion will be `ERROR`.
+If all other rules that were run returned an `ALLOW` result, then the final
+Arcjet conclusion will be `ERROR`.
 
 <SlotByFramework client:load>
   <ErrorsBun slot="bun" />

--- a/src/content/docs/signup-protection/concepts.mdx
+++ b/src/content/docs/signup-protection/concepts.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Arcjet signup form protection"
-description: "Arcjet signup form protection combines rate limiting, bot protection, and email validation to protect your signup forms from abuse."
+description:
+  "Arcjet signup form protection combines rate limiting, bot protection, and
+  email validation to protect your signup forms from abuse."
 prev: false
 ---
 
@@ -19,10 +21,11 @@ The SDK also provide a set of pre-built products which combine these primitives
 with our recommended configuration. This saves you time and means you can get
 value from Arcjet with a single rule in just a few minutes.
 
-The Arcjet signup form protection product combines [rate
-limiting](/rate-limiting/concepts), [bot protection](/bot-protection/concepts),
-and [email validation](/email-validation/concepts) to help minimize the number
-of fake or fraudulent accounts that sign up to your service.
+The Arcjet signup form protection product combines
+[rate limiting](/rate-limiting/concepts),
+[bot protection](/bot-protection/concepts), and
+[email validation](/email-validation/concepts) to help minimize the number of
+fake or fraudulent accounts that sign up to your service.
 
 - **Rate limiting** - signup forms are a common target for bots. Arcjet's rate
   limiting helps to prevent bots and other automated or malicious clients from

--- a/src/content/docs/signup-protection/quick-start.mdx
+++ b/src/content/docs/signup-protection/quick-start.mdx
@@ -8,7 +8,9 @@ titleByFramework:
   node-js: "Signup form protection for Node.js"
   remix: "Signup form protection for Remix"
   sveltekit: "Signup form protection for SvelteKit"
-description: "Quick start guide to protect your signup forms from abuse to your Next.js, Node.js, Bun, Remix, or SvelteKit app with Arcjet Signup form protection."
+description:
+  "Quick start guide to protect your signup forms from abuse to your Next.js,
+  Node.js, Bun, Remix, or SvelteKit app with Arcjet Signup form protection."
 frameworks:
   - bun
   - nest-js
@@ -70,7 +72,8 @@ import Step4Remix from "@/snippets/signup-protection/quick-start/remix/Step4.mdx
 import FAQs from "/src/components/FAQs.astro";
 import Comments from "/src/components/Comments.astro";
 
-Arcjet signup form protection combines rate limiting, bot protection, and email validation to protect your signup forms from abuse.
+Arcjet signup form protection combines rate limiting, bot protection, and email
+validation to protect your signup forms from abuse.
 
 <WhatIsArcjet />
 
@@ -82,7 +85,8 @@ Arcjet signup form protection combines rate limiting, bot protection, and email 
 
 ## Quick start
 
-This guide will show you how to protect your <FrameworkName client:load /> signup form from common attacks.
+This guide will show you how to protect your <FrameworkName client:load />
+signup form from common attacks.
 
 ### 1. Install Arcjet SDK
 
@@ -100,7 +104,9 @@ In your project root, run the following command to install the SDK:
 ### 2. Set your key
 
 [Create a free Arcjet account](https://app.arcjet.com) then follow the
-instructions to add a site and get a key. Add it to a `.env.local` file in your <FrameworkName client:load /> project root.
+instructions to add a site and get a key. Add it to a `.env.local` file in your
+
+<FrameworkName client:load /> project root.
 
 <SlotByFramework client:load>
   <Step2SetEnv slot="bun" />
@@ -113,11 +119,11 @@ instructions to add a site and get a key. Add it to a `.env.local` file in your 
 
 ### 3. Protect a form
 
-Arcjet signup form protection is a combination of the [rate
-limiting](/rate-limiting/quick-start?f=node-js), [bot
-protection](/bot-protection/quick-start?f=node-js), and [email
-validation](/email-validation/quick-start?f=node-js) primitives. These are
-configured using our recommended rules.
+Arcjet signup form protection is a combination of the
+[rate limiting](/rate-limiting/quick-start?f=node-js),
+[bot protection](/bot-protection/quick-start?f=node-js), and
+[email validation](/email-validation/quick-start?f=node-js) primitives. These
+are configured using our recommended rules.
 
 The example below is a simple email form. You could adapt this as part of a
 signup form.
@@ -184,8 +190,8 @@ protection and more.
 
 ## Get help
 
-Need help with anything? [Email us](mailto:support@arcjet.com) or [join our
-Discord](https://discord.gg/VRtMdATWNE) to get support from our
+Need help with anything? [Email us](mailto:support@arcjet.com) or
+[join our Discord](https://discord.gg/VRtMdATWNE) to get support from our
 engineering team.
 
 <Comments />

--- a/src/content/docs/signup-protection/reference.mdx
+++ b/src/content/docs/signup-protection/reference.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Signup from protection reference"
-description: "Reference guide for adding Arcjet email validation to your Next.js, Node.js, Bun, Remix, or SvelteKit app."
+description:
+  "Reference guide for adding Arcjet email validation to your Next.js, Node.js,
+  Bun, Remix, or SvelteKit app."
 frameworks:
   - bun
   - nest-js
@@ -66,8 +68,8 @@ validation to protect your signup forms from abuse.
 
 ## Plan availability
 
-Arcjet signup form protection availability depends depends on your [pricing
-plan](https://arcjet.com/pricing).
+Arcjet signup form protection availability depends depends on your
+[pricing plan](https://arcjet.com/pricing).
 
 | Plan                                                                             | Signup form protection                                 |
 | -------------------------------------------------------------------------------- | ------------------------------------------------------ |
@@ -83,10 +85,10 @@ plan](https://arcjet.com/pricing).
 
 ## Configuration
 
-Signup form protection is a combination of the [rate
-limiting](/rate-limiting/quick-start?f=next-js), [bot
-protection](/bot-protection/quick-start?f=next-js), and [email
-validation](/email-validation/quick-start?f=next-js) primitives. The
+Signup form protection is a combination of the
+[rate limiting](/rate-limiting/quick-start?f=next-js),
+[bot protection](/bot-protection/quick-start?f=next-js), and
+[email validation](/email-validation/quick-start?f=next-js) primitives. The
 configuration options are the same, but specified in a single rule.
 
 The configuration definition is:
@@ -131,12 +133,12 @@ This can be configured as follows:
 When you are testing your signup form protection configuration, you can run the
 rules in dry run mode first by setting `mode` to `DRY_RUN`. This will return an
 allow decision for every request, but log what the results would have been if
-they were in live mode. You can view the results in the [Arcjet
-dashboard](https://app.arcjet.com).
+they were in live mode. You can view the results in the
+[Arcjet dashboard](https://app.arcjet.com).
 
-Even in dry run mode each rule will still be evaluated, so you can still [check
-the rule results](#checking-rule-results) to see if the email address is valid
-or not, or log them to your database.
+Even in dry run mode each rule will still be evaluated, so you can still
+[check the rule results](#checking-rule-results) to see if the email address is
+valid or not, or log them to your database.
 
 <SlotByFramework client:load>
   <NextJsPagesServerActions slot="next-js" />
@@ -153,8 +155,8 @@ rule it also requires an additional `email` prop.
   <NestJsGuardDecision slot="nest-js" />
 </SlotByFramework>
 
-This function returns a `Promise` that resolves to an
-`ArcjetDecision` object. This contains the following properties:
+This function returns a `Promise` that resolves to an `ArcjetDecision` object.
+This contains the following properties:
 
 - `id` (`string`) - The unique ID for the request. This can be used to look up
   the request in the Arcjet dashboard. It is prefixed with `req_` for decisions
@@ -163,8 +165,8 @@ This function returns a `Promise` that resolves to an
 - `conclusion` (`ArcjetConclusion`) - The final conclusion based on evaluating
   each of the configured rules. If you wish to accept Arcjet's recommended
   action based on the configured rules then you can use this property.
-- `reason` (`ArcjetReason`) - An object containing more detailed
-  information about the conclusion.
+- `reason` (`ArcjetReason`) - An object containing more detailed information
+  about the conclusion.
 - `results` (`ArcjetRuleResult[]`) - An array of `ArcjetRuleResult` objects
   containing the results of each rule that was executed.
 - `ip` (`ArcjetIpDetails`) - An object containing Arcjet's analysis of the
@@ -218,11 +220,11 @@ when `NODE_ENV` or `ARCJET_ENV` is `development` and 500ms otherwise. However,
 in most cases, the response time will be less than 20-30ms.
 
 If there is an error condition when processing the rule, Arcjet will return an
-`ERROR` result for that rule and you can check the `message` property on the rule's
-error result for more information.
+`ERROR` result for that rule and you can check the `message` property on the
+rule's error result for more information.
 
-If all other rules that were run returned an `ALLOW` result, then the final Arcjet
-conclusion will be `ERROR`.
+If all other rules that were run returned an `ALLOW` result, then the final
+Arcjet conclusion will be `ERROR`.
 
 <SlotByFramework client:load>
   <ErrorsBun slot="bun" />

--- a/src/content/docs/testing.mdx
+++ b/src/content/docs/testing.mdx
@@ -20,8 +20,8 @@ collection runner for [Postman](https://www.postman.com/). It allows you to
 define requests in Postman format and run them from the command line without
 requiring Postman itself.
 
-You can find our full example of how to test Arcjet with Express and Newman [on
-GitHub](https://github.com/arcjet/arcjet-js/tree/main/examples/express-newman).
+You can find our full example of how to test Arcjet with Express and Newman
+[on GitHub](https://github.com/arcjet/arcjet-js/tree/main/examples/express-newman).
 The key files are:
 
 - [`index.js`](https://github.com/arcjet/arcjet-js/blob/main/examples/express-newman/index.js)
@@ -35,8 +35,8 @@ The key files are:
   [`tests/high-rate-limit.json`](https://github.com/arcjet/arcjet-js/blob/main/examples/express-newman/tests/high-rate-limit.json),
   and
   [`tests/low-rate-limit.json`](https://github.com/arcjet/arcjet-js/blob/main/examples/express-newman/tests/low-rate-limit.json)
-  files define the test requests in [Postman Collection
-  format](https://learning.postman.com/collection-format/getting-started/overview/).
+  files define the test requests in
+  [Postman Collection format](https://learning.postman.com/collection-format/getting-started/overview/).
 
 The example
 [`README`](https://github.com/arcjet/arcjet-js/tree/main/examples/express-newman)
@@ -54,14 +54,14 @@ Arcjet runs the same in production as locally. This ensures that the behavior
 you see in development is the same as in production. However, there are ways to
 trigger the different rules.
 
-- **Shield:** Send 5 requests with the special header `x-arcjet-suspicious:
-true` to trigger the shield rule on the next request.
+- **Shield:** Send 5 requests with the special header
+  `x-arcjet-suspicious: true` to trigger the shield rule on the next request.
 - **Rate limiting:** Make more requests than the rate limit allows.
 - **Bot protection:** Bot detection uses multiple heuristics so the quickest way
   to get a bot detection `DENY` response is to make a request that is always
   considered a bot. With a deny rule set to `CURL` you should see a `DENY`
-  response if you make a request using the `curl` command. See [Identifying
-  Bots](/bot-protection/identifying-bots) for more information.
+  response if you make a request using the `curl` command. See
+  [Identifying Bots](/bot-protection/identifying-bots) for more information.
 - **Email validation:** Use an email address that has invalid syntax or does not
   match any other rules you have configured e.g. has no MX records or if from a
   disposable email service.

--- a/src/content/docs/troubleshooting.mdx
+++ b/src/content/docs/troubleshooting.mdx
@@ -25,10 +25,10 @@ exclude routes from your middleware.
 
 ### Decision errors from platform liveness or health checks when using Arcjet as a middleware
 
-Platforms like Kubernetes have support for automatic liveness and health
-check probes. These requests do not come from a browser and do not have all
-the same metadata that browsers do (and will not include important headers
-like `X-Real-Ip` or `X-Forwarded-For`). This will cause Arcjet to reject these
+Platforms like Kubernetes have support for automatic liveness and health check
+probes. These requests do not come from a browser and do not have all the same
+metadata that browsers do (and will not include important headers like
+`X-Real-Ip` or `X-Forwarded-For`). This will cause Arcjet to reject these
 probes, which will make the platform think your app is either not alive or
 unhealthy. This can manifest in CrashLoopBackoff errors in Kubernetes or your
 platform of choice restarting your app constantly.
@@ -49,10 +49,9 @@ Assuming you have your Arcjet middleware at `middleware.ts`, adjust the
  };
 ```
 
-:::note
-Do not include the leading slash in the match that you add. That will cause
-the regex to match on `//healthz`, which is almost certainly not what you want.
-:::
+:::note Do not include the leading slash in the match that you add. That will
+cause the regex to match on `//healthz`, which is almost certainly not what you
+want. :::
 
 <Tabs>
 <TabItem label="TS (App)">
@@ -81,10 +80,10 @@ When you deploy your app next, Arcjet should not trigger on this route.
 
 ### Override development IP
 
-Arcjet's [IP geolocation](/blueprints/ip-geolocation) and [VPN & proxy
-detection](/blueprints/vpn-proxy-detection) features require a real IP address
-to work. In local development, Arcjet defaults to `127.0.0.1` so the IP analysis
-metadata will be empty.
+Arcjet's [IP geolocation](/blueprints/ip-geolocation) and
+[VPN & proxy detection](/blueprints/vpn-proxy-detection) features require a real
+IP address to work. In local development, Arcjet defaults to `127.0.0.1` so the
+IP analysis metadata will be empty.
 
 You can set the IP address to a real public IP by overriding the IP address
 field (`ip`) in the `request` object that is passed to the Arcjet `protect`
@@ -191,9 +190,9 @@ fields:
 
 The required fields are:
 
-- `ip` - The client IP address. Internally our SDKs use our [`@arcjet/ip`
-  package](https://github.com/arcjet/arcjet-js/tree/main/ip#example) to detect
-  the correct IP which you can also use directly.
+- `ip` - The client IP address. Internally our SDKs use our
+  [`@arcjet/ip` package](https://github.com/arcjet/arcjet-js/tree/main/ip#example)
+  to detect the correct IP which you can also use directly.
 - `method` - The HTTP method of the request.
 - `host` - The host of the request.
 - `path` or `url` - The path of the request. In the Node.js SDK this field is
@@ -202,7 +201,8 @@ The required fields are:
 
 ### Property '[INTERNALS]' is missing in type
 
-When using the Arcjet Next.js SDK you may see a warning in your editor like this:
+When using the Arcjet Next.js SDK you may see a warning in your editor like
+this:
 
 ```text
 Argument of type x is not assignable to parameter of type 'NextMiddleware'.
@@ -211,14 +211,15 @@ Argument of type x is not assignable to parameter of type 'NextMiddleware'.
 request.d.ts(7, 5): '[INTERNALS]' is declared here.
 ```
 
-This is usually caused by a mismatch between the version of Next.js you are using
-and the version of the Arcjet SDK. You have several options for fixing this:
+This is usually caused by a mismatch between the version of Next.js you are
+using and the version of the Arcjet SDK. You have several options for fixing
+this:
 
 1. Update the Arcjet SDK to the latest version and update your version of
    Next.js to the latest version. We try to keep the SDK up to date with the
    latest Next.js releases so they should generally match.
-2. Add a [resolution
-   override](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#overrides)
+2. Add a
+   [resolution override](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#overrides)
    to your `package.json` to force the SDK to use the same version of Next.js.
    For example, if you are using Next.js 14.1.4 you can add this override to
    your `package.json` to force the Arcjet SDK to use the same version:
@@ -289,9 +290,9 @@ The Arcjet SDK does not support CJS. You can fix this by changing your
 application to use ESM. This is usually done by adding `"type": "module"` to
 your `package.json`.
 
-Alternatively, you can rename the files where you are using the Arcjet SDK to use
-the `.mjs` or `.mts` extension. This will tell Node.js to treat the file as an
-ESM file.
+Alternatively, you can rename the files where you are using the Arcjet SDK to
+use the `.mjs` or `.mts` extension. This will tell Node.js to treat the file as
+an ESM file.
 
 ### Error: Log is required / Error: Client is required
 
@@ -325,9 +326,9 @@ Another example is if you access a field in the body to perform email validation
 and then later try to access the body again in another part of your request
 handler.
 
-To fix this with sensitive information detection, see the [Accessing the
-body](/sensitive-info/reference?f=node-js#accessing-the-body) section of the
-reference.
+To fix this with sensitive information detection, see the
+[Accessing the body](/sensitive-info/reference?f=node-js#accessing-the-body)
+section of the reference.
 
 To fix this with other cases, clone the request before accessing the body:
 
@@ -345,16 +346,16 @@ const decision = await aj.protect(req, { email });
 ### Error: Cannot read properties of undefined (reading 'flags')
 
 If you see this error then you are probably running an older version of Next.js.
-Arcjet supports the [active and maintenance LTS versions of
-Next.js](https://nextjs.org/support-policy) as indicated in [the SDK
-reference](/reference/nextjs#requirements). Upgrade your Next.js version to the
-latest version to fix this error.
+Arcjet supports the
+[active and maintenance LTS versions of Next.js](https://nextjs.org/support-policy)
+as indicated in [the SDK reference](/reference/nextjs#requirements). Upgrade
+your Next.js version to the latest version to fix this error.
 
 ## Get help
 
 We provide [technical support](/support) for all Arcjet users so if you need
-help, [email us](mailto:support@arcjet.com) or [join our
-Discord](https://arcjet.com/discord).
+help, [email us](mailto:support@arcjet.com) or
+[join our Discord](https://arcjet.com/discord).
 
 <Comments />
 ```

--- a/src/content/docs/upgrading/sdk-migration.mdx
+++ b/src/content/docs/upgrading/sdk-migration.mdx
@@ -1,6 +1,7 @@
 ---
 title: "SDK migration"
-description: "Migration guide for Arcjet users who are upgrading the Arcjet SDK."
+description:
+  "Migration guide for Arcjet users who are upgrading the Arcjet SDK."
 prev: false
 next: false
 ---
@@ -165,7 +166,8 @@ detectBot({
 
 ## Get help
 
-Need help with anything? [Email us](mailto:support@arcjet.com) or [join our
-Discord](https://arcjet.com/discord) to get support from our engineering team.
+Need help with anything? [Email us](mailto:support@arcjet.com) or
+[join our Discord](https://arcjet.com/discord) to get support from our
+engineering team.
 
 <Comments />

--- a/src/lib/twoslasher.ts
+++ b/src/lib/twoslasher.ts
@@ -1,4 +1,4 @@
-import { createTwoslasher} from "twoslash"
+import { createTwoslasher } from "twoslash";
 
 const twoslasher = createTwoslasher();
 

--- a/src/snippets/blueprints/CustomValidationRule.ts
+++ b/src/snippets/blueprints/CustomValidationRule.ts
@@ -31,7 +31,6 @@ function validateBody(options: {
   // Each instance will validate using a Zod schema
   schema: z.Schema;
 }) {
-
   // Note that `ruleId` is only used for caching purposes. In
   // this case we want to validate the body on every request,
   // so we provide a new random UUID for each instance.
@@ -52,7 +51,6 @@ function validateBody(options: {
         context: ArcjetContext,
         details: ArcjetRequestDetails,
       ): Promise<ArcjetRuleResult> {
-
         try {
           const body = await context.getBody();
           if (typeof body !== "string") {

--- a/src/snippets/bot-protection/quick-start/astro/Step3.mdx
+++ b/src/snippets/bot-protection/quick-start/astro/Step3.mdx
@@ -4,10 +4,11 @@ import Step3TS from "@repo/astro/src/bot-detection/quick-start/Step3.ts?raw";
 import Step3JS from "@repo/astro/src/bot-detection/quick-start/Step3.mjs?raw";
 
 For this quick start we will enable Arcjet Bot Protection across of all the
-[dynamic routes](https://docs.astro.build/en/guides/routing/#dynamic-routes)
-in your Astro application using [Astro middleware
-](https://docs.astro.build/en/guides/middleware/). Learn about how to protect
-static routes in our [Astro SDK reference docs](/reference/astro#static-routes).
+[dynamic routes](https://docs.astro.build/en/guides/routing/#dynamic-routes) in
+your Astro application using
+[Astro middleware ](https://docs.astro.build/en/guides/middleware/). Learn about
+how to protect static routes in our
+[Astro SDK reference docs](/reference/astro#static-routes).
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
 <div slot="TypeScript" slotIdx="1">

--- a/src/snippets/bot-protection/quick-start/bun/Step1.mdx
+++ b/src/snippets/bot-protection/quick-start/bun/Step1.mdx
@@ -9,10 +9,8 @@ bun add @arcjet/bun @arcjet/inspect
 </div>
 </SelectableContent>
 
-:::note
-Our `@arcjet/bun` package is built for
-Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
-on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
-(uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](/bot-protection/quick-start?f=node-js).
-:::
+:::note Our `@arcjet/bun` package is built for Bun's
+[HTTP server](https://bun.sh/docs/api/http). If your application relies on Bun's
+[Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis) (uses
+`node:http` or a Node.js framework like express) you should instead follow
+[our guide for Node.js](/bot-protection/quick-start?f=node-js). :::

--- a/src/snippets/bot-protection/quick-start/bun/Step2.mdx
+++ b/src/snippets/bot-protection/quick-start/bun/Step2.mdx
@@ -8,8 +8,6 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since Bun doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV` in
-your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since Bun doesn't set `NODE_ENV` for you, you also need
+to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept a
+local IP address for development purposes. :::

--- a/src/snippets/bot-protection/quick-start/deno/Step2.mdx
+++ b/src/snippets/bot-protection/quick-start/deno/Step2.mdx
@@ -8,8 +8,6 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since Deno doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV` in
-your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since Deno doesn't set `NODE_ENV` for you, you also need
+to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept a
+local IP address for development purposes. :::

--- a/src/snippets/bot-protection/quick-start/deno/Step4.mdx
+++ b/src/snippets/bot-protection/quick-start/deno/Step4.mdx
@@ -13,11 +13,9 @@ Start your Deno server:
 </div>
 </SelectableContent>
 
-:::note[Deno permissions]
-Deno will prompt you for various permissions. You can also start Deno with the
-appropriate permission flags (`--allow-read --allow-env --allow-net`) to skip
-the prompt.
-:::
+:::note[Deno permissions] Deno will prompt you for various permissions. You can
+also start Deno with the appropriate permission flags
+(`--allow-read --allow-env --allow-net`) to skip the prompt. :::
 
 Make a `curl` request from your terminal. You should see a `403 Forbidden`
 response because `curl` is considered an automated client by default.

--- a/src/snippets/bot-protection/quick-start/nestjs/Step2.mdx
+++ b/src/snippets/bot-protection/quick-start/nestjs/Step2.mdx
@@ -8,8 +8,6 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since NestJS doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV`
-in your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since NestJS doesn't set `NODE_ENV` for you, you also
+need to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept
+a local IP address for development purposes. :::

--- a/src/snippets/bot-protection/quick-start/nestjs/Step3.mdx
+++ b/src/snippets/bot-protection/quick-start/nestjs/Step3.mdx
@@ -8,9 +8,10 @@ clients we are sure are automated.
 
 This creates a global [guard](https://docs.nestjs.com/guards) that will be
 applied to all routes. In a real application, implementing guards or per-route
-protections would give you more flexibility. See the [reference
-guide](/bot-protection/reference) and the [NestJS example
-app](https://github.com/arcjet/example-nestjs) for how to do this.
+protections would give you more flexibility. See the
+[reference guide](/bot-protection/reference) and the
+[NestJS example app](https://github.com/arcjet/example-nestjs) for how to do
+this.
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/quick-start/nestjs/Step3.ts
+++ b/src/snippets/bot-protection/quick-start/nestjs/Step3.ts
@@ -41,7 +41,7 @@ import { APP_GUARD, NestFactory } from "@nestjs/core";
     },
   ],
 })
-class AppModule { }
+class AppModule {}
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/src/snippets/bot-protection/quick-start/nextjs/Step3.mdx
+++ b/src/snippets/bot-protection/quick-start/nextjs/Step3.mdx
@@ -6,14 +6,14 @@ import { Code } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 
 For this quick start we will enable Arcjet Bot Protection across your entire
-Next.js application. [Next.js
-middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware)
+Next.js application.
+[Next.js middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware)
 runs before every request, allowing Arcjet to protect your entire application
 before your code runs.
 
 The **basic** option exports the middleware directly whereas the **advanced**
-option allows you to customize the response based on the [Arcjet
-decision](/bot-protection/reference?f=next-js#decision).
+option allows you to customize the response based on the
+[Arcjet decision](/bot-protection/reference?f=next-js#decision).
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
 <div slot="TS (Basic)" slotIdx="1">

--- a/src/snippets/bot-protection/quick-start/nodejs/Step2.mdx
+++ b/src/snippets/bot-protection/quick-start/nodejs/Step2.mdx
@@ -8,8 +8,6 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since Node.js doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV`
-in your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since Node.js doesn't set `NODE_ENV` for you, you also
+need to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept
+a local IP address for development purposes. :::

--- a/src/snippets/bot-protection/reference/nestjs/DecisionLog.mdx
+++ b/src/snippets/bot-protection/reference/nestjs/DecisionLog.mdx
@@ -3,8 +3,8 @@ import { Code } from "@astrojs/starlight/components";
 import DecisionLogTS from "./DecisionLog.ts?raw";
 
 This example will log the results of each rule execution. It shows how Arcjet
-can be integrated into the NestJS logger. See the [SDK
-reference](/reference/nestjs) for more details.
+can be integrated into the NestJS logger. See the
+[SDK reference](/reference/nestjs) for more details.
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nestjs/DecoratorRoutes.mdx
+++ b/src/snippets/bot-protection/reference/nestjs/DecoratorRoutes.mdx
@@ -40,8 +40,8 @@ with Arcjet.
 ### Per route guard
 
 A per route guard can be configured in the controller for each route you wish to
-protect with specific Arcjet rules. The client created in `src/app.module.ts`
-is automatically passed to the guard.
+protect with specific Arcjet rules. The client created in `src/app.module.ts` is
+automatically passed to the guard.
 
 The rules will be applied and a generic error returned if the result is `DENY`.
 

--- a/src/snippets/bot-protection/reference/nextjs/Examples.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/Examples.mdx
@@ -87,8 +87,8 @@ For the Edge runtime:
 
 ## Edge Functions
 
-Arcjet works in Edge Functions and with the [Edge
-Runtime](https://edge-runtime.vercel.app/).
+Arcjet works in Edge Functions and with the
+[Edge Runtime](https://edge-runtime.vercel.app/).
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/bot-protection/reference/nextjs/Middleware.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/Middleware.mdx
@@ -52,8 +52,8 @@ address for the bot detection rule result:
 
 If you use Arcjet in middleware and individual routes, you need to be careful
 that Arcjet is not running multiple times per request. This can be avoided by
-excluding the API route from [the middleware
-matcher](https://nextjs.org/docs/pages/building-your-application/routing/middleware#matcher).
+excluding the API route from
+[the middleware matcher](https://nextjs.org/docs/pages/building-your-application/routing/middleware#matcher).
 
 For example, if you already have a bot detection rule defined in the API route
 at `/api/hello`, you can exclude it from the middleware by specifying a matcher

--- a/src/snippets/bot-protection/reference/nextjs/PagesServerActions.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/PagesServerActions.mdx
@@ -4,6 +4,6 @@ Arcjet can be used inside Next.js middleware, API routes, pages, server
 components, and server actions. Client components cannot be protected because
 they run on the client only.
 
-See the [Next.js SDK reference](/reference/nextjs) for examples of [pages / page
-components](/reference/nextjs#pages--page-components) and [server
-actions](/reference/nextjs#server-actions).
+See the [Next.js SDK reference](/reference/nextjs) for examples of
+[pages / page components](/reference/nextjs#pages--page-components) and
+[server actions](/reference/nextjs#server-actions).

--- a/src/snippets/bot-protection/reference/nextjs/PerRouteVsMiddleware.mdx
+++ b/src/snippets/bot-protection/reference/nextjs/PerRouteVsMiddleware.mdx
@@ -12,8 +12,8 @@ Bot protection rules can be configured in two ways:
   if you want to use the decision to add context to your own code. However, it
   means rules are not located in a single place.
 - **Middleware**: The rule is defined in the middleware. This allows you to
-  configure rules in a single place or apply them globally to all routes, but
-  it means the rules are not located alongside the code they are protecting.
+  configure rules in a single place or apply them globally to all routes, but it
+  means the rules are not located alongside the code they are protecting.
 
 ### Per route
 

--- a/src/snippets/bot-protection/reference/remix/LoaderVsAction.mdx
+++ b/src/snippets/bot-protection/reference/remix/LoaderVsAction.mdx
@@ -6,8 +6,8 @@ import ActionJS from "./Action.js?raw";
 
 ## Loader vs action
 
-Remix does not support middleware, instead [they
-recommend](https://github.com/remix-run/remix/discussions/1432) calling
+Remix does not support middleware, instead
+[they recommend](https://github.com/remix-run/remix/discussions/1432) calling
 functions directly inside the
 [loader](https://remix.run/docs/en/main/route/loader). Loaders execute before
 the page is loaded.

--- a/src/snippets/bot-protection/reference/sveltekit/PerRouteVsHooks.mdx
+++ b/src/snippets/bot-protection/reference/sveltekit/PerRouteVsHooks.mdx
@@ -13,9 +13,9 @@ Bot protection rules can be configured in two ways:
   you to configure the rule alongside the code it is protecting which is useful
   if you want to use the decision to add context to your own code. However, it
   means rules are not located in a single place.
-- **Hooks**: The rule is defined as a hook. This allows you to
-  configure rules in a single place or apply them globally to all routes, but
-  it means the rules are not located alongside the code they are protecting.
+- **Hooks**: The rule is defined as a hook. This allows you to configure rules
+  in a single place or apply them globally to all routes, but it means the rules
+  are not located alongside the code they are protecting.
 
 ### Per route
 
@@ -27,8 +27,8 @@ This configures bot protection on a single route.
 
 ### Hooks
 
-This will run on every request to your SvelteKit app - see [the SvelteKit Hooks
-docs](https://kit.svelte.dev/docs/hooks) for details.
+This will run on every request to your SvelteKit app - see
+[the SvelteKit Hooks docs](https://kit.svelte.dev/docs/hooks) for details.
 
 <SlotByFramework client:load>
   <Hooks slot="sveltekit" />
@@ -36,11 +36,11 @@ docs](https://kit.svelte.dev/docs/hooks) for details.
 
 ### Avoiding double protection with hooks
 
-If you use Arcjet in hooks and individual routes, you need to be careful
-that Arcjet is not running multiple times per request. This can be avoided by
+If you use Arcjet in hooks and individual routes, you need to be careful that
+Arcjet is not running multiple times per request. This can be avoided by
 excluding the individual routes before running Arcjet in the hook.
 
-For example, if you already have rules defined in the API route
-at `/api/arcjet`, you can exclude it from the hook like this:
+For example, if you already have rules defined in the API route at
+`/api/arcjet`, you can exclude it from the hook like this:
 
 <Code code={HookMatcher} lang="ts" title="/src/hooks.server.ts" />

--- a/src/snippets/email-validation/quick-start/bun/Step1.mdx
+++ b/src/snippets/email-validation/quick-start/bun/Step1.mdx
@@ -9,10 +9,8 @@ bun add @arcjet/bun @arcjet/inspect
 </div>
 </SelectableContent>
 
-:::note
-Our `@arcjet/bun` package is built for
-Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
-on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
-(uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](/email-validation/quick-start?f=node-js).
-:::
+:::note Our `@arcjet/bun` package is built for Bun's
+[HTTP server](https://bun.sh/docs/api/http). If your application relies on Bun's
+[Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis) (uses
+`node:http` or a Node.js framework like express) you should instead follow
+[our guide for Node.js](/email-validation/quick-start?f=node-js). :::

--- a/src/snippets/email-validation/quick-start/nestjs/Step3Controller.ts
+++ b/src/snippets/email-validation/quick-start/nestjs/Step3Controller.ts
@@ -48,7 +48,7 @@ export class SignupController {
   constructor(
     private readonly signupService: SignupService,
     @Inject(ARCJET) private readonly arcjet: ArcjetNest,
-  ) { }
+  ) {}
 
   // Implement a form handler following
   // https://docs.nestjs.com/techniques/file-upload#no-files. Note this isn't

--- a/src/snippets/email-validation/quick-start/nextjs/Step3.mdx
+++ b/src/snippets/email-validation/quick-start/nextjs/Step3.mdx
@@ -5,8 +5,8 @@ import Step3AppTS from "./Step3App.ts?raw";
 import Step3PagesJS from "./Step3Pages.js?raw";
 import Step3PagesTS from "./Step3Pages.ts?raw";
 
-If you are using server actions, see the [example in the SDK
-reference](/reference/nextjs#server-actions).
+If you are using server actions, see the
+[example in the SDK reference](/reference/nextjs#server-actions).
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
 <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/email-validation/reference/nestjs/DecisionLogAllow.ts
+++ b/src/snippets/email-validation/reference/nestjs/DecisionLogAllow.ts
@@ -53,7 +53,7 @@ export class SignupController {
   constructor(
     private readonly signupService: SignupService,
     @Inject(ARCJET) private readonly arcjet: ArcjetNest,
-  ) { }
+  ) {}
 
   // Implement a form handler following
   // https://docs.nestjs.com/techniques/file-upload#no-files. Note this isn't

--- a/src/snippets/email-validation/reference/nestjs/DecisionLogDeny.ts
+++ b/src/snippets/email-validation/reference/nestjs/DecisionLogDeny.ts
@@ -53,7 +53,7 @@ export class SignupController {
   constructor(
     private readonly signupService: SignupService,
     @Inject(ARCJET) private readonly arcjet: ArcjetNest,
-  ) { }
+  ) {}
 
   // Implement a form handler following
   // https://docs.nestjs.com/techniques/file-upload#no-files. Note this isn't

--- a/src/snippets/email-validation/reference/nestjs/Errors.ts
+++ b/src/snippets/email-validation/reference/nestjs/Errors.ts
@@ -49,7 +49,7 @@ export class SignupController {
   constructor(
     private readonly signupService: SignupService,
     @Inject(ARCJET) private readonly arcjet: ArcjetNest,
-  ) { }
+  ) {}
 
   // Implement a form handler following
   // https://docs.nestjs.com/techniques/file-upload#no-files. Note this isn't

--- a/src/snippets/email-validation/reference/nextjs/DecisionLogAllow.mdx
+++ b/src/snippets/email-validation/reference/nextjs/DecisionLogAllow.mdx
@@ -7,15 +7,31 @@ import DecisionLogPagesAllowTS from "./DecisionLogPagesAllow.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">
-    <Code code={DecisionLogAppAllowTS} lang="ts" title="/app/api/arcjet/route.ts" />
+    <Code
+      code={DecisionLogAppAllowTS}
+      lang="ts"
+      title="/app/api/arcjet/route.ts"
+    />
   </div>
   <div slot="TS (Pages)" slotIdx="2">
-    <Code code={DecisionLogPagesAllowTS} lang="ts" title="/pages/api/hello.ts" />
+    <Code
+      code={DecisionLogPagesAllowTS}
+      lang="ts"
+      title="/pages/api/hello.ts"
+    />
   </div>
   <div slot="JS (App)" slotIdx="3">
-    <Code code={DecisionLogAppAllowJS} lang="js" title="/app/api/arcjet/route.js" />
+    <Code
+      code={DecisionLogAppAllowJS}
+      lang="js"
+      title="/app/api/arcjet/route.js"
+    />
   </div>
   <div slot="JS (Pages)" slotIdx="4">
-    <Code code={DecisionLogPagesAllowJS} lang="js" title="/pages/api/hello.ts" />
+    <Code
+      code={DecisionLogPagesAllowJS}
+      lang="js"
+      title="/pages/api/hello.ts"
+    />
   </div>
 </SelectableContent>

--- a/src/snippets/email-validation/reference/nextjs/DecisionLogDeny.mdx
+++ b/src/snippets/email-validation/reference/nextjs/DecisionLogDeny.mdx
@@ -7,13 +7,21 @@ import DecisionLogDenyPagesTS from "./DecisionLogPagesDeny.ts?raw";
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">
-    <Code code={DecisionLogDenyAppTS} lang="ts" title="/app/api/arcjet/route.ts" />
+    <Code
+      code={DecisionLogDenyAppTS}
+      lang="ts"
+      title="/app/api/arcjet/route.ts"
+    />
   </div>
   <div slot="TS (Pages)" slotIdx="2">
     <Code code={DecisionLogDenyPagesTS} lang="ts" title="/pages/api/hello.ts" />
   </div>
   <div slot="JS (App)" slotIdx="3">
-    <Code code={DecisionLogDenyAppJS} lang="js" title="/app/api/arcjet/route.js" />
+    <Code
+      code={DecisionLogDenyAppJS}
+      lang="js"
+      title="/app/api/arcjet/route.js"
+    />
   </div>
   <div slot="JS (Pages)" slotIdx="4">
     <Code code={DecisionLogDenyPagesJS} lang="js" title="/pages/api/hello.ts" />

--- a/src/snippets/email-validation/reference/nextjs/PagesServerActions.mdx
+++ b/src/snippets/email-validation/reference/nextjs/PagesServerActions.mdx
@@ -4,6 +4,6 @@ Arcjet can be used inside Next.js middleware, API routes, pages, server
 components, and server actions. Client components cannot be protected because
 they run on the client only.
 
-See the [Next.js SDK reference](/reference/nextjs) for examples of [pages / page
-components](/reference/nextjs#pages--page-components) and [server
-actions](/reference/nextjs#server-actions).
+See the [Next.js SDK reference](/reference/nextjs) for examples of
+[pages / page components](/reference/nextjs#pages--page-components) and
+[server actions](/reference/nextjs#server-actions).

--- a/src/snippets/get-started/astro/Requirements.mdx
+++ b/src/snippets/get-started/astro/Requirements.mdx
@@ -1,2 +1,3 @@
 - Astro 5.9.3 or later
-- [On-demand rendering](https://docs.astro.build/en/guides/on-demand-rendering/) enabled
+- [On-demand rendering](https://docs.astro.build/en/guides/on-demand-rendering/)
+  enabled

--- a/src/snippets/get-started/astro/Step0.mdx
+++ b/src/snippets/get-started/astro/Step0.mdx
@@ -29,7 +29,8 @@ yarn create astro@latest
 </SelectableContent>
 
 Next enable on-demand rendering. This is important because Arcjet only protects
-dynamic routes. Learn why in our [Astro SDK reference docs](/reference/astro#static-routes).
+dynamic routes. Learn why in our
+[Astro SDK reference docs](/reference/astro#static-routes).
 
 Here we've chosen the node server adapter:
 
@@ -58,5 +59,7 @@ yarn astro add node
 </div>
 </SelectableContent>
 
-For detailed instructions refer to the [Astro installation docs](https://docs.astro.build/en/install-and-setup/)
-and the [Astro on-demand rendering docs](https://docs.astro.build/en/guides/on-demand-rendering/).
+For detailed instructions refer to the
+[Astro installation docs](https://docs.astro.build/en/install-and-setup/) and
+the
+[Astro on-demand rendering docs](https://docs.astro.build/en/guides/on-demand-rendering/).

--- a/src/snippets/get-started/astro/Step2.mdx
+++ b/src/snippets/get-started/astro/Step2.mdx
@@ -1,7 +1,7 @@
 The Arcjet Astro integration reads your Arcjet key from the `ARCJET_KEY`
-environment variable. During development, add your key to a `.env.local` file
-in your project root. Astro will automatically load the environment
-variables from this file, learn more in the
+environment variable. During development, add your key to a `.env.local` file in
+your project root. Astro will automatically load the environment variables from
+this file, learn more in the
 [Astro docs](https://docs.astro.build/en/guides/environment-variables/#env-files).
 
 ```ini title=".env.local"

--- a/src/snippets/get-started/astro/Step4.mdx
+++ b/src/snippets/get-started/astro/Step4.mdx
@@ -21,8 +21,8 @@ yarn run dev
 </div>
 </SelectableContent>
 
-Visit [`http://localhost:4321/api`](http://localhost:4321/api) in
-your browser and refresh a few times to hit the rate limit.
+Visit [`http://localhost:4321/api`](http://localhost:4321/api) in your browser
+and refresh a few times to hit the rate limit.
 
 Wait 10 seconds, then run:
 

--- a/src/snippets/get-started/bun-hono/Step0.mdx
+++ b/src/snippets/get-started/bun-hono/Step0.mdx
@@ -1,15 +1,16 @@
 import SelectableContent from "@/components/SelectableContent";
 
 {/* prettier-ignore */}
-
 Installing Bun
 
 ```sh
 npm install -g bun
 ```
-For detailed instructions refer to the [Bun docs](https://bun.sh/docs/installation).
 
-To install Hono: 
+For detailed instructions refer to the
+[Bun docs](https://bun.sh/docs/installation).
+
+To install Hono:
 
 <SelectableContent client:load syncKey="packageManager" frameworkSwitcher>
 <div slot="npm" slotIdx="1">
@@ -35,5 +36,5 @@ yarn create hono
 </div>
 </SelectableContent>
 
-For detailed instructions refer to the [Hono docs](https://hono.dev/docs/#quick-start).
-
+For detailed instructions refer to the
+[Hono docs](https://hono.dev/docs/#quick-start).

--- a/src/snippets/get-started/bun-hono/Step2.mdx
+++ b/src/snippets/get-started/bun-hono/Step2.mdx
@@ -8,8 +8,6 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since Bun doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV` in
-your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since Bun doesn't set `NODE_ENV` for you, you also need
+to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept a
+local IP address for development purposes. :::

--- a/src/snippets/get-started/bun-hono/Step4.mdx
+++ b/src/snippets/get-started/bun-hono/Step4.mdx
@@ -4,11 +4,9 @@
 bun run --hot index.ts
 ```
 
-:::note
-Bun's `--hot` flag will reload the runtime when changes are made to your `.ts`
-files, but not your `.env.local` file. If you change your `.env.local` file,
-you need to restart the command manually.
-:::
+:::note Bun's `--hot` flag will reload the runtime when changes are made to your
+`.ts` files, but not your `.env.local` file. If you change your `.env.local`
+file, you need to restart the command manually. :::
 
 Visit [`http://localhost:3000`](http://localhost:3000) in your browser and
 refresh a few times to hit the rate limit. You may see 2 requests - one for the

--- a/src/snippets/get-started/bun/Step0.mdx
+++ b/src/snippets/get-started/bun/Step0.mdx
@@ -1,9 +1,9 @@
 {/* prettier-ignore */}
-
 Installing Bun:
 
 ```sh
 npm install -g bun
 ```
-For detailed instructions refer to the [Bun docs](https://bun.sh/docs/installation).
 
+For detailed instructions refer to the
+[Bun docs](https://bun.sh/docs/installation).

--- a/src/snippets/get-started/bun/Step1.mdx
+++ b/src/snippets/get-started/bun/Step1.mdx
@@ -11,10 +11,8 @@ bun add @arcjet/bun @arcjet/inspect
 </div>
 </SelectableContent>
 
-:::note
-Our `@arcjet/bun` package is built for
-Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
-on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
-(uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](/get-started?f=node-js).
-:::
+:::note Our `@arcjet/bun` package is built for Bun's
+[HTTP server](https://bun.sh/docs/api/http). If your application relies on Bun's
+[Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis) (uses
+`node:http` or a Node.js framework like express) you should instead follow
+[our guide for Node.js](/get-started?f=node-js). :::

--- a/src/snippets/get-started/bun/Step2.mdx
+++ b/src/snippets/get-started/bun/Step2.mdx
@@ -8,8 +8,6 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since Bun doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV` in
-your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since Bun doesn't set `NODE_ENV` for you, you also need
+to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept a
+local IP address for development purposes. :::

--- a/src/snippets/get-started/bun/Step3.mdx
+++ b/src/snippets/get-started/bun/Step3.mdx
@@ -25,9 +25,9 @@ import SelectableContent from "@/components/SelectableContent";
   <strong>`Bun.serve()` support</strong>
 </summary>
 
-While our documentation gives you examples using [Bun's default export Object
-syntax](https://bun.sh/docs/api/http#object-syntax), it will also run if you
-use `Bun.serve()` instead:
+While our documentation gives you examples using
+[Bun's default export Object syntax](https://bun.sh/docs/api/http#object-syntax),
+it will also run if you use `Bun.serve()` instead:
 
 <Code code={Step3ServeTS} lang="ts" title="index.ts" />
 

--- a/src/snippets/get-started/bun/Step4.mdx
+++ b/src/snippets/get-started/bun/Step4.mdx
@@ -16,11 +16,9 @@ bun run --hot index.js
 </div>
 </SelectableContent>
 
-:::note
-Bun's `--hot` flag will reload the runtime when changes are made to your `.ts`
-files, but not your `.env.local` file. If you change your `.env.local` file,
-you need to restart the command manually.
-:::
+:::note Bun's `--hot` flag will reload the runtime when changes are made to your
+`.ts` files, but not your `.env.local` file. If you change your `.env.local`
+file, you need to restart the command manually. :::
 
 Visit [`http://localhost:3000`](http://localhost:3000) in your browser and
 refresh a few times to hit the rate limit. You may see 2 requests - one for the

--- a/src/snippets/get-started/deno/Step0.mdx
+++ b/src/snippets/get-started/deno/Step0.mdx
@@ -1,16 +1,18 @@
 {/* prettier-ignore */}
-
 Installing Deno:
 
 1. macOS and Linux
+
 ```sh
 curl -fsSL https://deno.land/install.sh | sh
 ```
+
 2. Windows
+
 ```sh
 irm https://deno.land/install.ps1 | iex
 
 ```
 
-For detailed instructions refer to the [Deno docs](https://docs.deno.com/runtime/getting_started/installation).
-
+For detailed instructions refer to the
+[Deno docs](https://docs.deno.com/runtime/getting_started/installation).

--- a/src/snippets/get-started/deno/Step2.mdx
+++ b/src/snippets/get-started/deno/Step2.mdx
@@ -8,8 +8,6 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since Deno doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV` in
-your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since Deno doesn't set `NODE_ENV` for you, you also need
+to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept a
+local IP address for development purposes. :::

--- a/src/snippets/get-started/deno/Step4.mdx
+++ b/src/snippets/get-started/deno/Step4.mdx
@@ -4,11 +4,9 @@
 deno run --watch index.ts
 ```
 
-:::note
-Deno will prompt you for various permissions. You can also start Deno with the
-appropriate permission flags (`--allow-read --allow-env --allow-net`) to skip
-the prompt.
-:::
+:::note Deno will prompt you for various permissions. You can also start Deno
+with the appropriate permission flags (`--allow-read --allow-env --allow-net`)
+to skip the prompt. :::
 
 Visit [`http://localhost:3000`](http://localhost:3000) in your browser and
 refresh a few times to hit the rate limit. You may see 2 requests - one for the

--- a/src/snippets/get-started/fastify/Step0.mdx
+++ b/src/snippets/get-started/fastify/Step0.mdx
@@ -28,6 +28,8 @@ yarn add fastify
 </div>
 </SelectableContent>
 
-For detailed instructions refer to the [Fastify docs](https://fastify.dev/docs/latest/Guides/Getting-Started/).
+For detailed instructions refer to the
+[Fastify docs](https://fastify.dev/docs/latest/Guides/Getting-Started/).
 
-To install Node.js on your system follow the official [docs](https://nodejs.org/en/download/package-manager).
+To install Node.js on your system follow the official
+[docs](https://nodejs.org/en/download/package-manager).

--- a/src/snippets/get-started/fastify/Step2.mdx
+++ b/src/snippets/get-started/fastify/Step2.mdx
@@ -8,7 +8,6 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since Fastify doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since Fastify doesn't set `NODE_ENV` for you, you also
+need to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept
+a local IP address for development purposes. :::

--- a/src/snippets/get-started/nest-js/Requirements.mdx
+++ b/src/snippets/get-started/nest-js/Requirements.mdx
@@ -1,5 +1,6 @@
 - NestJS 10.4 or later.
 - Node.js 20 or later.
 - Express and Fastify are supported.
-- CommonJS is not supported. Arcjet is ESM only. See [our NestJS example
-  app](https://github.com/arcjet/example-nestjs) for how to use ESM with NestJS.
+- CommonJS is not supported. Arcjet is ESM only. See
+  [our NestJS example app](https://github.com/arcjet/example-nestjs) for how to
+  use ESM with NestJS.

--- a/src/snippets/get-started/nest-js/Step0.mdx
+++ b/src/snippets/get-started/nest-js/Step0.mdx
@@ -1,9 +1,8 @@
 {/* prettier-ignore */}
-
 Installing Nest.js
 
 ```sh
 npm i -g @nestjs/cli
 ```
-For detailed instructions refer to the [Nest.js docs](https://docs.nestjs.com/).
 
+For detailed instructions refer to the [Nest.js docs](https://docs.nestjs.com/).

--- a/src/snippets/get-started/nest-js/Step2.mdx
+++ b/src/snippets/get-started/nest-js/Step2.mdx
@@ -8,8 +8,6 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since NestJS doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV`
-in your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since NestJS doesn't set `NODE_ENV` for you, you also
+need to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept
+a local IP address for development purposes. :::

--- a/src/snippets/get-started/nest-js/Step3.mdx
+++ b/src/snippets/get-started/nest-js/Step3.mdx
@@ -12,8 +12,8 @@ import GlobalGuard from "./GlobalGuard.ts?raw";
 
 This creates a global [guard](https://docs.nestjs.com/guards) that will be
 applied to all routes. In a real application, implementing guards or per-route
-protections would give you more flexibility. See [our example
-app](https://github.com/arcjet/example-nestjs) for how to do this.
+protections would give you more flexibility. See
+[our example app](https://github.com/arcjet/example-nestjs) for how to do this.
 
 </div>
 </SelectableContent>

--- a/src/snippets/get-started/next-js/Step0.mdx
+++ b/src/snippets/get-started/next-js/Step0.mdx
@@ -1,8 +1,9 @@
 {/* prettier-ignore */}
-
 To create a Next.js project:
 
 ```sh
 npx create-next-app@latest
 ```
-For detailed instructions refer to the [Next.js docs](https://nextjs.org/docs/app/getting-started/installation).
+
+For detailed instructions refer to the
+[Next.js docs](https://nextjs.org/docs/app/getting-started/installation).

--- a/src/snippets/get-started/node-js-express/Step0.mdx
+++ b/src/snippets/get-started/node-js-express/Step0.mdx
@@ -1,11 +1,12 @@
 {/* prettier-ignore */}
-
-To install Express: 
+To install Express:
 
 ```sh
 npm install express
 ```
-For detailed instructions refer to [Express.js docs](https://expressjs.com/en/starter/installing.html).
 
-To install Node.js on your system follow the official [docs](https://nodejs.org/en/download/package-manager).
+For detailed instructions refer to
+[Express.js docs](https://expressjs.com/en/starter/installing.html).
 
+To install Node.js on your system follow the official
+[docs](https://nodejs.org/en/download/package-manager).

--- a/src/snippets/get-started/node-js-express/Step2.mdx
+++ b/src/snippets/get-started/node-js-express/Step2.mdx
@@ -8,8 +8,6 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since Node.js doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV`
-in your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since Node.js doesn't set `NODE_ENV` for you, you also
+need to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept
+a local IP address for development purposes. :::

--- a/src/snippets/get-started/node-js-hono/Step0.mdx
+++ b/src/snippets/get-started/node-js-hono/Step0.mdx
@@ -1,8 +1,7 @@
 import SelectableContent from "@/components/SelectableContent";
 
 {/* prettier-ignore */}
-
-To install Hono: 
+To install Hono:
 
 <SelectableContent client:load syncKey="packageManager" frameworkSwitcher>
 <div slot="npm" slotIdx="1">
@@ -28,13 +27,8 @@ yarn create hono
 </div>
 </SelectableContent>
 
-For detailed instructions refer to the [Hono docs](https://hono.dev/docs/#quick-start).
+For detailed instructions refer to the
+[Hono docs](https://hono.dev/docs/#quick-start).
 
-To install Node.js on your system follow the official [docs](https://nodejs.org/en/download/package-manager).
-
-
-
-
-
-
-
+To install Node.js on your system follow the official
+[docs](https://nodejs.org/en/download/package-manager).

--- a/src/snippets/get-started/node-js-hono/Step2.mdx
+++ b/src/snippets/get-started/node-js-hono/Step2.mdx
@@ -10,11 +10,9 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since Node.js doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV`
-in your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since Node.js doesn't set `NODE_ENV` for you, you also
+need to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept
+a local IP address for development purposes. :::
 
 Next you need to update the dev command in your `package.json` to use the
 `.env.local` file.

--- a/src/snippets/get-started/node-js/Step0.mdx
+++ b/src/snippets/get-started/node-js/Step0.mdx
@@ -1,4 +1,2 @@
 {/* prettier-ignore */}
-
 To install Node.js on your system follow the official [docs](https://nodejs.org/en/download/package-manager).
-

--- a/src/snippets/get-started/node-js/Step2.mdx
+++ b/src/snippets/get-started/node-js/Step2.mdx
@@ -8,7 +8,6 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since Node.js doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since Node.js doesn't set `NODE_ENV` for you, you also
+need to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept
+a local IP address for development purposes. :::

--- a/src/snippets/get-started/remix/Step0.mdx
+++ b/src/snippets/get-started/remix/Step0.mdx
@@ -1,9 +1,9 @@
 {/* prettier-ignore */}
-
 To create a Remix project:
 
 ```sh
 npx create-remix@latest
 ```
-For detailed instructions refer to the [Remix docs](https://remix.run/docs/en/main/start/quickstart#installation).
 
+For detailed instructions refer to the
+[Remix docs](https://remix.run/docs/en/main/start/quickstart#installation).

--- a/src/snippets/get-started/sveltekit/Step0.mdx
+++ b/src/snippets/get-started/sveltekit/Step0.mdx
@@ -1,9 +1,9 @@
 {/* prettier-ignore */}
-
 To create a SvelteKit project:
 
 ```sh
 npx sv create my-app
 ```
-For detailed instructions refer to the [SvelteKit docs](https://svelte.dev/docs/kit/creating-a-project).
 
+For detailed instructions refer to the
+[SvelteKit docs](https://svelte.dev/docs/kit/creating-a-project).

--- a/src/snippets/nosecone/quick-start/next-js/Step2.mdx
+++ b/src/snippets/nosecone/quick-start/next-js/Step2.mdx
@@ -26,9 +26,9 @@ Nosecone will run on every route. This ensures the headers are applied to all
 requests.
 
 You also need to opt-out of static generation in your application. See the
-`@nosecone/next` [reference
-guide](/nosecone/reference#nextjs-security-headers-middleware) for more details
-about this requirement.
+`@nosecone/next`
+[reference guide](/nosecone/reference#nextjs-security-headers-middleware) for
+more details about this requirement.
 
 To opt-out of static generation, modify your layout file with the following:
 

--- a/src/snippets/nosecone/quick-start/sveltekit/Step2Config.js
+++ b/src/snippets/nosecone/quick-start/sveltekit/Step2Config.js
@@ -1,6 +1,6 @@
 import adapter from "@sveltejs/adapter-auto";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
-import { csp } from "@nosecone/sveltekit"
+import { csp } from "@nosecone/sveltekit";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {

--- a/src/snippets/nosecone/reference/next-js/Middleware.mdx
+++ b/src/snippets/nosecone/reference/next-js/Middleware.mdx
@@ -13,7 +13,5 @@ import MiddlewareJS from "./Middleware.js?raw";
   </div>
 </SelectableContent>
 
-:::note
-We recommend you remove any `export const config = ...` from your middleware so
-Nosecone will run on every route.
-:::
+:::note We recommend you remove any `export const config = ...` from your
+middleware so Nosecone will run on every route. :::

--- a/src/snippets/nosecone/reference/next-js/StaticOptOut.mdx
+++ b/src/snippets/nosecone/reference/next-js/StaticOptOut.mdx
@@ -41,7 +41,5 @@ import LayoutNoCacheJS from "./LayoutNoCache.js?raw";
   </div>
 </SelectableContent>
 
-:::caution
-If you cannot opt-out of static generation, you will need to remove the
-`nonce()` function from the provided defaults.
-:::
+:::caution If you cannot opt-out of static generation, you will need to remove
+the `nonce()` function from the provided defaults. :::

--- a/src/snippets/nosecone/reference/sveltekit/Config.js
+++ b/src/snippets/nosecone/reference/sveltekit/Config.js
@@ -1,6 +1,6 @@
 import adapter from "@sveltejs/adapter-auto";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
-import { csp } from "@nosecone/sveltekit"
+import { csp } from "@nosecone/sveltekit";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {

--- a/src/snippets/rate-limiting/quick-start/bun/Step1.mdx
+++ b/src/snippets/rate-limiting/quick-start/bun/Step1.mdx
@@ -11,10 +11,8 @@ bun add @arcjet/bun @arcjet/inspect
 </div>
 </SelectableContent>
 
-:::note
-Our `@arcjet/bun` package is built for
-Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
-on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
-(uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](/rate-limiting/quick-start?f=node-js).
-:::
+:::note Our `@arcjet/bun` package is built for Bun's
+[HTTP server](https://bun.sh/docs/api/http). If your application relies on Bun's
+[Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis) (uses
+`node:http` or a Node.js framework like express) you should instead follow
+[our guide for Node.js](/rate-limiting/quick-start?f=node-js). :::

--- a/src/snippets/rate-limiting/quick-start/bun/Step2.mdx
+++ b/src/snippets/rate-limiting/quick-start/bun/Step2.mdx
@@ -8,8 +8,6 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since Bun doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV` in
-your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since Bun doesn't set `NODE_ENV` for you, you also need
+to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept a
+local IP address for development purposes. :::

--- a/src/snippets/rate-limiting/quick-start/nestjs/Step2.mdx
+++ b/src/snippets/rate-limiting/quick-start/nestjs/Step2.mdx
@@ -8,8 +8,6 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since NestJS doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV`
-in your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since NestJS doesn't set `NODE_ENV` for you, you also
+need to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept
+a local IP address for development purposes. :::

--- a/src/snippets/rate-limiting/quick-start/nodejs/Step2.mdx
+++ b/src/snippets/rate-limiting/quick-start/nodejs/Step2.mdx
@@ -8,8 +8,6 @@ ARCJET_ENV=development
 ARCJET_KEY=ajkey_yourkey
 ```
 
-:::caution[IP Address]
-Since Node.js doesn't set `NODE_ENV` for you, you also need to set `ARCJET_ENV`
-in your environment file. This allows Arcjet to accept a local IP address for
-development purposes.
-:::
+:::caution[IP Address] Since Node.js doesn't set `NODE_ENV` for you, you also
+need to set `ARCJET_ENV` in your environment file. This allows Arcjet to accept
+a local IP address for development purposes. :::

--- a/src/snippets/rate-limiting/reference/nestjs/DecoratorRoutes.mdx
+++ b/src/snippets/rate-limiting/reference/nestjs/DecoratorRoutes.mdx
@@ -40,8 +40,8 @@ with Arcjet.
 ### Per route guard
 
 A per route guard can be configured in the controller for each route you wish to
-protect with specific Arcjet rules. The client created in `src/app.module.ts`
-is automatically passed to the guard.
+protect with specific Arcjet rules. The client created in `src/app.module.ts` is
+automatically passed to the guard.
 
 The rules will be applied and a generic error returned if the result is `DENY`.
 

--- a/src/snippets/rate-limiting/reference/nestjs/Headers.mdx
+++ b/src/snippets/rate-limiting/reference/nestjs/Headers.mdx
@@ -4,9 +4,9 @@ import HeadersTS from "./Headers.ts?raw";
 
 To set the rate limit headers on the NestJS response you need to add the
 `passthrough` option to the `@Res()` decorator in your controller method i.e.
-`@Res({ passthrough: true })`. See [the NestJS docs on the library-specific
-approach](https://docs.nestjs.com/controllers#library-specific-approach) for
-details.
+`@Res({ passthrough: true })`. See
+[the NestJS docs on the library-specific approach](https://docs.nestjs.com/controllers#library-specific-approach)
+for details.
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nextjs/Examples.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/Examples.mdx
@@ -30,8 +30,8 @@ applies a limit of 60 requests per hour per IP address. If the limit is
 exceeded, the client is blocked for 10 minutes before being able to make any
 further requests.
 
-Applying a rate limit by IP address is the default if no
-`characteristics` are specified.
+Applying a rate limit by IP address is the default if no `characteristics` are
+specified.
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">
@@ -101,9 +101,8 @@ track the number of tokens used by a `gpt-3.5-turbo` AI chatbot. It sets a limit
 of `2,000` tokens per hour with a maximum of `5,000` tokens in the bucket. This
 allows for a reasonable conversation length without consuming too many tokens.
 
-See the [arcjet-js GitHub repo](https://github.com/arcjet/arcjet-js) for [a
-full example using
-Next.js](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-openai).
+See the [arcjet-js GitHub repo](https://github.com/arcjet/arcjet-js) for
+[a full example using Next.js](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-openai).
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">
@@ -137,11 +136,9 @@ applies a limit of 60 requests per hour per API key, where the key is provided
 in a custom header called `x-api-key`. If the limit is exceeded, the client is
 blocked for 10 minutes before being able to make any further requests.
 
-:::caution
-If you specify different characteristics and do not include `ip.src`, you may
-inadvertently rate limit everyone. Be sure to include a characteristic which can
-narrowly identify each client, such as an API key as shown here.
-:::
+:::caution If you specify different characteristics and do not include `ip.src`,
+you may inadvertently rate limit everyone. Be sure to include a characteristic
+which can narrowly identify each client, such as an API key as shown here. :::
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
@@ -154,10 +151,8 @@ narrowly identify each client, such as an API key as shown here.
 Using Next.js middleware allows you to set a rate limit that applies to every
 route:
 
-:::note
-Middleware runs on every route so be careful to avoid double
-protection if you are configuring Arcjet directly on other routes.
-:::
+:::note Middleware runs on every route so be careful to avoid double protection
+if you are configuring Arcjet directly on other routes. :::
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">
@@ -195,9 +190,9 @@ requests, but redirect all page route requests to an error page.
 ### Wrap existing handler
 
 All the examples on this page show how you can inspect the decision to control
-what to do next. However, if you just wish to send a generic `429 Too Many
-Requests` response you can delegate this to Arcjet by wrapping your handler
-`withArcjet`.
+what to do next. However, if you just wish to send a generic
+`429 Too Many Requests` response you can delegate this to Arcjet by wrapping
+your handler `withArcjet`.
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS (App)" slotIdx="1">

--- a/src/snippets/rate-limiting/reference/nextjs/PagesServerActions.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/PagesServerActions.mdx
@@ -4,6 +4,6 @@ Arcjet can be used inside Next.js middleware, API routes, pages, server
 components, and server actions. Client components cannot be protected because
 they run on the client only.
 
-See the [Next.js SDK reference](/reference/nextjs) for examples of [pages / page
-components](/reference/nextjs#pages--page-components) and [server
-actions](/reference/nextjs#server-actions).
+See the [Next.js SDK reference](/reference/nextjs) for examples of
+[pages / page components](/reference/nextjs#pages--page-components) and
+[server actions](/reference/nextjs#server-actions).

--- a/src/snippets/rate-limiting/reference/nextjs/PerRouteVsMiddleware.mdx
+++ b/src/snippets/rate-limiting/reference/nextjs/PerRouteVsMiddleware.mdx
@@ -13,14 +13,12 @@ Rate limit rules can be configured in two ways:
   if you want to use the decision to add context to your own code. However, it
   means rules are not located in a single place.
 - **Middleware**: The rule is defined in the middleware. This allows you to
-  configure rules in a single place or apply them globally to all routes, but
-  it means the rules are not located alongside the code they are protecting.
+  configure rules in a single place or apply them globally to all routes, but it
+  means the rules are not located alongside the code they are protecting.
 
-:::note
-If you use a platform that performs health checks or liveness probes, ensure
-that Arcjet is not enabled for those routes. These requests will not have all
-of the metadata that Arcjet requires to make security decisions.
-:::
+:::note If you use a platform that performs health checks or liveness probes,
+ensure that Arcjet is not enabled for those routes. These requests will not have
+all of the metadata that Arcjet requires to make security decisions. :::
 
 ### Per route
 
@@ -47,8 +45,8 @@ You can use conditionals in your Next.js middleware to match multiple paths.
 
 If you use Arcjet in middleware and individual routes, you need to be careful
 that Arcjet is not running multiple times per request. This can be avoided by
-excluding the API route from [the middleware
-matcher](https://nextjs.org/docs/pages/building-your-application/routing/middleware#matcher).
+excluding the API route from
+[the middleware matcher](https://nextjs.org/docs/pages/building-your-application/routing/middleware#matcher).
 
 For example, if you already have a rate limit defined in the API route at
 `/api/hello`, you can exclude it from the middleware by specifying a matcher in

--- a/src/snippets/rate-limiting/reference/remix/LoaderVsAction.mdx
+++ b/src/snippets/rate-limiting/reference/remix/LoaderVsAction.mdx
@@ -6,8 +6,8 @@ import ActionJS from "./Action.js?raw";
 
 ## Loader vs action
 
-Remix does not support middleware, instead [they
-recommend](https://github.com/remix-run/remix/discussions/1432) calling
+Remix does not support middleware, instead
+[they recommend](https://github.com/remix-run/remix/discussions/1432) calling
 functions directly inside the
 [loader](https://remix.run/docs/en/main/route/loader). Loaders execute before
 the page is loaded.

--- a/src/snippets/rate-limiting/reference/sveltekit/PerRouteVsHooks.mdx
+++ b/src/snippets/rate-limiting/reference/sveltekit/PerRouteVsHooks.mdx
@@ -12,9 +12,9 @@ Rate limit rules can be configured in two ways:
   you to configure the rule alongside the code it is protecting which is useful
   if you want to use the decision to add context to your own code. However, it
   means rules are not located in a single place.
-- **Hooks**: The rule is defined as a hook. This allows you to
-  configure rules in a single place or apply them globally to all routes, but
-  it means the rules are not located alongside the code they are protecting.
+- **Hooks**: The rule is defined as a hook. This allows you to configure rules
+  in a single place or apply them globally to all routes, but it means the rules
+  are not located alongside the code they are protecting.
 
 ### Per route
 
@@ -36,8 +36,8 @@ use `event.url.pathname.startsWith`.
 
 ### Avoiding double protection with hooks
 
-If you use Arcjet in hooks and individual routes, you need to be careful
-that Arcjet is not running multiple times per request. This can be avoided by
+If you use Arcjet in hooks and individual routes, you need to be careful that
+Arcjet is not running multiple times per request. This can be avoided by
 excluding the individual routes before running Arcjet in the hook.
 
 For example, if you already have a rule defined in the route at `/api`, you can

--- a/src/snippets/reference/nextjs/ErrorUserAgentApp.js
+++ b/src/snippets/reference/nextjs/ErrorUserAgentApp.js
@@ -28,7 +28,7 @@ export async function GET(req) {
     // See https://docs.arcjet.com/bot-protection/concepts#user-agent-header
     console.warn("User-Agent header is missing");
 
-    return NextResponse.json({ error: "Bad request", }, { status: 400 });
+    return NextResponse.json({ error: "Bad request" }, { status: 400 });
   }
 
   return NextResponse.json({ message: "Hello world" });

--- a/src/snippets/reference/node-versions.mdx
+++ b/src/snippets/reference/node-versions.mdx
@@ -1,5 +1,6 @@
-Arcjet supports the [active and maintenance LTS
-versions](https://github.com/nodejs/release) of Node.js 20 or later.
+Arcjet supports the
+[active and maintenance LTS versions](https://github.com/nodejs/release) of
+Node.js 20 or later.
 
 When a Node.js version goes end of life, we will bump the major version of the
 Arcjet SDK. [Technical support](/support) is provided for the current major

--- a/src/snippets/reference/shared/IPAnalysis.mdx
+++ b/src/snippets/reference/shared/IPAnalysis.mdx
@@ -12,7 +12,8 @@ The following are available on the <Badge text="Free" variant="caution" /> plan:
   address.
 
 {/* prettier-ignore */}
-The following are available on the <Badge text="Starter" variant="note" /> and <Badge text="Business" variant="tip" /> plans:
+The following are available on the <Badge text="Starter" variant="note" />
+and <Badge text="Business" variant="tip" /> plans:
 
 - `latitude` (`number | undefined`): the latitude of the client IP address.
 - `longitude` (`number | undefined`): the longitude of the client IP address.
@@ -67,7 +68,9 @@ The IP AS fields may be `undefined`, but you can use the `hasASN()` method to
 check their availability. Using this method will also refine the type to remove
 the need for null-ish checks.
 
-The following are available on the <Badge text="Starter" variant="note" /> and <Badge text="Business" variant="tip" /> plans:
+The following are available on the <Badge text="Starter" variant="note" /> and
+
+<Badge text="Business" variant="tip" /> plans:
 
 - `hasASN()` (`bool`): returns whether all of the ASN fields are available.
 - `asn` (`string | undefined`): the autonomous system (AS) number of the client

--- a/src/snippets/sensitive-info/quick-start/bun/Step1.mdx
+++ b/src/snippets/sensitive-info/quick-start/bun/Step1.mdx
@@ -11,10 +11,8 @@ bun add @arcjet/bun @arcjet/inspect
 </div>
 </SelectableContent>
 
-:::note
-Our `@arcjet/bun` package is built for
-Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
-on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
-(uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](/sensitive-info/quick-start?f=node-js).
-:::
+:::note Our `@arcjet/bun` package is built for Bun's
+[HTTP server](https://bun.sh/docs/api/http). If your application relies on Bun's
+[Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis) (uses
+`node:http` or a Node.js framework like express) you should instead follow
+[our guide for Node.js](/sensitive-info/quick-start?f=node-js). :::

--- a/src/snippets/sensitive-info/quick-start/nestjs/Step3.mdx
+++ b/src/snippets/sensitive-info/quick-start/nestjs/Step3.mdx
@@ -5,9 +5,10 @@ import SelectableContent from "@/components/SelectableContent";
 
 This creates a global [guard](https://docs.nestjs.com/guards) that will be
 applied to all routes. In a real application, implementing guards or per-route
-protections would give you more flexibility. See the [reference
-guide](/sensitive-info/reference) and the [NestJS example
-app](https://github.com/arcjet/example-nestjs) for how to do this.
+protections would give you more flexibility. See the
+[reference guide](/sensitive-info/reference) and the
+[NestJS example app](https://github.com/arcjet/example-nestjs) for how to do
+this.
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/sensitive-info/reference/nestjs/DecoratorRoutes.mdx
+++ b/src/snippets/sensitive-info/reference/nestjs/DecoratorRoutes.mdx
@@ -40,8 +40,8 @@ with Arcjet.
 ### Per route guard
 
 A per route guard can be configured in the controller for each route you wish to
-protect with specific Arcjet rules. The client created in `src/app.module.ts`
-is automatically passed to the guard.
+protect with specific Arcjet rules. The client created in `src/app.module.ts` is
+automatically passed to the guard.
 
 The rules will be applied and a generic error returned if the result is `DENY`.
 

--- a/src/snippets/sensitive-info/reference/nextjs/Middleware.mdx
+++ b/src/snippets/sensitive-info/reference/nextjs/Middleware.mdx
@@ -31,8 +31,8 @@ import MiddlewareMatcher from "./MiddlewareMatcher.ts?raw";
 
 If you use Arcjet in middleware and individual routes, you need to be careful
 that Arcjet is not running multiple times per request. This can be avoided by
-excluding the API route from [the middleware
-matcher](https://nextjs.org/docs/pages/building-your-application/routing/middleware#matcher).
+excluding the API route from
+[the middleware matcher](https://nextjs.org/docs/pages/building-your-application/routing/middleware#matcher).
 
 For example, if you already have a sensitive info rule defined in the API route
 at `/api/hello`, you can exclude it from the middleware by specifying a matcher

--- a/src/snippets/sensitive-info/reference/nextjs/PagesServerActions.mdx
+++ b/src/snippets/sensitive-info/reference/nextjs/PagesServerActions.mdx
@@ -4,6 +4,6 @@ Arcjet can be used inside Next.js middleware, API routes, pages, server
 components, and server actions. Client components cannot be protected because
 they run on the client only.
 
-See the [Next.js SDK reference](/reference/nextjs) for examples of [pages / page
-components](/reference/nextjs#pages--page-components) and [server
-actions](/reference/nextjs#server-actions).
+See the [Next.js SDK reference](/reference/nextjs) for examples of
+[pages / page components](/reference/nextjs#pages--page-components) and
+[server actions](/reference/nextjs#server-actions).

--- a/src/snippets/sensitive-info/reference/nextjs/PerRouteVsMiddleware.mdx
+++ b/src/snippets/sensitive-info/reference/nextjs/PerRouteVsMiddleware.mdx
@@ -12,8 +12,8 @@ Bot protection rules can be configured in two ways:
   if you want to use the decision to add context to your own code. However, it
   means rules are not located in a single place.
 - **Middleware**: The rule is defined in the middleware. This allows you to
-  configure rules in a single place or apply them globally to all routes, but
-  it means the rules are not located alongside the code they are protecting.
+  configure rules in a single place or apply them globally to all routes, but it
+  means the rules are not located alongside the code they are protecting.
 
 ### Per route
 

--- a/src/snippets/sensitive-info/reference/nodejs/PagesServerActions.mdx
+++ b/src/snippets/sensitive-info/reference/nodejs/PagesServerActions.mdx
@@ -4,6 +4,6 @@ Arcjet can be used inside Next.js middleware, API routes, pages, server
 components, and server actions. Client components cannot be protected because
 they run on the client only.
 
-See the [Next.js SDK reference](/reference/nextjs) for examples of [pages / page
-components](/reference/nextjs#pages--page-components) and [server
-actions](/reference/nextjs#server-actions).
+See the [Next.js SDK reference](/reference/nextjs) for examples of
+[pages / page components](/reference/nextjs#pages--page-components) and
+[server actions](/reference/nextjs#server-actions).

--- a/src/snippets/sensitive-info/reference/remix/PagesServerActions.mdx
+++ b/src/snippets/sensitive-info/reference/remix/PagesServerActions.mdx
@@ -4,6 +4,6 @@ Arcjet can be used inside Next.js middleware, API routes, pages, server
 components, and server actions. Client components cannot be protected because
 they run on the client only.
 
-See the [Next.js SDK reference](/reference/nextjs) for examples of [pages / page
-components](/reference/nextjs#pages--page-components) and [server
-actions](/reference/nextjs#server-actions).
+See the [Next.js SDK reference](/reference/nextjs) for examples of
+[pages / page components](/reference/nextjs#pages--page-components) and
+[server actions](/reference/nextjs#server-actions).

--- a/src/snippets/sensitive-info/reference/sveltekit/PagesServerActions.mdx
+++ b/src/snippets/sensitive-info/reference/sveltekit/PagesServerActions.mdx
@@ -4,6 +4,6 @@ Arcjet can be used inside Next.js middleware, API routes, pages, server
 components, and server actions. Client components cannot be protected because
 they run on the client only.
 
-See the [Next.js SDK reference](/reference/nextjs) for examples of [pages / page
-components](/reference/nextjs#pages--page-components) and [server
-actions](/reference/nextjs#server-actions).
+See the [Next.js SDK reference](/reference/nextjs) for examples of
+[pages / page components](/reference/nextjs#pages--page-components) and
+[server actions](/reference/nextjs#server-actions).

--- a/src/snippets/sensitive-info/reference/sveltekit/PerRouteVsHooks.mdx
+++ b/src/snippets/sensitive-info/reference/sveltekit/PerRouteVsHooks.mdx
@@ -13,9 +13,9 @@ Bot protection rules can be configured in two ways:
   you to configure the rule alongside the code it is protecting which is useful
   if you want to use the decision to add context to your own code. However, it
   means rules are not located in a single place.
-- **Hooks**: The rule is defined as a hook. This allows you to
-  configure rules in a single place or apply them globally to all routes, but
-  it means the rules are not located alongside the code they are protecting.
+- **Hooks**: The rule is defined as a hook. This allows you to configure rules
+  in a single place or apply them globally to all routes, but it means the rules
+  are not located alongside the code they are protecting.
 
 ### Per route
 
@@ -27,8 +27,8 @@ This configures bot protection on a single route.
 
 ### Hooks
 
-This will run on every request to your SvelteKit app - see [the SvelteKit Hooks
-docs](https://kit.svelte.dev/docs/hooks) for details.
+This will run on every request to your SvelteKit app - see
+[the SvelteKit Hooks docs](https://kit.svelte.dev/docs/hooks) for details.
 
 <SlotByFramework client:load>
   <Hooks slot="sveltekit" />
@@ -36,8 +36,8 @@ docs](https://kit.svelte.dev/docs/hooks) for details.
 
 ### Avoiding double protection with hooks
 
-If you use Arcjet in hooks and individual routes, you need to be careful
-that Arcjet is not running multiple times per request. This can be avoided by
+If you use Arcjet in hooks and individual routes, you need to be careful that
+Arcjet is not running multiple times per request. This can be avoided by
 excluding the individual routes before running Arcjet in the hook.
 
 For example, if you already have a sensitive info rule defined in the API route

--- a/src/snippets/shared/astro/Install.mdx
+++ b/src/snippets/shared/astro/Install.mdx
@@ -30,8 +30,9 @@ yarn astro add @arcjet/astro
 </SelectableContent>
 
 This automatically installs and configures the Arcjet Astro integration in your
-project. Learn more about how this works in the [Astro docs](https://docs.astro.build/en/guides/integrations-guide/)
-. Alternatively, you can follow the manual installation instructions.
+project. Learn more about how this works in the
+[Astro docs](https://docs.astro.build/en/guides/integrations-guide/) .
+Alternatively, you can follow the manual installation instructions.
 
 <details>
     <summary>Manual installation instruction</summary>

--- a/src/snippets/shield/quick-start/bun/Step1.mdx
+++ b/src/snippets/shield/quick-start/bun/Step1.mdx
@@ -11,10 +11,8 @@ bun add @arcjet/bun @arcjet/inspect
 </div>
 </SelectableContent>
 
-:::note
-Our `@arcjet/bun` package is built for
-Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
-on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
-(uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](/shield/quick-start?f=node-js).
-:::
+:::note Our `@arcjet/bun` package is built for Bun's
+[HTTP server](https://bun.sh/docs/api/http). If your application relies on Bun's
+[Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis) (uses
+`node:http` or a Node.js framework like express) you should instead follow
+[our guide for Node.js](/shield/quick-start?f=node-js). :::

--- a/src/snippets/shield/quick-start/nestjs/Step3.mdx
+++ b/src/snippets/shield/quick-start/nestjs/Step3.mdx
@@ -5,9 +5,10 @@ import SelectableContent from "@/components/SelectableContent";
 
 This creates a global [guard](https://docs.nestjs.com/guards) that will be
 applied to all routes. In a real application, implementing guards or per-route
-protections would give you more flexibility. See the [reference
-guide](/shield/reference) and the [NestJS example
-app](https://github.com/arcjet/example-nestjs) for how to do this.
+protections would give you more flexibility. See the
+[reference guide](/shield/reference) and the
+[NestJS example app](https://github.com/arcjet/example-nestjs) for how to do
+this.
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/shield/reference/nestjs/DecoratorRoutes.mdx
+++ b/src/snippets/shield/reference/nestjs/DecoratorRoutes.mdx
@@ -43,8 +43,8 @@ with Arcjet.
 ### Per route guard
 
 A per route guard can be configured in the controller for each route you wish to
-protect with specific Arcjet rules. The client created in `src/app.module.ts`
-is automatically passed to the guard.
+protect with specific Arcjet rules. The client created in `src/app.module.ts` is
+automatically passed to the guard.
 
 The rules will be applied and a generic error returned if the result is `DENY`.
 

--- a/src/snippets/shield/reference/nextjs/Middleware.mdx
+++ b/src/snippets/shield/reference/nextjs/Middleware.mdx
@@ -30,11 +30,11 @@ for details).
 
 If you use Arcjet in middleware and individual routes, you need to be careful
 that Arcjet is not running multiple times per request. This can be avoided by
-excluding the API route from [the middleware
-matcher](https://nextjs.org/docs/pages/building-your-application/routing/middleware#matcher).
+excluding the API route from
+[the middleware matcher](https://nextjs.org/docs/pages/building-your-application/routing/middleware#matcher).
 
-For example, if you already have a shield rule defined in the API route
-at `/api/hello`, you can exclude it from the middleware by specifying a matcher
-in `/middleware.ts`:
+For example, if you already have a shield rule defined in the API route at
+`/api/hello`, you can exclude it from the middleware by specifying a matcher in
+`/middleware.ts`:
 
 <Code code={MiddlewareMatcher} lang="ts" title="/middleware.ts" />

--- a/src/snippets/shield/reference/nextjs/PagesServerActions.mdx
+++ b/src/snippets/shield/reference/nextjs/PagesServerActions.mdx
@@ -4,6 +4,6 @@ Arcjet can be used inside Next.js middleware, API routes, pages, server
 components, and server actions. Client components cannot be protected because
 they run on the client only.
 
-See the [Next.js SDK reference](/reference/nextjs) for examples of [pages / page
-components](/reference/nextjs#pages--page-components) and [server
-actions](/reference/nextjs#server-actions).
+See the [Next.js SDK reference](/reference/nextjs) for examples of
+[pages / page components](/reference/nextjs#pages--page-components) and
+[server actions](/reference/nextjs#server-actions).

--- a/src/snippets/shield/reference/nextjs/PerRouteVsMiddleware.mdx
+++ b/src/snippets/shield/reference/nextjs/PerRouteVsMiddleware.mdx
@@ -12,8 +12,8 @@ Shield can be configured in two ways:
   if you want to use the decision to add context to your own code. However, it
   means rules are not located in a single place.
 - **Middleware**: The rule is defined in the middleware. This allows you to
-  configure rules in a single place or apply them globally to all routes, but
-  it means the rules are not located alongside the code they are protecting.
+  configure rules in a single place or apply them globally to all routes, but it
+  means the rules are not located alongside the code they are protecting.
 
 ### Per route
 

--- a/src/snippets/shield/reference/remix/LoaderVsAction.mdx
+++ b/src/snippets/shield/reference/remix/LoaderVsAction.mdx
@@ -6,8 +6,8 @@ import ActionJS from "./Action.js?raw";
 
 ## Loader vs action
 
-Remix does not support middleware, instead [they
-recommend](https://github.com/remix-run/remix/discussions/1432) calling
+Remix does not support middleware, instead
+[they recommend](https://github.com/remix-run/remix/discussions/1432) calling
 functions directly inside the
 [loader](https://remix.run/docs/en/main/route/loader). Loaders execute before
 the page is loaded.

--- a/src/snippets/shield/reference/sveltekit/PerRouteVsHooks.mdx
+++ b/src/snippets/shield/reference/sveltekit/PerRouteVsHooks.mdx
@@ -14,9 +14,9 @@ Bot protection rules can be configured in two ways:
   you to configure the rule alongside the code it is protecting which is useful
   if you want to use the decision to add context to your own code. However, it
   means rules are not located in a single place.
-- **Hooks**: The rule is defined as a hook. This allows you to
-  configure rules in a single place or apply them globally to all routes, but
-  it means the rules are not located alongside the code they are protecting.
+- **Hooks**: The rule is defined as a hook. This allows you to configure rules
+  in a single place or apply them globally to all routes, but it means the rules
+  are not located alongside the code they are protecting.
 
 ### Per route
 
@@ -28,8 +28,8 @@ This configures bot protection on a single route.
 
 ### Hooks
 
-This will run on every request to your SvelteKit app - see [the SvelteKit Hooks
-docs](https://kit.svelte.dev/docs/hooks) for details.
+This will run on every request to your SvelteKit app - see
+[the SvelteKit Hooks docs](https://kit.svelte.dev/docs/hooks) for details.
 
 <SlotByFramework client:load>
   <Hooks slot="sveltekit" />
@@ -37,12 +37,12 @@ docs](https://kit.svelte.dev/docs/hooks) for details.
 
 ### Avoiding double protection with hooks
 
-If you use Arcjet in hooks and individual routes, you need to be careful
-that Arcjet is not running multiple times per request. This can be avoided by
+If you use Arcjet in hooks and individual routes, you need to be careful that
+Arcjet is not running multiple times per request. This can be avoided by
 excluding the individual routes before running Arcjet in the hook.
 
-For example, if you already have a shield rule defined in the API route
-at `/api/arcjet`, you can exclude it from the hook like this:
+For example, if you already have a shield rule defined in the API route at
+`/api/arcjet`, you can exclude it from the hook like this:
 
 <SelectableContent client:load syncKey="language" frameworkSwitcher>
   <div slot="TS" slotIdx="1">

--- a/src/snippets/signup-protection/quick-start/bun/Step1.mdx
+++ b/src/snippets/signup-protection/quick-start/bun/Step1.mdx
@@ -11,10 +11,8 @@ bun add @arcjet/bun @arcjet/inspect
 </div>
 </SelectableContent>
 
-:::note
-Our `@arcjet/bun` package is built for
-Bun's [HTTP server](https://bun.sh/docs/api/http). If your application relies
-on Bun's [Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis)
-(uses `node:http` or a Node.js framework like express) you should instead
-follow [our guide for Node.js](/signup-protection/quick-start?f=node-js).
-:::
+:::note Our `@arcjet/bun` package is built for Bun's
+[HTTP server](https://bun.sh/docs/api/http). If your application relies on Bun's
+[Node.js Compatiblity](https://bun.sh/docs/runtime/nodejs-apis) (uses
+`node:http` or a Node.js framework like express) you should instead follow
+[our guide for Node.js](/signup-protection/quick-start?f=node-js). :::

--- a/src/snippets/signup-protection/reference/nextjs/PagesServerActions.mdx
+++ b/src/snippets/signup-protection/reference/nextjs/PagesServerActions.mdx
@@ -4,6 +4,6 @@ Arcjet can be used inside Next.js middleware, API routes, pages, server
 components, and server actions. Client components cannot be protected because
 they run on the client only.
 
-See the [Next.js SDK reference](/reference/nextjs) for examples of [pages / page
-components](/reference/nextjs#pages--page-components) and [server
-actions](/reference/nextjs#server-actions).
+See the [Next.js SDK reference](/reference/nextjs) for examples of
+[pages / page components](/reference/nextjs#pages--page-components) and
+[server actions](/reference/nextjs#server-actions).

--- a/src/styles/partials/_theme.scss
+++ b/src/styles/partials/_theme.scss
@@ -12,60 +12,68 @@
   --aj-radius-md: 8px;
   --aj-radius-lg: 12px;
   --aj-radius-xl: 16px;
-  --aj-shadow-xs: var(--aj-shadowRing, 0 0 #000),
+  --aj-shadow-xs:
+    var(--aj-shadowRing, 0 0 #000),
     0px 1px 2px 0px
       rgba(var(--aj-shadowChannel, 21 21 21) / var(--aj-shadowOpacity, 0.12));
-  --aj-shadow-sm: var(--aj-shadowRing, 0 0 #000),
-    0px 1px 4px -1px rgba(var(--aj-shadowChannel, 21 21 21) /
-          var(--aj-shadowOpacity, 0.08)),
-    0px 3px 8px -1px rgba(var(--aj-shadowChannel, 21 21 21) /
-          var(--aj-shadowOpacity, 0.08)),
-    0px 7px 16px -2px rgba(var(--aj-shadowChannel, 21 21 21) /
-          var(--aj-shadowOpacity, 0.08));
-  --aj-shadow-md: var(--aj-shadowRing, 0 0 #000),
-    0px 2px 8px -1px rgba(var(--aj-shadowChannel, 21 21 21) /
-          var(--aj-shadowOpacity, 0.08)),
-    0px 6px 16px -2px rgba(var(--aj-shadowChannel, 21 21 21) /
-          var(--aj-shadowOpacity, 0.08)),
-    0px 14px 32px -4px rgba(var(--aj-shadowChannel, 21 21 21) /
-          var(--aj-shadowOpacity, 0.08));
-  --aj-shadow-lg: var(--aj-shadowRing, 0 0 #000),
-    0px 4px 16px -2px rgba(var(--aj-shadowChannel, 21 21 21) /
-          var(--aj-shadowOpacity, 0.08)),
-    0px 12px 32px -4px rgba(var(--aj-shadowChannel, 21 21 21) /
-          var(--aj-shadowOpacity, 0.08)),
-    0px 28px 64px -8px rgba(var(--aj-shadowChannel, 21 21 21) /
-          var(--aj-shadowOpacity, 0.08));
-  --aj-shadow-xl: var(--aj-shadowRing, 0 0 #000),
-    0px 2px 8px -2px rgba(var(--aj-shadowChannel, 21 21 21) /
-          var(--aj-shadowOpacity, 0.12)),
-    0px 20px 24px -4px rgba(var(--aj-shadowChannel, 21 21 21) /
-          var(--aj-shadowOpacity, 0.12));
+  --aj-shadow-sm:
+    var(--aj-shadowRing, 0 0 #000),
+    0px 1px 4px -1px
+      rgba(var(--aj-shadowChannel, 21 21 21) / var(--aj-shadowOpacity, 0.08)),
+    0px 3px 8px -1px
+      rgba(var(--aj-shadowChannel, 21 21 21) / var(--aj-shadowOpacity, 0.08)),
+    0px 7px 16px -2px
+      rgba(var(--aj-shadowChannel, 21 21 21) / var(--aj-shadowOpacity, 0.08));
+  --aj-shadow-md:
+    var(--aj-shadowRing, 0 0 #000),
+    0px 2px 8px -1px
+      rgba(var(--aj-shadowChannel, 21 21 21) / var(--aj-shadowOpacity, 0.08)),
+    0px 6px 16px -2px
+      rgba(var(--aj-shadowChannel, 21 21 21) / var(--aj-shadowOpacity, 0.08)),
+    0px 14px 32px -4px
+      rgba(var(--aj-shadowChannel, 21 21 21) / var(--aj-shadowOpacity, 0.08));
+  --aj-shadow-lg:
+    var(--aj-shadowRing, 0 0 #000),
+    0px 4px 16px -2px
+      rgba(var(--aj-shadowChannel, 21 21 21) / var(--aj-shadowOpacity, 0.08)),
+    0px 12px 32px -4px
+      rgba(var(--aj-shadowChannel, 21 21 21) / var(--aj-shadowOpacity, 0.08)),
+    0px 28px 64px -8px
+      rgba(var(--aj-shadowChannel, 21 21 21) / var(--aj-shadowOpacity, 0.08));
+  --aj-shadow-xl:
+    var(--aj-shadowRing, 0 0 #000),
+    0px 2px 8px -2px
+      rgba(var(--aj-shadowChannel, 21 21 21) / var(--aj-shadowOpacity, 0.12)),
+    0px 20px 24px -4px
+      rgba(var(--aj-shadowChannel, 21 21 21) / var(--aj-shadowOpacity, 0.12));
   --aj-shadow-svgGlowSm: drop-shadow(
       0 1px 2px rgb(var(--aj-palette-glowChannel) / 0.6)
     )
     drop-shadow(0 2px 4px rgb(var(--aj-palette-glowChannel) / 1));
-  --aj-shadow-textGlowSm: 0 1px 2px rgba(var(--aj-palette-glowChannel) / 0.5),
+  --aj-shadow-textGlowSm:
+    0 1px 2px rgba(var(--aj-palette-glowChannel) / 0.5),
     0 2px 8px rgba(var(--aj-palette-glowChannel) / 0.8);
-  --aj-shadow-glowSm: 0 1px 4px rgba(var(--aj-palette-glowChannel) / 0.2),
+  --aj-shadow-glowSm:
+    0 1px 4px rgba(var(--aj-palette-glowChannel) / 0.2),
     0 2px 8px rgba(var(--aj-palette-glowChannel) / 0.3),
     0 4px 12px rgba(var(--aj-palette-glowChannel) / 0.1);
-  --aj-shadow-glowXsm: 0 1px 2px rgba(var(--aj-palette-glowChannel) / 0.1),
+  --aj-shadow-glowXsm:
+    0 1px 2px rgba(var(--aj-palette-glowChannel) / 0.1),
     0 1px 4px rgba(var(--aj-palette-glowChannel) / 0.25),
     0 2px 8px rgba(var(--aj-palette-glowChannel) / 0.05);
   --aj-shadow-svgDangerGlowSm: drop-shadow(
       0 1px 2px rgb(var(--aj-palette-dangerGlowChannel) / 0.6)
     )
     drop-shadow(0 2px 4px rgb(var(--aj-palette-dangerGlowChannel) / 1));
-  --aj-shadow-textDangerGlowSm: 0 1px 2px
-      rgba(var(--aj-palette-dangerGlowChannel) / 0.5),
+  --aj-shadow-textDangerGlowSm:
+    0 1px 2px rgba(var(--aj-palette-dangerGlowChannel) / 0.5),
     0 2px 8px rgba(var(--aj-palette-dangerGlowChannel) / 0.8);
-  --aj-shadow-dangerGlowSm: 0 1px 4px
-      rgba(var(--aj-palette-dangerGlowChannel) / 0.2),
+  --aj-shadow-dangerGlowSm:
+    0 1px 4px rgba(var(--aj-palette-dangerGlowChannel) / 0.2),
     0 2px 8px rgba(var(--aj-palette-dangerGlowChannel) / 0.3),
     0 4px 12px rgba(var(--aj-palette-dangerGlowChannel) / 0.1);
-  --aj-shadow-dangerGlowXsm: 0 1px 2px
-      rgba(var(--aj-palette-dangerGlowChannel) / 0.1),
+  --aj-shadow-dangerGlowXsm:
+    0 1px 2px rgba(var(--aj-palette-dangerGlowChannel) / 0.1),
     0 1px 4px rgba(var(--aj-palette-dangerGlowChannel) / 0.25),
     0 2px 8px rgba(var(--aj-palette-dangerGlowChannel) / 0.05);
   --aj-zIndex-badge: 1;

--- a/src/styles/partials/_vars.scss
+++ b/src/styles/partials/_vars.scss
@@ -155,7 +155,8 @@
   --sl-color-gray-5: var(--aj-palette-source-neutral-04);
   --sl-color-gray-6: var(--aj-palette-source-neutral-02);
   --sl-color-gray-7: var(--aj-palette-source-black);
-  --sl-color-bg: linear-gradient(
+  --sl-color-bg:
+    linear-gradient(
       rgba(var(--aj-palette-source-neutralRgb-00) / 0.4),
       rgba(var(--aj-palette-source-neutralRgb-00) / 0.4)
     ),
@@ -163,7 +164,8 @@
       rgba(var(--aj-palette-source-blackRgb) / 1),
       rgba(var(--aj-palette-source-blackRgb) / 1)
     );
-  --sl-color-bg-sidebar: linear-gradient(
+  --sl-color-bg-sidebar:
+    linear-gradient(
       rgba(var(--aj-palette-source-neutralRgb-00) / 0.4),
       rgba(var(--aj-palette-source-neutralRgb-00) / 0.4)
     ),
@@ -171,7 +173,8 @@
       rgba(var(--aj-palette-source-blackRgb) / 1),
       rgba(var(--aj-palette-source-blackRgb) / 1)
     );
-  --sl-color-bg-nav: linear-gradient(
+  --sl-color-bg-nav:
+    linear-gradient(
       rgba(var(--aj-palette-source-neutralRgb-00) / 0.4),
       rgba(var(--aj-palette-source-neutralRgb-00) / 0.4)
     ),
@@ -205,7 +208,8 @@
   --sl-color-gray-5: var(--aj-palette-source-neutral-11);
   --sl-color-gray-6: var(--aj-palette-source-neutral-15);
   --sl-color-gray-7: var(--aj-palette-source-white);
-  --sl-color-bg: linear-gradient(
+  --sl-color-bg:
+    linear-gradient(
       rgba(var(--aj-palette-source-neutralRgb-15) / 0.4),
       rgba(var(--aj-palette-source-neutralRgb-15) / 0.4)
     ),
@@ -213,7 +217,8 @@
       rgba(var(--aj-palette-source-whiteRgb) / 1),
       rgba(var(--aj-palette-source-whiteRgb) / 1)
     );
-  --sl-color-bg-sidebar: linear-gradient(
+  --sl-color-bg-sidebar:
+    linear-gradient(
       rgba(var(--aj-palette-source-neutralRgb-15) / 0.4),
       rgba(var(--aj-palette-source-neutralRgb-15) / 0.4)
     ),
@@ -221,7 +226,8 @@
       rgba(var(--aj-palette-source-whiteRgb) / 1),
       rgba(var(--aj-palette-source-whiteRgb) / 1)
     );
-  --sl-color-bg-nav: linear-gradient(
+  --sl-color-bg-nav:
+    linear-gradient(
       rgba(var(--aj-palette-source-neutralRgb-15) / 0.4),
       rgba(var(--aj-palette-source-neutralRgb-15) / 0.4)
     ),


### PR DESCRIPTION
https://docs.trunk.io/code-quality/linters/supported/prettier#usage-notes

Let prettier & trunk handle the line wrapping in markdown files. I'd be happy to revert https://github.com/arcjet/arcjet-docs/commit/240031ad8ed9ca42041416a6403a5368dcefb700 here too and do this incrementally if that makes more sense