### PR TITLE
docs(signup-protection): fix typo

### DIFF
--- a/src/content/docs/signup-protection/reference.mdx
+++ b/src/content/docs/signup-protection/reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Signup from protection reference"
+title: "Signup form protection reference"
 description: "Reference guide for adding Arcjet email validation to your Next.js, Node.js, Bun, Remix, or SvelteKit app."
 frameworks:
   - bun


### PR DESCRIPTION
I also <kbd>cmd+f</kbd>d and could not find similar typos