### PR TITLE
docs(python): document `environment=` kwarg on `arcjet()` / `arcjet_sync()`

### DIFF
--- a/src/content/docs/environment.mdx
+++ b/src/content/docs/environment.mdx
@@ -46,14 +46,10 @@ and production mode otherwise.
 `NODE_ENV` is a convention used in Node.js apps — the Python SDK reads
 `ARCJET_ENV` only.
 
-If you load configuration with a library that doesn't propagate values into
-`os.environ` (e.g. `pydantic-settings`, which loads `.env` into a typed
-`BaseSettings` object rather than writing values back to the process
-environment), `ARCJET_ENV` won't reach the Python SDK through `os.getenv`.
-Pass the value explicitly via the `environment=` kwarg on `arcjet()` /
-`arcjet_sync()` — see the
-<Link.Page href="/reference/python#pydantic-settings-users">Python SDK reference</Link.Page>
-for an example.
+Python SDK users: if your config library doesn't propagate `.env` into
+`os.environ` (e.g. `pydantic-settings`), pass `ARCJET_ENV` via the
+`environment=` kwarg on `arcjet()` / `arcjet_sync()` — see the
+<Link.Page href="/reference/python#pydantic-settings-users">Python SDK reference</Link.Page>.
 
 In development, the timeout for connecting to Cloud API is increased.
 In production, the timeout is quicker.

--- a/src/content/docs/environment.mdx
+++ b/src/content/docs/environment.mdx
@@ -46,11 +46,12 @@ and production mode otherwise.
 `NODE_ENV` is a convention used in Node.js apps — the Python SDK reads
 `ARCJET_ENV` only.
 
-If you load configuration with a library that does not propagate values into
-`os.environ` (for example `pydantic-settings`, which reads `.env` into a typed
-`BaseSettings` object instead), `ARCJET_ENV` will appear unset to the Python
-SDK and dev mode will silently fail to engage. Pass the value explicitly via
-the `environment=` kwarg on `arcjet()` / `arcjet_sync()` instead — see the
+If you load configuration with a library that doesn't propagate values into
+`os.environ` (e.g. `pydantic-settings`, which loads `.env` into a typed
+`BaseSettings` object rather than writing values back to the process
+environment), `ARCJET_ENV` won't reach the Python SDK through `os.getenv`.
+Pass the value explicitly via the `environment=` kwarg on `arcjet()` /
+`arcjet_sync()` — see the
 <Link.Page href="/reference/python#pydantic-settings-users">Python SDK reference</Link.Page>
 for an example.
 

--- a/src/content/docs/environment.mdx
+++ b/src/content/docs/environment.mdx
@@ -46,6 +46,14 @@ and production mode otherwise.
 `NODE_ENV` is a convention used in Node.js apps — the Python SDK reads
 `ARCJET_ENV` only.
 
+If you load configuration with a library that does not propagate values into
+`os.environ` (for example `pydantic-settings`, which reads `.env` into a typed
+`BaseSettings` object instead), `ARCJET_ENV` will appear unset to the Python
+SDK and dev mode will silently fail to engage. Pass the value explicitly via
+the `environment=` kwarg on `arcjet()` / `arcjet_sync()` instead — see the
+<Link.Page href="/reference/python#pydantic-settings-users">Python SDK reference</Link.Page>
+for an example.
+
 In development, the timeout for connecting to Cloud API is increased.
 In production, the timeout is quicker.
 This is because in production your app typically runs close to an Arcjet server,

--- a/src/content/docs/reference/python.mdx
+++ b/src/content/docs/reference/python.mdx
@@ -218,8 +218,7 @@ through the `environment=` kwarg. By design, pydantic-settings loads `.env`
 into a typed `BaseSettings` object rather than writing values back to
 `os.environ`, so the SDK — which reads `ARCJET_ENV` via `os.getenv` — won't
 pick up the value through that channel. Without the kwarg, the SDK defaults
-to production, so dev-mode behavior (loopback IP fallback, `X-Arcjet-Ip`
-header override, and the longer dev-mode request timeout) won't engage.
+to production mode.
 
 ```py
 from arcjet import arcjet

--- a/src/content/docs/reference/python.mdx
+++ b/src/content/docs/reference/python.mdx
@@ -129,13 +129,13 @@ The optional fields are:
   This is useful if you are behind a load balancer or proxy that sets the client
   IP address in a header. See [Load balancers &
   proxies](#load-balancers--proxies) below for an example.
-- `environment` (`str | None`) — Development/production mode override for
-  callers whose config library does not write to `os.environ` (e.g.
-  `pydantic-settings`). When `None` (default), the SDK falls back to reading
+- `environment` (`str | None`) — Explicit development/production mode
+  (`"development"` or `"production"`). When `None` (default), falls back to
   the
   <Link.Page href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>
-  environment variable. See [Pydantic-settings users](#pydantic-settings-users)
-  below.
+  environment variable. Pass this when your config library doesn't propagate
+  `.env` into `os.environ` (e.g. `pydantic-settings`). See
+  [Pydantic-settings users](#pydantic-settings-users) below.
 
 <Tabs>
   <TabItem label="FastAPI (async)">
@@ -210,19 +210,16 @@ passed explicitly via the `key` argument.
 
 #### Pydantic-settings users
 
-The SDK reads
+If you use
+[`pydantic-settings`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/),
+pass
 <Link.Page href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>
-via `os.getenv`, but
-[`pydantic-settings`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/) —
-the de-facto FastAPI config pattern — intentionally does not push `.env`
-values into `os.environ`. If you rely on it, the SDK will silently default
-to production mode: loopback IPs are dropped and (with `fail_open=True`)
-local requests return `ALLOW` with no dashboard visibility.
-
-Pass the value explicitly through the `environment` kwarg so the SDK gates
-development behavior (loopback IP fallback, `X-Arcjet-Ip` header override,
-and the longer dev-mode request timeout) on your settings object instead of
-`os.environ`:
+through the `environment=` kwarg. By design, pydantic-settings loads `.env`
+into a typed `BaseSettings` object rather than writing values back to
+`os.environ`, so the SDK — which reads `ARCJET_ENV` via `os.getenv` — won't
+pick up the value through that channel. Without the kwarg, the SDK defaults
+to production, so dev-mode behavior (loopback IP fallback, `X-Arcjet-Ip`
+header override, and the longer dev-mode request timeout) won't engage.
 
 ```py
 from arcjet import arcjet
@@ -245,10 +242,7 @@ aj = arcjet(
 )
 ```
 
-The same kwarg is accepted by `arcjet_sync()`. When `environment=None` (the
-default) the SDK falls back to `os.getenv("ARCJET_ENV")`, so existing
-callers that already set `ARCJET_ENV` in the process environment do not
-need to change.
+`arcjet_sync()` accepts the same kwarg.
 
 #### Load balancers & proxies
 

--- a/src/content/docs/reference/python.mdx
+++ b/src/content/docs/reference/python.mdx
@@ -229,7 +229,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env")
 
     ARCJET_KEY: str
-    ARCJET_ENV: str = "production"
+    ARCJET_ENV: str = "development"
 
 
 settings = Settings()

--- a/src/content/docs/reference/python.mdx
+++ b/src/content/docs/reference/python.mdx
@@ -129,6 +129,13 @@ The optional fields are:
   This is useful if you are behind a load balancer or proxy that sets the client
   IP address in a header. See [Load balancers &
   proxies](#load-balancers--proxies) below for an example.
+- `environment` (`str | None`) — Development/production mode override for
+  callers whose config library does not write to `os.environ` (e.g.
+  `pydantic-settings`). When `None` (default), the SDK falls back to reading
+  the
+  <Link.Page href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>
+  environment variable. See [Pydantic-settings users](#pydantic-settings-users)
+  below.
 
 <Tabs>
   <TabItem label="FastAPI (async)">
@@ -200,6 +207,48 @@ See <Link.Page href="/environment">Concepts: Environment variables</Link.Page>
 for more info.
 The `ARCJET_KEY` environment variable is not read automatically and must be
 passed explicitly via the `key` argument.
+
+#### Pydantic-settings users
+
+The SDK reads
+<Link.Page href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>
+via `os.getenv`, but
+[`pydantic-settings`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/) —
+the de-facto FastAPI config pattern — intentionally does not push `.env`
+values into `os.environ`. If you rely on it, the SDK will silently default
+to production mode: loopback IPs are dropped and (with `fail_open=True`)
+local requests return `ALLOW` with no dashboard visibility.
+
+Pass the value explicitly through the `environment` kwarg so the SDK gates
+development behavior (loopback IP fallback, `X-Arcjet-Ip` header override,
+and the longer dev-mode request timeout) on your settings object instead of
+`os.environ`:
+
+```py
+from arcjet import arcjet
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env")
+
+    ARCJET_KEY: str
+    ARCJET_ENV: str = "production"
+
+
+settings = Settings()
+
+aj = arcjet(
+    key=settings.ARCJET_KEY,
+    rules=[...],
+    environment=settings.ARCJET_ENV,
+)
+```
+
+The same kwarg is accepted by `arcjet_sync()`. When `environment=None` (the
+default) the SDK falls back to `os.getenv("ARCJET_ENV")`, so existing
+callers that already set `ARCJET_ENV` in the process environment do not
+need to change.
 
 #### Load balancers & proxies
 


### PR DESCRIPTION
## Summary

Documents the `environment=` kwarg shipped in [arcjet/arcjet-py#127](https://github.com/arcjet/arcjet-py/pull/127). Users on `pydantic-settings` (or any config library that doesn't propagate `.env` into `os.environ`) can now pass dev/prod mode explicitly instead of relying on `ARCJET_ENV` being readable via `os.getenv`.

- **`src/content/docs/reference/python.mdx`** — Adds `environment` to the Configuration optional-fields bullet list with `"development"` / `"production"` stated inline, plus a new `#### Pydantic-settings users` subsection with a runnable `BaseSettings` example. `arcjet_sync()` is called out for Flask/Django users.
- **`src/content/docs/environment.mdx`** — Adds a one-line pointer under `### ARCJET_ENV, NODE_ENV` so customers who land on the concept page searching `ARCJET_ENV` get routed to the kwarg. Mechanism explanation lives on the reference page only.

## Why

`pydantic-settings` — the de-facto FastAPI config pattern — loads `.env` into a typed `BaseSettings` object by design and does not write values back to `os.environ`. The Python SDK reads `ARCJET_ENV` via `os.getenv`, so without an explicit channel between the two, the SDK defaults to production mode for users on this pattern. The new `environment=` kwarg is that bridge, and the docs need to point users to it where they'll look for the symptom.

## Test plan

Open the Vercel preview link from the PR's checks (sidebar → "Visit Preview"), then walk through:

- [x] **Anchor exists.** Open `/reference/python` on the preview. Scroll down to (or `Cmd+F`) the `Pydantic-settings users` heading. Click the heading and confirm the URL becomes `…/reference/python#pydantic-settings-users`.
- [x] **Bullet → subsection.** On the same page, in the Configuration section, find the `environment` bullet (between `proxies` and the FastAPI/Flask code tabs). Click the **Pydantic-settings users** link in that bullet. Confirm it jumps to the subsection on the same page.
- [x] **Bullet → ARCJET_ENV.** In the same `environment` bullet, click the `ARCJET_ENV` link. Confirm it navigates to `/environment#arcjet-env` and scrolls to the `ARCJET_ENV, NODE_ENV` heading.
- [x] **Concept page → reference.** Open `/environment` directly on the preview. Find the `ARCJET_ENV, NODE_ENV` section. Click the **Python SDK reference** link in the "Python SDK users: …" sentence. Confirm it lands on `/reference/python#pydantic-settings-users`.
- [x] **Visual scan.** On `/reference/python`, read the Configuration section end-to-end (from `### Configuration` through `#### Load balancers & proxies`) and confirm the new bullet and subsection sit naturally in the flow with no rendering glitches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)