### PR TITLE
chore: add biome linting to trunk

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.0
+      ref: v1.7.1
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -16,13 +16,32 @@ runtimes:
     - python@3.10.8
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
+  definitions:
+    - name: biome
+      # Configuration needed until Trunk supports Biome 2
+      commands:
+        - name: assist
+          output: rewrite
+          run: biome check --formatter-enabled=false --linter-enabled=false --write ${target}
+          success_codes: [0]
+          batch: true
+          in_place: true
+          allow_empty_files: false
+          cache_results: true
+          formatter: true
+        - name: lint
+          run: biome check --formatter-enabled=false --reporter github --error-on-warnings ${target}
+          parse_regex: ::(?P<severity>note|notice|allow|deny|disabled|error|info|warning)\s+title=(?P<code>[^,]+),file=(?P<path>[^,]+),line=(?P<line>\d+),(?:endLine=\d+,)?col=(?P<col>\d+)(?:,endColumn=\d+)?::(?P<message>.*)\n
+          read_output_from: stdout
   enabled:
+    - biome@2.1.1:
+        commands: [assist, lint]
     - git-diff-check
     - markdownlint@0.45.0
-    - prettier@3.5.3
-    - svgo@3.3.2
-    - trivy@0.63.0
-    - trufflehog@3.89.1
+    - prettier@3.6.2
+    - svgo@4.0.0
+    - trivy@0.64.1
+    - trufflehog@3.90.2
     - yamllint@1.37.1
   disabled:
     - eslint


### PR DESCRIPTION
- update trunk
- add biome to Trunk

I chose biome in lieu of eslint for a few reasons:
- Much smaller dependency footprint
- Import sorting
- No configuration necessary (beyond the Trunk compat I plan to upstream)