### PR TITLE
chore: add example-react-router to sidebar

### DIFF
--- a/src/lib/sidebars.ts
+++ b/src/lib/sidebars.ts
@@ -42,6 +42,11 @@ export const main = [
             attrs: { target: "_blank", class: "external-link" },
           },
           {
+            label: "React Router",
+            link: "https://github.com/arcjet/example-react-router",
+            attrs: { target: "_blank", class: "external-link" },
+          },
+          {
             label: "Remix",
             link: "https://github.com/arcjet/example-remix",
             attrs: { target: "_blank", class: "external-link" },


### PR DESCRIPTION
Add the new https://github.com/arcjet/example-react-router to the docs sidebar.