### PR TITLE
docs(filters): add field availability grid

### DIFF
--- a/src/content/docs/filters/reference.mdx
+++ b/src/content/docs/filters/reference.mdx
@@ -38,6 +38,7 @@ ajToc:
     anchor: "limitations"
 ---
 
+import { Badge } from "@astrojs/starlight/components";
 import FrameworkLinks from "@/components/FrameworkLinks";
 import DisplayType from "@/components/DisplayType.astro";
 import SlotByFramework from "@/components/SlotByFramework";


### PR DESCRIPTION
This commits adds a matrix of fields to pricing plans showing what is available where.
The table contains two existing tables:

* https://github.com/arcjet/arcjet-docs/blob/main/src/content/docs/blueprints/ip-geolocation.mdx#available-fields
* https://github.com/arcjet/arcjet-docs/blob/main/src/content/docs/blueprints/vpn-proxy-detection.mdx#available-fields

…and also lists the “regular” literal fields which are available everywhere.