### PR TITLE
docs(signup-protection): fix wrong type

### DIFF
--- a/src/content/docs/signup-protection/reference.mdx
+++ b/src/content/docs/signup-protection/reference.mdx
@@ -101,7 +101,7 @@ The configuration definition is:
 
 ```ts
 interface ProtectSignupOptions {
-  bots?: BotOptionsAllow | BotOptionsDeny;
+  bots?: BotOptions;
   email?: EmailOptions;
   rateLimit?: SlidingWindowRateLimitOptions;
 }


### PR DESCRIPTION
No arrays of options are supported.

Note: not sure why `BotOptions` is expanded to allow and deny, but `EmailOptions` is not expanded?
Probably good to be consistent? Which one should it be?

I also checked `DisplayType`, which would automatically be in sync but is very verbose.
That does not work because it *requires* a type parameter, and thus crashes.
We can also make type parameters optional, in `arcjet/arcjet-js`.
And we can perhaps add support for displaying required type parameters, here in `arcjet-docs`.