### PR TITLE
refactor: consistent sidebar case

### DIFF
--- a/src/lib/sidebars.ts
+++ b/src/lib/sidebars.ts
@@ -168,7 +168,7 @@ export const main = [
             link: "/bot-protection/concepts",
           },
           {
-            label: "Identifying Bots",
+            label: "Identifying bots",
             link: "/bot-protection/identifying-bots",
           },
           {


### PR DESCRIPTION
Sentence case is used everywhere else, this one stuck out to me