### PR TITLE
docs: use `Cloud API` as external name

### DIFF
--- a/src/components/FAQs.astro
+++ b/src/components/FAQs.astro
@@ -13,9 +13,9 @@
     minimize latency for each request. Where decisions can be made locally or
     previous decisions are cached in-memory, latency is usually &lt;1ms.</p>
     
-    <p>When a call to the Arcjet API is required, such as when tracking a 
+    <p>When a call to the Cloud API is required, such as when tracking a
     rate limit in a serverless environment, there is some additional latency
-    before a decision is made. The Arcjet API has been designed for high 
+    before a decision is made. The Cloud API has been designed for high
     performance and low latency, and is deployed to multiple regions around the 
     world. The SDK will automatically use the closest region which means the 
     total overhead is typically no more than 20-30ms, often significantly less.</p>
@@ -27,7 +27,7 @@
     <p>Where a decision has been cached locally e.g. blocking a client, Arcjet 
     will continue to function even if the service is unavailable.</p>
 
-    <p>If a call to the Arcjet API is needed and there is a network problem or 
+    <p>If a call to the Cloud API is needed and there is a network problem or
     Arcjet is unavailable, the default behavior is to fail open and allow 
     the request. You have control over how to handle errors, including choosing 
     to fail close if you prefer. See the reference docs for details.</p>

--- a/src/content/docs/architecture.mdx
+++ b/src/content/docs/architecture.mdx
@@ -85,7 +85,7 @@ In this example flow:
    based on the rules you configured, then decides to allow the request.
 5. Arcjet returns the result and your application code continues to execute as
    normally. You can inspect the decision to understand why Arcjet came to that
-   conclusion. An asynchronous report is made to the Arcjet API for post-request
+   conclusion. An asynchronous report is made to the Cloud API for post-request
    analysis.
 
 <img
@@ -137,14 +137,14 @@ For example:
 ### Arcjet Cloud API
 
 In many cases, Arcjet can make a decision locally and report that decision
-asynchronously to the Arcjet API. However, there are some cases where Arcjet
+asynchronously to the Cloud API. However, there are some cases where Arcjet
 must make a decision in the cloud.
 
 For example, if you are want to enforce a rate limit, the number of requests for
 each client must be tracked. This means you typically need to manage something
 like Redis or another database, something that is particularly tricky in
 serverless environments. If you are using Arcjet, this is managed for you with
-no additional infrastructure. The Arcjet SDK will make a call to the Arcjet API
+no additional infrastructure. The Arcjet SDK will make a call to the Cloud API
 to get the current rate limit for the client.
 
 The API has been designed for high performance and low latency, and combines all
@@ -157,7 +157,7 @@ in-memory cache. In many cases, the total latency will be less than 1ms.
 1. A client makes an HTTP request to your application. It passes through the
    network level DDoS protection as described above then reaches your server.
 2. The Arcjet SDK is configured with a rate limit rule on an API route. The SDK
-   passes the request context through to the Arcjet API which checks the rate
+   passes the request context through to the Cloud API which checks the rate
    limit for that client and then returns an allow decision.
 3. The SDK returns the details and your application code continues to execute as
    normal.
@@ -179,12 +179,12 @@ This time when the request is received, the rate limit has been exceeded.
 
 1. A client makes another request to your application with a rate limit rule
    configured.
-2. As before, the SDK passes the request context through to the Arcjet API which
+2. As before, the SDK passes the request context through to the Cloud API which
    determines the limit has been exceeded.
 3. The SDK provides the details and your application code returns a 429 response
    to the client.
 4. The decision is also cached locally so that subsequent requests which match
-   the rate limit rule does not need to rely on a call to the Arcjet API.
+   the rate limit rule does not need to rely on a call to the Cloud API.
 
 <img
   class="dark"
@@ -213,7 +213,7 @@ the local cache and return the response immediately:
 
 #### When the API is required
 
-A call to the Arcjet API is required when:
+A call to the Cloud API is required when:
 
 - A [shield](/shield/concepts) rule is configured. Behavior must be compared
   across multiple requests to protect against common attacks.
@@ -229,13 +229,13 @@ A call to the Arcjet API is required when:
 - An [email validation](/email-validation/concepts) rule is configured and the
   email address syntax is valid. The Arcjet SDK analyzes the email address
   locally to check the syntax. If it is invalid, the SDK will return a decision
-  immediately. If it is valid, the SDK will make a call to the Arcjet API to
+  immediately. If it is valid, the SDK will make a call to the Cloud API to
   verify the email address e.g. does it have a valid MX record or is it a
   disposable email address.
 - A [filter](/filters/reference) rule is configured that inspects `ip.src.*` IP
   address fields such as `ip.src.vpn`, `ip.src.asnum.domain`, or
   `ip.src.country`. These fields require data from our IP reputation database so
-  a call to the Arcjet API is required. Other fields are analyzed locally.
+  a call to the Cloud API is required. Other fields are analyzed locally.
 
 #### API latency
 
@@ -243,8 +243,8 @@ The Arcjet SDK tries to do as much as possible asynchronously and locally to
 minimize latency for each request. This adds less than 1ms of overhead to a
 typical request.
 
-When a call to the Arcjet API is required there is some additional latency
-before a decision is made. The Arcjet API has been designed for high performance
+When a call to the Cloud API is required there is some additional latency
+before a decision is made. The Cloud API has been designed for high performance
 and low latency, and is deployed to multiple regions around the world. The SDK
 will automatically use the closest region which means the total overhead is
 typically no more than 20-30ms, often significantly less.
@@ -289,7 +289,7 @@ requests are used to inform the decision for the current request.
 2. The request is analyzed by the Arcjet SDK based on the rules you configured.
 3. The SDK returns the result and your application code continues to execute as
    normal.
-4. The result is also reported to the Arcjet API for post-request analysis. This
+4. The result is also reported to the Cloud API for post-request analysis. This
    is used to inform future decisions for that client.
 5. The client makes another request and the result of the post-request analysis
    is used to inform the decision. This will be applied if you have configured a

--- a/src/content/docs/filters/concepts.mdx
+++ b/src/content/docs/filters/concepts.mdx
@@ -46,11 +46,11 @@ modified to support an “undetermined” state for fields that are not availabl
 
 All `ip.src.*` [fields][filters-fields] reflect information about the client
 IP address (the request source IP). These fields require data from our IP
-reputation database so a call to the Arcjet API is required. Other fields are
+reputation database so a call to the Cloud API is required. Other fields are
 analyzed locally.
 
 Arcjet only ever makes a single call to our Cloud API regardless of the rule
-configuration. The Arcjet API has been designed for high performance and low
+configuration. The Cloud API has been designed for high performance and low
 latency, and is deployed to multiple regions around the world. The SDK will
 automatically use the closest region which means the total overhead is typically
 no more than 20-30ms, often significantly less. See the [Architecture

--- a/src/content/docs/filters/reference.mdx
+++ b/src/content/docs/filters/reference.mdx
@@ -253,10 +253,10 @@ filter({
 
 All `ip.src.*` fields reflect information about the client IP address (the
 request source IP). These fields require data from our IP reputation database so
-a call to the Arcjet API is required. Other fields are analyzed locally.
+a call to the Cloud API is required. Other fields are analyzed locally.
 
 Arcjet only ever makes a single call to our Cloud API regardless of the rule
-configuration. The Arcjet API has been designed for high performance and low
+configuration. The Cloud API has been designed for high performance and low
 latency, and is deployed to multiple regions around the world. The SDK will
 automatically use the closest region which means the total overhead is typically
 no more than 20-30ms, often significantly less. See the [Architecture

--- a/src/content/docs/reference/astro.mdx
+++ b/src/content/docs/reference/astro.mdx
@@ -70,7 +70,7 @@ Check out the [quick start guide](/get-started?f=astro).
 
 ## Configuration
 
-Arcjet is configured as an integration in your `astro.config.mjs` file. You will need to add your Arcjet API key as an environment variable and configure the rules you want to apply.
+Arcjet is configured as an integration in your `astro.config.mjs` file. You will need to add your Cloud API key as an environment variable and configure the rules you want to apply.
 
 ### API Key
 

--- a/src/content/docs/reference/nuxt.mdx
+++ b/src/content/docs/reference/nuxt.mdx
@@ -72,7 +72,7 @@ Check out the [quick start guide](/get-started?f=nuxt).
 ## Configuration
 
 Arcjet is configured as an integration in your `nuxt.config.ts` file. You will
-need to add your Arcjet API key as an environment variable and configure the
+need to add your Cloud API key as an environment variable and configure the
 rules you want to apply.
 
 ### API Key

--- a/src/content/docs/regions.mdx
+++ b/src/content/docs/regions.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Arcjet API regions"
-description: "Which cloud regions the Arcjet API is deployed to."
+title: "Arcjet Cloud API regions"
+description: "Which regions the Arcjet Cloud API is deployed to."
 ---
 
 import Comments from "/src/components/Comments.astro";
 
-Arcjet's API minimizes latency by running as close as possible to your
+Arcjet's Cloud API minimizes latency by running as close as possible to your
 application and routing requests based on the lowest latency region.
 
 ## New regions

--- a/src/content/docs/shield/concepts.mdx
+++ b/src/content/docs/shield/concepts.mdx
@@ -85,7 +85,7 @@ developers to build with security in mind without sacrificing usability.
 
 ## How does Arcjet Shield WAF work?
 
-The Arcjet SDK communicates with the Arcjet API on every request as part of
+The Arcjet SDK communicates with the Cloud API on every request as part of
 applying your configured rules. The request ([except the
 body](/limitations#shield-analysis-does-not-use-the-request-body)) is included
 as part of this process and rules are executed based on the request content.

--- a/src/content/docs/troubleshooting.mdx
+++ b/src/content/docs/troubleshooting.mdx
@@ -141,7 +141,7 @@ const aj = arcjet({
 ConnectError: [deadline_exceeded] the operation timed out
 ```
 
-This error means that the Arcjet SDK was unable to connect to the Arcjet API
+This error means that the Arcjet SDK was unable to connect to the Cloud API
 within the short timeout period. This is usually caused by a network issue. The
 SDK is designed to fail open so that in the event of a network problem or
 outage, requests will be allowed.

--- a/src/mermaid/architecture-local-analysis.txt
+++ b/src/mermaid/architecture-local-analysis.txt
@@ -1,6 +1,6 @@
 flowchart TD;
     A[Client] -->|Request| B(Arcjet SDK)
     B --> C{Evaluate Arcjet Rules}
-    C -->|Report| F[✦ Arcjet API]
+    C -->|Report| F[✦ Arcjet Cloud API]
     C -->|Allow| E[Execute application code]
     E -->|200 Response| A[Client]

--- a/src/mermaid/architecture-post-request.txt
+++ b/src/mermaid/architecture-post-request.txt
@@ -1,7 +1,7 @@
 flowchart TD
     A[Client] -->|Request| B(Arcjet SDK)
     B --> C{Evaluate Arcjet Rules}
-    C -->|Rate Limit Rule| D[✦ Arcjet API]
+    C -->|Rate Limit Rule| D[✦ Arcjet Cloud API]
     D -->|Request Context| F{Post-Request
     Analysis}
     F -->|Results|D

--- a/src/mermaid/architecture-rl-allow.txt
+++ b/src/mermaid/architecture-rl-allow.txt
@@ -1,6 +1,6 @@
 flowchart TD
     A[Client] -->|Request| B(Arcjet SDK)
     B --> C{Evaluate Arcjet Rules}
-    C -->|Rate Limit Rule| D[✦ Arcjet API]
+    C -->|Rate Limit Rule| D[✦ Arcjet Cloud API]
     D -->|Allow| E[Execute application code]
     E -->|200 Response| A[Client]

--- a/src/mermaid/architecture-rl-cached.txt
+++ b/src/mermaid/architecture-rl-cached.txt
@@ -1,7 +1,7 @@
 flowchart TD
     A[Client] -->|Request| B(Arcjet SDK)
     B --> C{Evaluate Arcjet Rules}
-    C -->|Rate Limit Rule| D[✦ Arcjet API]
+    C -->|Rate Limit Rule| D[✦ Arcjet Cloud API]
     D -->|Limit exceeded| E[Application constructs response]
     E -. Decision Cached Locally .-> B
     E -->|"429 Too Many Requests Response"| A[Client]

--- a/src/mermaid/architecture-rl-deny.txt
+++ b/src/mermaid/architecture-rl-deny.txt
@@ -1,7 +1,7 @@
 flowchart TD
     A[Client] -->|Request| B(Arcjet SDK)
     B --> C{Evaluate Arcjet Rules}
-    C -->|Report| F[✦ Arcjet API]
+    C -->|Report| F[✦ Arcjet Cloud API]
     C -->|Previous decision
     read from cache| E[Application constructs response]
     E -->|"429 Too Many Requests Response"| A[Client]


### PR DESCRIPTION
This solves what Quinn reported 3 weeks ago: https://github.com/arcjet/arcjet-docs/pull/592#discussion_r2362906695. The external name, according to the glossary, is Cloud API.

I searched for `decide` and `remote` and got no real matches. Searching for `arcjet\s+api` did give a bunch.

In most cases I went `Arcjet API` -> `Cloud API`, the Arcjet is mostly implied.
In some cases I went explicit, `Arcjet Cloud API`. Feel free to suggest changes.

Q (as in general question not quinn specific): how to regenerate mermaid?