### PR TITLE
chore: add initial react-router logo

### DIFF
--- a/src/components/icons/tech/ReactRouter.tsx
+++ b/src/components/icons/tech/ReactRouter.tsx
@@ -1,26 +1,43 @@
 import type { ForwardedRef, HTMLProps } from "react";
 import { forwardRef } from "react";
 
+// Logo source:
+// https://github.com/remix-run/react-router-website/blob/19aa959df6218e68b9b7ac55fd89a2751af46dfa/public/_brand/React%20Router%20Brand%20Assets.zip
+
 export interface Props extends HTMLProps<SVGSVGElement> {}
 
 export const ReactRouter = forwardRef(
-  (props: Props, ref: ForwardedRef<SVGSVGElement>) => {
-    const { className: extraClassNames, ...rest } = props;
-    let className = "aj-Icon aj-Icon-react-router";
-    if (extraClassNames) className += " " + extraClassNames;
-
+  ({ className, ...props }: Props, ref: ForwardedRef<SVGSVGElement>) => {
+    let cls = "aj-Icon aj-Icon-react-router";
+    if (className) cls += " " + className;
     return (
-      // TODO: add actual logo.
       <svg
-        className={className}
-        fill="currentColor"
-        height="128"
         ref={ref}
-        stroke="currentColor"
-        viewBox="0 0 128 128"
+        viewBox="0 0 602 360"
         width="128"
-        {...rest}
-      />
+        height="128"
+        fill="currentColor"
+        stroke="currentColor"
+        className={cls}
+        {...props}
+      >
+        <path
+          d="M480.96 180C480.96 196.572 474.239 211.572 463.357 222.42C452.475 233.28 437.445 240 420.84 240C404.235 240 389.205 246.708 378.335 257.568C367.453 268.428 360.72 283.428 360.72 300C360.72 316.572 353.999 331.572 343.117 342.42C332.235 353.28 317.205 360 300.6 360C283.995 360 268.965 353.28 258.095 342.42C247.213 331.572 240.48 316.572 240.48 300C240.48 283.428 247.213 268.428 258.095 257.568C268.965 246.708 283.995 240 300.6 240C317.205 240 332.235 233.28 343.117 222.42C353.999 211.572 360.72 196.572 360.72 180C360.72 146.856 333.81 120 300.6 120C283.995 120 268.965 113.28 258.095 102.42C247.213 91.572 240.48 76.572 240.48 60C240.48 43.428 247.213 28.428 258.095 17.568C268.965 6.708 283.995 0 300.6 0C333.81 0 360.72 26.856 360.72 60C360.72 76.572 367.453 91.572 378.335 102.42C389.205 113.28 404.235 120 420.84 120C454.05 120 480.96 146.856 480.96 180Z"
+          fill="currentColor"
+        />
+        <path
+          d="M240.48 180C240.48 146.862 213.563 120 180.36 120C147.157 120 120.24 146.862 120.24 180C120.24 213.137 147.157 240 180.36 240C213.563 240 240.48 213.137 240.48 180Z"
+          fill="currentColor"
+        />
+        <path
+          d="M120.24 300C120.24 266.863 93.3234 240 60.12 240C26.9166 240 0 266.863 0 300C0 333.138 26.9166 360 60.12 360C93.3234 360 120.24 333.138 120.24 300Z"
+          fill="currentColor"
+        />
+        <path
+          d="M601.2 300C601.2 266.863 574.283 240 541.08 240C507.877 240 480.96 266.863 480.96 300C480.96 333.138 507.877 360 541.08 360C574.283 360 601.2 333.138 601.2 300Z"
+          fill="currentColor"
+        />
+      </svg>
     );
   },
 );


### PR DESCRIPTION
Quick react-router logo that we can ship this week.

cc @arcjet/design-team - I'm sure you'll have opinions on this 😄 

---

<img width="491" height="344" alt="Screenshot 2025-09-23 at 4 09 36 PM" src="https://github.com/user-attachments/assets/cc262e2e-720e-4889-8bae-6180b45612f9" />
<img width="491" height="344" alt="Screenshot 2025-09-23 at 4 09 43 PM" src="https://github.com/user-attachments/assets/832cdf7d-f3f7-4545-88be-d33f032dd984" />
