### PR TITLE
fix: changelog link in sidebar

### DIFF
--- a/src/lib/sidebars.ts
+++ b/src/lib/sidebars.ts
@@ -341,7 +341,7 @@ export const main = [
           },
           {
             label: "Changelog",
-            link: "https://blog.arcjet.com/tag/changelog/",
+            link: "https://github.com/arcjet/arcjet-js/releases",
             attrs: { target: "_blank", class: "external-link" },
           },
         ],


### PR DESCRIPTION
Sidebar currently, under “Upgrading”, for “Changelog”, links to `https://blog.arcjet.com/tag/changelog/`, which gives a 404. The link on `https://blog.arcjet.com` for Changelog points to `https://github.com/arcjet/arcjet-js/releases`.
To solve this 404, this commit links to that same page too.