### PR TITLE
docs(bots): suggest `filters` to handle missing user agent

### DIFF
--- a/src/content/docs/bot-protection/concepts.mdx
+++ b/src/content/docs/bot-protection/concepts.mdx
@@ -45,22 +45,21 @@ possible to achieve 100% accuracy.
 
 ### `User-Agent` header
 
-Requests without `User-Agent` headers might not be identified as any particular
-bot and could be marked as an errored result.
+Requests without `User-Agent` headers cannot be identified as any particular
+bot and are marked as an errored result.
 
-Our recommendation is to block requests without `User-Agent` headers before
-calling Arcjet because most legitimate clients send this header:
+Most legitimate clients send it because HTTP/1.1 (RFC 7231) says it _should_ be
+sent.
+You can choose to block such requests with an additional
+[filter rule](/filters/quick-start).
 
 ```ts
-if (!request.headers.get("User-Agent")) {
-  log.warn("request missing required user-agent header");
-  // Return a 400 Bad request error here
-  // Next.js example:
-  // return NextResponse.json({ error: "Bad request" }, { status: 400 });
-  // Node.js example:
-  // res.writeHead(400, { "Content-Type": "application/json" });
-  // res.end(JSON.stringify({ error: "Bad request" }));
-}
+filter({
+  // This will deny any traffic that has no user agent:
+  deny: ['len(http.request.headers["user-agent"]) eq 0'],
+  // Block requests with `LIVE`, use `DRY_RUN` to log only.
+  mode: "LIVE",
+}),
 ```
 
 An alternative approach is to check the rule results using the


### PR DESCRIPTION
This commit “dog-foods” the recent filter feature instead of suggesting to write manual application code.

It also slightly rewords the prose.
Comments welcome on improving that!

(importantly, expand below this PR, as there is an alternative strategy there which supports different things than allow/deny)