### PR TITLE
docs(filters): include filters in existing blueprints

### DIFF
--- a/src/content/docs/blueprints/ip-geolocation.mdx
+++ b/src/content/docs/blueprints/ip-geolocation.mdx
@@ -1,27 +1,34 @@
 ---
-title: "Arcjet IP geolocation"
+title: "IP geolocation"
 description: "Use Arcjet's IP analysis to customize the response based on the IP location."
 ---
 
 import { Aside, Badge } from "@astrojs/starlight/components";
 
-Every decision provided by Arcjet includes IP address analysis. You can use this
-to customize your response based on the IP location.
+Arcjet provides IP geolocation information in two places:
+
+- Decisions from Arcjet include IP address analysis.
+  You can use this to customize responses.
+- [Filter rules](/filters/quick-start) have access to IP address analysis.
+  You can use this to block traffic.
 
 ## Available fields
 
-Availability of these fields depends on your pricing plan:
+| Filters                  | Decision            | <Badge text="Free" variant="caution" /> | <Badge text="Starter" variant="note" /> | <Badge text="Business" variant="tip" /> |
+| ------------------------ | ------------------- | --------------------------------------- | --------------------------------------- | --------------------------------------- |
+| `ip.src.accuracy_radius` | `ip.accuracyRadius` | No                                      | Yes                                     | Yes                                     |
+| `ip.src.city`            | `ip.city`           | No                                      | Yes                                     | Yes                                     |
+| `ip.src.continent.name`  | `ip.continentName`  | No                                      | Yes                                     | Yes                                     |
+| `ip.src.continent`       | `ip.continent`      | No                                      | Yes                                     | Yes                                     |
+| `ip.src.country.name`    | `ip.countryName`    | Yes                                     | Yes                                     | Yes                                     |
+| `ip.src.country`         | `ip.country`        | Yes                                     | Yes                                     | Yes                                     |
+| `ip.src.lat`             | `ip.latitude`       | No                                      | Yes                                     | Yes                                     |
+| `ip.src.lon`             | `ip.longitude`      | No                                      | Yes                                     | Yes                                     |
+| `ip.src.postal_code`     | `ip.postalCode`     | No                                      | Yes                                     | Yes                                     |
+| `ip.src.region`          | `ip.region`         | No                                      | Yes                                     | Yes                                     |
+| `ip.src.timezone.name`   | `ip.timezone`       | ??                                      | ???                                     | ???                                     |
 
-| Data Type              | Example                  | Plan availability                                                                                                       |
-| ---------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| Latitude and longitude | `37.36883`, `-122.03635` | <Badge text="Starter" variant="note" /> <Badge text="Business" variant="tip" />                                         |
-| Postal code            | `94104`                  | <Badge text="Starter" variant="note" /> <Badge text="Business" variant="tip" />                                         |
-| City                   | `San Francisco`          | <Badge text="Starter" variant="note" /> <Badge text="Business" variant="tip" />                                         |
-| Region                 | `California`             | <Badge text="Starter" variant="note" /> <Badge text="Business" variant="tip" />                                         |
-| Country                | `US`                     | <Badge text="Free" variant="caution" /> <Badge text="Starter" variant="note" /> <Badge text="Business" variant="tip" /> |
-| Country name           | `United States`          | <Badge text="Free" variant="caution" /> <Badge text="Starter" variant="note" /> <Badge text="Business" variant="tip" /> |
-| Continent              | `NA`                     | <Badge text="Starter" variant="note" /> <Badge text="Business" variant="tip" />                                         |
-| Continent name         | `North America`          | <Badge text="Starter" variant="note" /> <Badge text="Business" variant="tip" />                                         |
+TODO: where is `timezone` available?
 
 <Aside type="caution">
   IP geolocation can be notoriously inaccurate, especially for mobile devices,
@@ -35,9 +42,7 @@ Availability of these fields depends on your pricing plan:
 ## Checking for data
 
 The IP location fields may be `undefined`, but you can use various methods to
-check their availability. See the SDK reference for details.
-
-## Examples
+check their availability:
 
 ```ts
 // ... imports, client configuration, etc
@@ -61,29 +66,86 @@ if (decision.ip.hasContinent() && decision.ip.continent === "NA") {
 }
 ```
 
+## Examples
+
 ### Block all countries except US
 
+Filter rules can be used to block traffic based on IP geolocation:
+
 ```ts
-// ... imports, client configuration, etc
-// See https://docs.arcjet.com/get-started
+// …
+rules: [
+  filter({
+    allow: ['ip.src.country eq "US"'],
+    mode: "LIVE",
+  })
+],
+
+// …
+
 const decision = await aj.protect(req);
 
-if (decision.ip.hasCountry() && decision.ip.country !== "US") {
+if (decision.isDenied()) {
   // Return 403 Forbidden
 }
 ```
 
-### Block all countries except US, UK, Japan
+### Customize response for US
+
+The `ip` field on a `decision` can be used to customize the response based on IP
+geolocation:
 
 ```ts
-// ... imports, client configuration, etc
-// See https://docs.arcjet.com/get-started
+// …
 const decision = await aj.protect(req);
 
-if (
-  decision.ip.hasCountry() &&
-  !["US", "UK", "JP"].includes(decision.ip.country)
-) {
+if (decision.isDenied()) {
+  // Handle your other configured rules here.
+}
+
+// Otherwise, customize for US:
+if (decision.ip.country === "US") {
+  return new Response("Hello, US visitor!");
+}
+```
+
+### Block all regions except California
+
+Filter rules can be used to block traffic based on IP geolocation:
+
+```ts
+// …
+rules: [
+  filter({
+    allow: ['ip.src.country eq "US" and ip.src.region eq "California"'],
+    mode: "LIVE",
+  })
+],
+
+// …
+
+const decision = await aj.protect(req);
+
+if (decision.isDenied()) {
   // Return 403 Forbidden
+}
+```
+
+### Customize response for California
+
+The `ip` field on a `decision` can be used to customize the response based on IP
+geolocation:
+
+```ts
+// …
+const decision = await aj.protect(req);
+
+if (decision.isDenied()) {
+  // Handle your other configured rules here.
+}
+
+// Otherwise, customize for California:
+if (decision.ip.country === "US" && decision.ip.region === "California") {
+  return new Response("Go California!");
 }
 ```

--- a/src/content/docs/blueprints/vpn-proxy-detection.mdx
+++ b/src/content/docs/blueprints/vpn-proxy-detection.mdx
@@ -5,26 +5,43 @@ description: "Use Arcjet's IP analysis to detect VPNs and proxies."
 
 import { Aside, Badge } from "@astrojs/starlight/components";
 
-Every decision provided by Arcjet includes IP address analysis. You can use this
-to detect VPNs and proxies.
+Arcjet provides IP reputation information in two places:
 
-## Available fields
+- Decisions from Arcjet include IP address analysis.
+  You can use this to customize responses.
+- [Filter rules](/filters/quick-start) have access to IP address analysis.
+  You can use this to block traffic.
+
+## Available data
 
 - **IP AS type.** This is the [Autonomous
   System](<https://en.wikipedia.org/wiki/Autonomous_system_(Internet)>)
   associated with the IP, which can be used to identify VPNs and proxies. This
-  can be one of `isp`, `hosting`, `business` or `education`. This field is only
-  available on <Badge text="Starter" variant="note" /> and <Badge text="Business" variant="tip" /> plans.
+  can be one of `isp`, `hosting`, `business` or `education`.
 - **IP type.** Arcjet adds one or more categories to the IP address to help you
   identify VPNs and proxies. The categories are `vpn`, `proxy`, `tor`,
-  `hosting`, `relay`. This field is available on all pricing plans.
+  `hosting`, `relay`.
+
+## Available fields
+
+| Filters                | Decision         | <Badge text="Free" variant="caution" /> | <Badge text="Starter" variant="note" /> | <Badge text="Business" variant="tip" /> |
+| ---------------------- | ---------------- | --------------------------------------- | --------------------------------------- | --------------------------------------- |
+| `ip.src.asnum.country` | `ip.asnCountry`  | No                                      | Yes                                     | Yes                                     |
+| `ip.src.asnum.domain`  | `ip.asnDomain`   | No                                      | Yes                                     | Yes                                     |
+| `ip.src.asnum.name`    | `ip.asnName`     | No                                      | Yes                                     | Yes                                     |
+| `ip.src.asnum.type`    | `ip.asnType`     | No                                      | Yes                                     | Yes                                     |
+| `ip.src.asnum`         | `ip.asn`         | No                                      | Yes                                     | Yes                                     |
+| `ip.src.hosting`       | `ip.isHosting()` | Yes                                     | Yes                                     | Yes                                     |
+| `ip.src.proxy`         | `ip.isProxy()`   | Yes                                     | Yes                                     | Yes                                     |
+| `ip.src.relay`         | `ip.isRelay()`   | Yes                                     | Yes                                     | Yes                                     |
+| `ip.src.service`       | `ip.service`     | Yes                                     | Yes                                     | Yes                                     |
+| `ip.src.tor`           | `ip.isTor()`     | Yes                                     | Yes                                     | Yes                                     |
+| `ip.src.vpn`           | `ip.isVpn()`     | Yes                                     | Yes                                     | Yes                                     |
 
 ## Checking for data
 
 The IP analysis fields may be `undefined`, but you can use various methods to
 check their availability. See the SDK reference for details.
-
-## Example
 
 ```ts
 // ... imports, client configuration, etc
@@ -38,11 +55,12 @@ if (decision.ip.hasASN() && decision.ip.asnType === "hosting") {
 
 if (
   decision.ip.isHosting() ||
-  decision.ip.isVpn() ||
   decision.ip.isProxy() ||
-  decision.ip.isRelay()
+  decision.ip.isRelay() ||
+  decision.ip.isTor() ||
+  decision.ip.isVpn()
 ) {
-  // The IP is from a hosting provider, VPN, or proxy. We can check the name
+  // The IP is from a hosting provider, proxy, relay, Tor, or VPN. We can check the name
   // of the service and customize the response
   if (decision.ip.hasService()) {
     if (decision.ip.service === "Apple Private Relay") {
@@ -54,5 +72,48 @@ if (
   } else {
     // The service name is not available, but we can still do something here
   }
+}
+```
+
+## Examples
+
+### Block VPN traffic
+
+Filter rules can be used to block traffic based on IP reputation:
+
+```ts
+// …
+rules: [
+  filter({
+    deny: ['ip.src.vpn'],
+    mode: "LIVE",
+  })
+],
+
+// …
+
+const decision = await aj.protect(req);
+
+if (decision.isDenied()) {
+  // Return 403 Forbidden
+}
+```
+
+### Customize response for Apple Private Relay
+
+The `ip` field on a `decision` can be used to customize the response based on IP
+reputation:
+
+```ts
+// …
+const decision = await aj.protect(req);
+
+if (decision.isDenied()) {
+  // Handle your other configured rules here.
+}
+
+// Otherwise, customize for Apple Private Relay:
+if (decision.ip.service === "Apple Private Relay") {
+  return new Response("Hello, Apple Private Relay user!");
 }
 ```


### PR DESCRIPTION
This adds filters to the 2 blueprints that talk about info based on IPs.
The IP geolocation blueprint already talked about blocking things: with filters that can now happen *inside* a rule. That leaves IP info on `decision` for more *customizing responses*.

(Important note btw is that `decision` IP info is not available on a local DENY, as those never hit the server)

Important Q: where is `timezone` available? On Free? Just on starter/business?

Related-to: GH-645.
