### PR TITLE
docs: reframe agent docs around skills-first, align CLI and plugin docs with 1.0.0

### DIFF
--- a/src/content/docs/agent-get-started.mdx
+++ b/src/content/docs/agent-get-started.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Agent get started"
-description: "A step-by-step guide for AI coding agents to set up Arcjet security in any project. Install the plugin, connect via MCP, get your API key, install the SDK, and add protection."
+description: "A step-by-step guide for AI coding agents to set up Arcjet security in any project. Install a skill, connect to the Arcjet API via the CLI or MCP server, and add protection."
 prev: false
 next: false
 ---
 
-import { Aside, Code, TabItem, Tabs } from "@astrojs/starlight/components";
+import { Aside } from "@astrojs/starlight/components";
 import { Link } from "@/components/link";
 
 [Arcjet](https://arcjet.com) is the runtime security platform that ships with your code. Enforce budgets, stop prompt injection, detect bots, and protect personal information with Arcjet's AI security building blocks.
@@ -14,27 +14,41 @@ Arcjet protects two types of entry points:
 - **Request-based** — HTTP route handlers and API endpoints. Use `protect()` with any <Link.Page href="/get-started">supported framework</Link.Page>.
 - **Guards** — tool calls, queue consumers, agentic pipelines, and anywhere else you process untrusted input without an HTTP request. Use `guard()` to pass inputs directly. See <Link.Page href="/guards">Guards</Link.Page>.
 
-Set up Arcjet in two steps: (1) install a skill that gives your agent the
-documentation to integrate the Arcjet SDK, and (2) connect to Arcjet with the
-CLI to create sites, retrieve credentials, and verify decisions.
+The recommended path for an agentic workflow is to install a skill that gives
+your agent the documentation to integrate the Arcjet SDK, then connect to the
+Arcjet API via the <Link.Page href="/cli">CLI</Link.Page> or
+<Link.Page href="/mcp-server">MCP server</Link.Page> to create sites, retrieve
+credentials, and verify decisions.
 
 <Aside type="tip">
   This guide is designed for AI coding agents. If you are a developer, see the
   <Link.Page href="/get-started">quick start guide</Link.Page>.
 </Aside>
 
-## Step 1: Install a skill
+## Skills
 
-Skills give your agent the documentation to detect your framework, install the
-SDK, and wire up protection rules. Install one per use case:
+Skills are the primary entry point for setting up Arcjet in an agentic
+workflow. They give your agent the documentation to detect your framework,
+install the SDK, and wire up protection rules.
 
-**Request protection** (HTTP routes):
+Install the Arcjet skills:
+
 ```bash
-npx skills add arcjet/skills --skill add-request-protection
+npx skills add arcjet/skills
 ```
 
-**Guard protection** (tool calls, MCP servers, queues):
+The two canonical skills are:
+
+- **`add-request-protection`** — protect HTTP routes and API endpoints with
+  rate limiting, bot detection, email validation, and shield.
+- **`add-guard-protection`** — protect non-HTTP code paths (AI agent tool
+  calls, MCP tool handlers, queue workers, background jobs) with
+  `@arcjet/guard` (JS/TS) or `arcjet.guard` (Python).
+
+You can also install a single skill directly:
+
 ```bash
+npx skills add arcjet/skills --skill add-request-protection
 npx skills add arcjet/skills --skill add-guard-protection
 ```
 
@@ -42,21 +56,37 @@ Then describe what you want to protect. The skill handles the rest.
 
 Source: [github.com/arcjet/skills](https://github.com/arcjet/skills)
 
-You can also use the <Link.Page href="/arcjet-plugin">Arcjet plugin</Link.Page>
-for Claude Code and Cursor, which bundles skills, MCP, and coding rules.
+## Connect to the Arcjet API
 
-## Step 2: Connect with the CLI
+Skills handle the SDK and rule integration in your code. To create sites,
+retrieve `ARCJET_KEY`, inspect requests, and manage remote rules, the agent
+needs to talk to the Arcjet API. There are two parallel support transports —
+pick whichever fits your working style:
+
+- **<Link.Page href="/cli">Arcjet CLI</Link.Page>** — for agents and humans
+  working in a terminal (Claude Code, Codex, plugin tasks, CI). No editor or
+  MCP setup required.
+- **<Link.Page href="/mcp-server">MCP server</Link.Page>** — for online clients
+  without shell access (ChatGPT, Claude Desktop) and editors with built-in MCP
+  support (VS Code Copilot, Windsurf, Cursor).
+
+Both transports expose the same management-plane surface. The sections below
+describe each path end to end.
+
+### Path A: Connect with the CLI
 
 The <Link.Page href="/cli">Arcjet CLI</Link.Page> lets you manage sites, keys,
 and rules from your terminal:
 
 ```bash
-npm i -g @arcjet/cli
-arcjet auth login
-arcjet teams list
-arcjet sites list --team-id team_01abc123
-arcjet sites get-key --site-id site_01abc123
+npx -y @arcjet/cli@latest auth login
+npx -y @arcjet/cli@latest teams list
+npx -y @arcjet/cli@latest sites list --team-id team_01abc123
+npx -y @arcjet/cli@latest sites get-key --site-id site_01abc123
 ```
+
+For frequent use, install the binary so you can run `arcjet <command>`
+directly. See <Link.Page href="/cli#install">CLI install paths</Link.Page>.
 
 Set the key in the project environment:
 
@@ -65,67 +95,22 @@ Set the key in the project environment:
 ARCJET_KEY=ajkey_yourkey
 ```
 
-You can also use the <Link.Page href="/mcp-server">MCP server</Link.Page> to
-manage sites and keys. See [Manual setup](#manual-setup) below.
+Then continue with [Install the SDK](#install-the-sdk) and
+[Add protection](#add-protection) below.
 
-## Manual setup
+### Path B: Connect with the MCP server
 
-Use this path if you prefer step-by-step control or are using a tool with
-built-in MCP support (VS Code Copilot, Windsurf, ChatGPT, Claude Code, Claude
-Desktop, Cursor).
+Use this path if you are using a tool with built-in MCP support (VS Code
+Copilot, Windsurf, ChatGPT, Claude Code, Claude Desktop, Cursor).
 
-### Step 1: Connect the MCP server
-
-The Arcjet MCP server lets you manage your account directly from your AI coding
-tool.
-
-<Tabs>
-  <TabItem label="ChatGPT">
-    1. In ChatGPT, go to **Settings**.
-    2. Navigate to **Connectors** and select **Add connection**.
-    3. Enter `https://api.arcjet.com/mcp` as the server URL.
-    4. Select **OAuth** for authentication.
-    5. Click **Create**.
-  </TabItem>
-  <TabItem label="Claude Code">
-    ```bash
-    claude mcp add arcjet --transport http https://api.arcjet.com/mcp
-    ```
-  </TabItem>
-  <TabItem label="Claude Desktop">
-    1. Open **Settings** in the sidebar.
-    2. Navigate to **Connectors** and select **Add custom connector**.
-    3. Set the **Name** to `Arcjet` and the **URL** to `https://api.arcjet.com/mcp`.
-  </TabItem>
-  <TabItem label="Cursor">
-    Add to `.cursor/mcp.json`:
-    ```json
-    { "mcpServers": { "arcjet": { "type": "streamable-http", "url": "https://api.arcjet.com/mcp" } } }
-    ```
-  </TabItem>
-  <TabItem label="VS Code (Copilot)">
-    Add to `.vscode/mcp.json`:
-    ```json
-    { "servers": { "arcjet": { "type": "http", "url": "https://api.arcjet.com/mcp" } } }
-    ```
-  </TabItem>
-  <TabItem label="Windsurf">
-    Add to `mcp_config.json`:
-    ```json
-    { "mcpServers": { "arcjet": { "serverUrl": "https://api.arcjet.com/mcp" } } }
-    ```
-  </TabItem>
-</Tabs>
+The Arcjet MCP server lets you manage your account directly from your AI
+coding tool. See <Link.Page href="/mcp-server#setup">MCP server setup</Link.Page>
+for the per-client configuration steps.
 
 OAuth authentication happens automatically on first connection — a browser
 window will open for the user to sign in.
 
-See the <Link.Page href="/mcp-server">MCP server docs</Link.Page> for the
-full tool reference.
-
-### Step 2: Get your ARCJET_KEY
-
-Use the MCP tools to retrieve your site key:
+Once connected, retrieve your site key with the MCP tools:
 
 1. Call `list-teams` to get available teams.
 2. Call `list-sites` with the team ID to find the site (or call `create-site`
@@ -140,10 +125,13 @@ ARCJET_KEY=ajkey_yourkey
 ARCJET_ENV=development
 ```
 
+`ARCJET_ENV` is read by the Arcjet SDK in your local app to switch into
+development mode. It is not used by the MCP connection itself.
+
 If the user doesn't have an Arcjet account yet, direct them to
 [app.arcjet.com](https://app.arcjet.com) to create one (free trial).
 
-### Step 3: Install the SDK
+## Install the SDK
 
 Detect the framework by checking the project files:
 
@@ -173,7 +161,7 @@ Then install the correct package:
 | Python FastAPI | `pip install arcjet` or `uv add arcjet`   |
 | Python Flask   | `pip install arcjet` or `uv add arcjet`   |
 
-### Step 4: Add protection
+## Add protection
 
 Add Arcjet rules to protect the application. See the
 [llms.txt](/llms.txt) file for complete, copy-paste code examples for every
@@ -194,7 +182,7 @@ The typical setup is:
   context.
 </Aside>
 
-#### Recommended rules by app type
+### Recommended rules by app type
 
 | App type               | Rules                                                                 |
 | ---------------------- | --------------------------------------------------------------------- |
@@ -204,15 +192,18 @@ The typical setup is:
 | Internal / admin route | `shield` + `filter` (country/VPN blocking)                           |
 | Any web app            | `shield` + `detectBot` (good baseline)                               |
 
-### Step 5: Verify
+## Verify
 
 After adding protection and starting the app:
 
 1. Send a test request to a protected route.
-2. Use the MCP `list-requests` tool to confirm requests are flowing to Arcjet.
-3. Use `get-request-details` or `explain-decision` to inspect individual
-   decisions.
-4. Use `analyze-traffic` for a dashboard-level overview of request patterns.
+2. List recent requests via the CLI (`arcjet requests list --site-id <id>`)
+   or the MCP `list-requests` tool to confirm requests are flowing to Arcjet.
+3. Inspect individual decisions via the CLI (`arcjet requests details`,
+   `arcjet requests explain`) or the MCP tools (`get-request-details`,
+   `explain-decision`).
+4. Use `arcjet analyze traffic --site-id <id>` (CLI) or `analyze-traffic` (MCP)
+   for a dashboard-level overview of request patterns.
 5. Check the [Arcjet dashboard](https://app.arcjet.com) for real-time request
    monitoring.
 
@@ -221,8 +212,10 @@ set correctly and that `protect()` is being called in the route handler.
 
 ## Common agent prompts
 
-These prompts work well when given to an AI coding agent with the Arcjet plugin
-installed or MCP server connected:
+These prompts work well when given to an AI coding agent with skills installed
+and either the CLI or MCP server connected (the
+<Link.Page href="/arcjet-plugin">Arcjet plugin</Link.Page> is a bundled
+alternative for Claude Code and Cursor users):
 
 - **"Protect my API routes with Arcjet"** — adds shield, bot detection, and
   rate limiting to all API routes.
@@ -244,13 +237,21 @@ installed or MCP server connected:
   `get-dry-run-impact` to show blocked requests, affected IPs, and
   false-positive risk.
 
+## See also
+
+- <Link.Page href="/arcjet-plugin">Arcjet Plugin</Link.Page> — bundled
+  experience for Claude Code and Cursor users who prefer a single-command
+  install that wires up MCP, skills, and coding rules together. Not the
+  recommended first step for general agentic workflows, but a convenient
+  alternative if you are already in one of those editors.
+
 ## Reference
 
 - <Link.Page href="/get-started">Quick start guide</Link.Page> — framework-specific setup with full code examples
 - <Link.Page href="/guards">Guards</Link.Page> — protect tool calls, queues, and agentic pipelines without an HTTP request
-- <Link.Page href="/arcjet-plugin">Arcjet Plugin</Link.Page> — plugin for Claude Code and Cursor with automatic security guidance
 - <Link.Page href="/cli">Arcjet CLI</Link.Page> — manage sites, keys, and rules from the terminal
-- [llms.txt](/llms.txt) — machine-readable reference with all framework examples, rule parameters, and decision API
 - <Link.Page href="/mcp-server">MCP server</Link.Page> — full MCP tool reference and client setup
+- <Link.Page href="/arcjet-plugin">Arcjet Plugin</Link.Page> — bundled experience for Claude Code and Cursor
+- [llms.txt](/llms.txt) — machine-readable reference with all framework examples, rule parameters, and decision API
 - <Link.Page href="/remote-rules">Remote rules</Link.Page> — manage rules from the dashboard or MCP server without code changes
 - <Link.Page href="/best-practices">Best practices</Link.Page> — recommended patterns and anti-patterns

--- a/src/content/docs/arcjet-plugin.mdx
+++ b/src/content/docs/arcjet-plugin.mdx
@@ -5,13 +5,26 @@ prev: false
 next: false
 ---
 
-import { Aside, Code, TabItem, Tabs } from "@astrojs/starlight/components";
+import { Aside } from "@astrojs/starlight/components";
 import Comments from "/src/components/Comments.astro";
 
 [Arcjet](https://arcjet.com) is the runtime security platform that ships with your code. Enforce budgets, stop prompt injection, detect bots, and protect personal information with Arcjet's AI security building blocks.
 
-The [Arcjet plugin](https://github.com/arcjet/arcjet-plugin) turns any supported AI coding agent into a security expert. It
-pre-loads agents with knowledge of the Arcjet security platform and
+The [Arcjet plugin](https://github.com/arcjet/arcjet-plugin) is a bundled
+experience for [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+and [Cursor](https://www.cursor.com) users who prefer a single-command install
+that wires up MCP, skills, and security-aware coding rules together.
+
+<Aside type="tip">
+  The recommended path for most agentic workflows is to install Arcjet skills
+  directly with `npx skills add arcjet/skills` and connect to the Arcjet API
+  via the [CLI](/cli) or [MCP server](/mcp-server). See
+  [Agent get started](/agent-get-started) for the canonical entry point. The
+  plugin is an alternative for users who prefer a bundled experience inside
+  Claude Code or Cursor.
+</Aside>
+
+The plugin pre-loads agents with knowledge of the Arcjet security platform and
 automatically injects the right guidance based on what you're working on —
 framework-specific SDK patterns, protection rules, and best practices.
 
@@ -19,21 +32,13 @@ framework-specific SDK patterns, protection rules, and best practices.
 
 Install the plugin with a single command:
 
-<Tabs>
-  <TabItem label="Claude Code">
-    ```bash
-    npx plugins add arcjet/arcjet-plugin
-    ```
-  </TabItem>
-  <TabItem label="Cursor">
-    ```bash
-    npx plugins add arcjet/arcjet-plugin
-    ```
-  </TabItem>
-</Tabs>
+```bash
+npx plugins add arcjet/arcjet-plugin
+```
 
-The plugin activates automatically after installation. There are no additional
-setup steps or commands to learn.
+The same command works in both Claude Code and Cursor. The plugin activates
+automatically after installation. There are no additional setup steps or
+commands to learn.
 
 ### Prerequisites
 
@@ -110,6 +115,21 @@ access to your Arcjet account. When connected via OAuth, agents can:
   See the [MCP server docs](/mcp-server) for full tool reference and the [agent
   get started guide](/agent-get-started) for a step-by-step setup walkthrough.
 </Aside>
+
+## Using the plugin with the CLI
+
+The plugin invokes the [Arcjet CLI](/cli) to stream live request activity into
+your agent's context — for example when you ask the agent to watch traffic on
+a site or investigate recent requests. The CLI exposes the same management-
+plane surface as the MCP server (teams, sites, rules, requests, analysis)
+directly from the terminal.
+
+## See also
+
+- [Agent get started](/agent-get-started) — canonical entry point for setting
+  up Arcjet in an agentic workflow.
+- [Arcjet CLI](/cli) — terminal-based management-plane access.
+- [MCP server](/mcp-server) — full MCP tool reference.
 
 ## Source code
 

--- a/src/content/docs/arcjet-plugin.mdx
+++ b/src/content/docs/arcjet-plugin.mdx
@@ -77,10 +77,10 @@ Guidance triggers automatically in specific contexts:
 
 Invoke skills directly within your AI coding agent:
 
-| Skill                              | Purpose                                                                                                                                                                  |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `/arcjet:add-request-protection`   | Add protection to HTTP route handlers and API endpoints with automatic framework detection — rate limiting, bot detection, email validation, and shield.                |
-| `/arcjet:add-guard-protection`     | Add protection to non-HTTP code paths (AI agent tool calls, MCP tool handlers, queue workers, background jobs) using `@arcjet/guard` (JS/TS) or `arcjet.guard` (Python). |
+| Skill                            | Purpose                                                                                                                          |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `/arcjet:add-request-protection` | Add protection to HTTP route handlers and API endpoints — rate limiting, bot detection, email validation, and shield.            |
+| `/arcjet:add-guard-protection`   | Protect non-HTTP code paths (AI tool calls, MCP handlers, queue workers, background jobs) via `@arcjet/guard` / `arcjet.guard`.  |
 
 The previous skill names — `/arcjet:protect-route` and `/arcjet:add-ai-protection` — remain as deprecated aliases that emit a diagnostic on use. Migrate to the canonical names above.
 

--- a/src/content/docs/arcjet-plugin.mdx
+++ b/src/content/docs/arcjet-plugin.mdx
@@ -77,10 +77,14 @@ Guidance triggers automatically in specific contexts:
 
 Invoke skills directly within your AI coding agent:
 
-| Skill                         | Purpose                                                                          |
-| ----------------------------- | -------------------------------------------------------------------------------- |
-| `/arcjet:protect-route`       | Designed for web apps. Adds protection to route handlers with automatic framework detection             |
-| `/arcjet:add-ai-protection`   | Designed for AI apps. Implements prompt injection detection, PII blocking, and token budget rate limiting |
+| Skill                              | Purpose                                                                                                                                                                  |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `/arcjet:add-request-protection`   | Add protection to HTTP route handlers and API endpoints with automatic framework detection — rate limiting, bot detection, email validation, and shield.                |
+| `/arcjet:add-guard-protection`     | Add protection to non-HTTP code paths (AI agent tool calls, MCP tool handlers, queue workers, background jobs) using `@arcjet/guard` (JS/TS) or `arcjet.guard` (Python). |
+
+The previous skill names — `/arcjet:protect-route` and `/arcjet:add-ai-protection` — remain as deprecated aliases that emit a diagnostic on use. Migrate to the canonical names above.
+
+The plugin's skills track the canonical [arcjet/skills](https://github.com/arcjet/skills) package, which is the source of truth. You can install the same skills outside the plugin with `npx skills add arcjet/skills`.
 
 ### Supported frameworks
 

--- a/src/content/docs/cli.mdx
+++ b/src/content/docs/cli.mdx
@@ -61,10 +61,21 @@ For frequent or interactive use, install the binary so commands can be invoked a
 
     Available for macOS (Apple Silicon, Intel) and Linux (x86_64, arm64).
   </TabItem>
+  <TabItem label="Install script">
+    ```bash
+    curl -sSfL https://arcjet.com/cli/install.sh | bash
+    ```
+
+    Downloads the appropriate release archive from
+    [github.com/arcjet/cli/releases](https://github.com/arcjet/cli/releases)
+    and installs the `arcjet` binary onto your `PATH`. Available for macOS
+    (Apple Silicon, Intel) and Linux (x86_64, arm64).
+  </TabItem>
   <TabItem label="Release binary">
     Download the latest archive for your platform from
     [github.com/arcjet/cli/releases](https://github.com/arcjet/cli/releases),
-    extract it, and place the `arcjet` binary somewhere on your `PATH`.
+    extract it, and place the `arcjet` binary somewhere on your `PATH`. Useful
+    for internal redistribution and air-gapped environments.
 
     Available for macOS (Apple Silicon, Intel), Linux (x86_64, arm64), and
     Windows (x86_64, arm64).
@@ -191,10 +202,9 @@ Remote rules support `rate_limit`, `bot`, `shield`, and `filter` types. Rules th
 
 | Command                                  | Description                                       |
 | ---------------------------------------- | ------------------------------------------------- |
-| `arcjet skills`                          | List available skill topics.                      |
-| `arcjet skills <topic>`                  | Show a detailed skill guide for a topic.          |
-| `arcjet skills install`                  | Install `ARCJET.md` into the current project.     |
-| `arcjet skills initialize`               | Guided project setup — installs the SDK and configures the application. |
+| `arcjet skills`                          | Print a pointer to the canonical skills package (`npx skills add arcjet/skills`). |
+| `arcjet skills install`                  | Print a pointer to the canonical skills package (`npx skills add arcjet/skills`). |
+| `arcjet skills initialize`               | Guided project setup — interactive auth, site selection, and `.env` write. Ends by printing the same skills-install recommendation. |
 | `arcjet completion <bash\|zsh\|fish>`    | Generate shell completions.                       |
 | `arcjet version`                         | Print version information.                        |
 
@@ -214,26 +224,29 @@ The CLI mirrors the MCP server's typical workflows. Each step is a single comman
 
 ## Skills
 
-The `arcjet skills` command ships built-in documentation bundled with the binary, so it always matches the installed CLI version. Run `arcjet skills` to list the available topics and `arcjet skills <topic>` to read one — discover what is available from the help output rather than hard-coding topic names.
-
-For richer SDK integration documentation aimed at AI coding agents, install the standalone Arcjet skills package from [github.com/arcjet/skills](https://github.com/arcjet/skills):
+Arcjet's agent-facing skills live in the standalone [arcjet/skills](https://github.com/arcjet/skills) package and are installed with the [`skills`](https://www.npmjs.com/package/skills) CLI:
 
 ```bash
 npx skills add arcjet/skills --skill add-request-protection
 npx skills add arcjet/skills --skill add-guard-protection
 ```
 
-Install `ARCJET.md` into the project so future agent turns can discover Arcjet without a docs round trip:
+The two canonical skills are:
 
-```bash
-arcjet skills install
-```
+- **`add-request-protection`** — protect HTTP routes and API endpoints with rate limiting, bot detection, email validation, and shield.
+- **`add-guard-protection`** — protect non-HTTP code paths (AI agent tool calls, MCP tool handlers, queue workers, background jobs) with `@arcjet/guard` (JS/TS) or `arcjet.guard` (Python).
 
-For a guided end-to-end setup that installs the SDK and wires up protection, run:
+The previous skill names (`protect-route`, `add-ai-protection`) remain as deprecated aliases that emit a diagnostic on use.
+
+`arcjet skills` and `arcjet skills install` are breadcrumbs, not file-writers: both print a recommendation pointing at `npx skills add arcjet/skills` so agents discovering the CLI can find the canonical skills package. They do not write any files into the project.
+
+For a guided end-to-end project setup — interactive auth, site selection, and writing the `ARCJET_KEY` to `.env` — run:
 
 ```bash
 arcjet skills initialize
 ```
+
+`arcjet skills initialize` ends by printing the same skills-install recommendation so the next agent turn can follow up with `npx skills add arcjet/skills`.
 
 ## Invariants
 

--- a/src/content/docs/cli.mdx
+++ b/src/content/docs/cli.mdx
@@ -11,7 +11,7 @@ import Comments from "/src/components/Comments.astro";
 
 [Arcjet](https://arcjet.com) is the runtime security platform that ships with your code. Enforce budgets, stop prompt injection, detect bots, and protect personal information with Arcjet's AI security building blocks.
 
-The Arcjet CLI gives AI coding agents and humans terminal access to the Arcjet management plane. It mirrors the surface of the <Link.Page href="/mcp-server">MCP server</Link.Page> — teams, sites, rules, traffic analysis, request inspection, and live monitoring — without an MCP connection or editor integration.
+The Arcjet CLI is one of two ways to connect <Link.Page href="/agent-get-started#skills">Arcjet skills</Link.Page> to the Arcjet API — the other being the <Link.Page href="/mcp-server">MCP server</Link.Page>. Both transports expose the same management-plane surface (teams, sites, rules, traffic analysis, request inspection, live monitoring); the CLI is the right choice when you are working in a terminal and the MCP server is the right choice when you are working in an online client without shell access.
 
 <Aside type="tip">
   This page is written for AI coding agents working in a terminal session or
@@ -221,19 +221,7 @@ The CLI mirrors the MCP server's typical workflows. Each step is a single comman
 
 ## Skills
 
-Arcjet's agent-facing skills live in the standalone [arcjet/skills](https://github.com/arcjet/skills) package and are installed with the [`skills`](https://www.npmjs.com/package/skills) CLI:
-
-```bash
-npx skills add arcjet/skills --skill add-request-protection
-npx skills add arcjet/skills --skill add-guard-protection
-```
-
-The two canonical skills are:
-
-- **`add-request-protection`** — protect HTTP routes and API endpoints with rate limiting, bot detection, email validation, and shield.
-- **`add-guard-protection`** — protect non-HTTP code paths (AI agent tool calls, MCP tool handlers, queue workers, background jobs) with `@arcjet/guard` (JS/TS) or `arcjet.guard` (Python).
-
-The previous skill names (`protect-route`, `add-ai-protection`) remain as deprecated aliases that emit a diagnostic on use.
+Skills are documented in <Link.Page href="/agent-get-started#skills">Agent get started</Link.Page>. The CLI is one of the transports that connects skills to the Arcjet API — it is not itself a skill surface.
 
 ## Invariants
 

--- a/src/content/docs/cli.mdx
+++ b/src/content/docs/cli.mdx
@@ -198,13 +198,10 @@ Remote rules support `rate_limit`, `bot`, `shield`, and `filter` types. Rules th
 | `arcjet briefing --site-id <id>`   | Comprehensive security briefing — traffic, threats, anomalies, dry-run readiness, quota, recommendations. |
 | `arcjet watch --site-id <id>`      | Stream live requests for a site (polls the API).             |
 
-### Skills and utilities
+### Utilities
 
 | Command                                  | Description                                       |
 | ---------------------------------------- | ------------------------------------------------- |
-| `arcjet skills`                          | Print a pointer to the canonical skills package (`npx skills add arcjet/skills`). |
-| `arcjet skills install`                  | Print a pointer to the canonical skills package (`npx skills add arcjet/skills`). |
-| `arcjet skills initialize`               | Guided project setup — interactive auth, site selection, and `.env` write. Ends by printing the same skills-install recommendation. |
 | `arcjet completion <bash\|zsh\|fish>`    | Generate shell completions.                       |
 | `arcjet version`                         | Print version information.                        |
 
@@ -237,16 +234,6 @@ The two canonical skills are:
 - **`add-guard-protection`** — protect non-HTTP code paths (AI agent tool calls, MCP tool handlers, queue workers, background jobs) with `@arcjet/guard` (JS/TS) or `arcjet.guard` (Python).
 
 The previous skill names (`protect-route`, `add-ai-protection`) remain as deprecated aliases that emit a diagnostic on use.
-
-`arcjet skills` and `arcjet skills install` are breadcrumbs, not file-writers: both print a recommendation pointing at `npx skills add arcjet/skills` so agents discovering the CLI can find the canonical skills package. They do not write any files into the project.
-
-For a guided end-to-end project setup — interactive auth, site selection, and writing the `ARCJET_KEY` to `.env` — run:
-
-```bash
-arcjet skills initialize
-```
-
-`arcjet skills initialize` ends by printing the same skills-install recommendation so the next agent turn can follow up with `npx skills add arcjet/skills`.
 
 ## Invariants
 

--- a/src/content/docs/mcp-server.mdx
+++ b/src/content/docs/mcp-server.mdx
@@ -5,31 +5,17 @@ prev: false
 next: false
 ---
 
-import { Aside, Code, TabItem, Tabs } from "@astrojs/starlight/components";
+import { Aside } from "@astrojs/starlight/components";
 import Comments from "/src/components/Comments.astro";
 
 [Arcjet](https://arcjet.com) is the runtime security platform that ships with your code. Enforce budgets, stop prompt injection, detect bots, and protect personal information with Arcjet's AI security building blocks.
 
-The Arcjet MCP server gives AI coding assistants the skills of a security engineer. By connecting to the Arcjet MCP server, your AI coding tools can:
+The Arcjet MCP server is one of two transports that connects [Arcjet skills](/agent-get-started#skills) to the Arcjet API — the other being the [Arcjet CLI](/cli). The MCP server is the right choice for AI coding tools without shell access (ChatGPT, Claude Desktop) and editors with built-in MCP support (VS Code Copilot, Windsurf, Cursor); the CLI is the right choice when you are working in a terminal session.
 
-- **List teams** you belong to.
-- **List sites** within a team.
-- **Create new sites** within a team.
-- **Get site keys** (`ARCJET_KEY`) for use in your projects.
-- **List requests** received by a site with optional filtering.
-- **Explain decisions** to understand why requests were allowed or denied.
-- **Get request details** including headers, rules executed, and decision info.
-- **Get site quota** usage and limits for the current billing window.
-- **Analyze traffic** patterns, denial rates, top paths, and top IPs.
-- **Detect anomalies** by comparing current traffic to the previous period.
-- **Investigate IPs** with geo, threat intelligence, and request activity.
-- **Get dry-run impact** analysis before promoting rules to live.
-- **Get a security briefing** combining traffic, threats, anomalies, and recommendations.
-- **List remote rules** configured for a site.
-- **Create remote rules** with DRY_RUN or LIVE mode — configure rules with no code changes needed.
-- **Update remote rules** by replacing the full rule configuration.
-- **Delete remote rules** to immediately stop evaluation.
-- **Promote remote rules** from DRY_RUN to LIVE after verification.
+Both transports expose the same management-plane surface — teams, sites,
+keys, requests, decisions, traffic analysis, anomaly detection, IP
+investigation, security briefings, and remote rule management. See
+[Available tools](#available-tools) for the full reference.
 
 The MCP server is available at:
 
@@ -279,6 +265,14 @@ Once authenticated, your AI assistant can securely access your account resources
   can review actions before they execute.
 - **Trusted clients only** — only connect from AI clients you trust. Connecting
   grants the AI tool the same access as your Arcjet account.
+
+## See also
+
+- [Agent get started](/agent-get-started) — canonical entry point for setting
+  up Arcjet in an agentic workflow.
+- [Arcjet CLI](/cli) — sibling support transport for terminal-based workflows.
+- [Arcjet Plugin](/arcjet-plugin) — bundled experience for Claude Code and
+  Cursor users that wires up MCP, skills, and coding rules together.
 
 ## Privacy and support
 


### PR DESCRIPTION
## Summary

Restructures the four agent-facing documentation pages around a new framing decision: **skills (`arcjet/skills`) are the preferred entry path for agentic workflows; the CLI and MCP server are support transports for connecting skills to the Arcjet API; the plugin is an alternative for users who prefer a bundled experience and is not the recommended first step.**

This PR also ships the original 1.0.0 alignment work — canonical skill names, install matrix updates, and removal of the deprecated `arcjet skills` subcommand documentation.

## What changed

**`agent-get-started.mdx`** — restructured around skills as the lead.
- New flow: Skills (`npx skills add arcjet/skills`) → connect via CLI or MCP (parallel support paths) → install SDK → add protection → verify.
- CLI bootstrap uses `npx -y @arcjet/cli@latest` (matches the canonical install order in `cli.mdx`).
- The duplicate MCP client setup block (~36 lines that mirrored `/mcp-server#setup`) replaced with a single link.
- Plugin moved from a featured option to a "See also" block near the end. Still documented, no longer pushed as a primary path.
- Added a one-line clarification that `ARCJET_ENV` is consumed by the SDK in the user's app (not the MCP connection itself), and dropped it from the CLI bootstrap path since the CLI does not read it.

**`cli.mdx`** — reframed as "one of two transports" alongside MCP.
- Intro now positions the CLI and MCP server as parallel support surfaces for skills, picked based on working style (terminal vs. online client).
- The `## Skills` section was replaced with a one-line pointer to `/agent-get-started#skills`. Skills aren't a CLI surface, so they belong on the canonical entry-point page, not duplicated here.
- Install matrix order matches the broader 1.0.0 canonical: `npx`, then npm, Homebrew, install script, release binary.
- Dropped all `arcjet skills`/`arcjet skills install`/`arcjet skills initialize` rows from the command reference table. For 1.0.0 (the initial public release) the canonical entry point is `npx skills add arcjet/skills`, not a CLI subcommand.

**`mcp-server.mdx`** — added a `## See also` section linking to `/agent-get-started`, `/cli`, and `/arcjet-plugin` (the page was previously an island). Collapsed the duplicate capabilities/tools listings into one canonical `## Available tools` block.

**`arcjet-plugin.mdx`** — added a top-of-page `<Aside>` framing the plugin as an alternative for Claude Code and Cursor users who prefer a bundled experience, with the recommended path pointing at `/agent-get-started`. Collapsed the two identical install Tabs into one block. Renamed the plugin's slash commands to the canonical names — `/arcjet:add-request-protection` (HTTP routes) and `/arcjet:add-guard-protection` (non-HTTP code paths) — with a note that `/arcjet:protect-route` and `/arcjet:add-ai-protection` remain as deprecated aliases that emit a diagnostic. Added a `## Using the plugin with the CLI` section and a `## See also` block.

## Companion PRs

The skills-canonical-names migration ships in parallel against `arcjet/arcjet-plugin`. The `arcjet skills` no-op behavior is already in the `arcjet/arcjet` monorepo (`arcjet-decide/internal/cli/skills.go`).
