### PR TITLE
chore: add deno example to sidebar & drop nextjs-prisma

### DIFF
--- a/src/lib/sidebars.ts
+++ b/src/lib/sidebars.ts
@@ -17,6 +17,11 @@ export const main = [
             attrs: { target: "_blank", class: "external-link" },
           },
           {
+            label: "Deno",
+            link: "https://github.com/arcjet/example-deno",
+            attrs: { target: "_blank", class: "external-link" },
+          },
+          {
             label: "Express.js",
             link: "https://github.com/arcjet/example-expressjs",
             attrs: { target: "_blank", class: "external-link" },
@@ -68,11 +73,6 @@ export const main = [
               {
                 label: "Next.js + Fly.io",
                 link: "https://github.com/arcjet/example-nextjs-fly",
-                attrs: { target: "_blank", class: "external-link" },
-              },
-              {
-                label: "Next.js + Prisma",
-                link: "https://github.com/arcjet/example-nextjs-prisma",
                 attrs: { target: "_blank", class: "external-link" },
               },
               {


### PR DESCRIPTION
[`example-nextjs-prisma`](https://github.com/arcjet/example-nextjs-prisma) was recently archived and [`example-deno`](https://github.com/arcjet/example-deno) was created