### PR TITLE
docs(python): note libgcc requirement for Alpine Linux

### DIFF
--- a/src/content/docs/reference/python.mdx
+++ b/src/content/docs/reference/python.mdx
@@ -48,6 +48,11 @@ pip install arcjet
 ### Requirements
 
 - Python 3.10 or later
+- `libgcc` — needed by the bundled WebAssembly runtime (used for local bot
+  detection, sensitive information detection, and prompt injection
+  detection). Most Linux distributions include this by default, but Alpine
+  Linux does not; run `apk add libgcc` first, otherwise `import arcjet`
+  raises `OSError: Error loading shared library libgcc_s.so.1`.
 
 ## Quick start
 

--- a/src/snippets/get-started/python-fastapi/Requirements.mdx
+++ b/src/snippets/get-started/python-fastapi/Requirements.mdx
@@ -1,1 +1,4 @@
 - Python 3.10 or later
+- `libgcc` — needed by the bundled WebAssembly runtime. Most Linux
+  distributions include this by default, but Alpine Linux does not; run
+  `apk add libgcc` first

--- a/src/snippets/get-started/python-flask/Requirements.mdx
+++ b/src/snippets/get-started/python-flask/Requirements.mdx
@@ -1,1 +1,4 @@
 - Python 3.10 or later
+- `libgcc` — needed by the bundled WebAssembly runtime. Most Linux
+  distributions include this by default, but Alpine Linux does not; run
+  `apk add libgcc` first


### PR DESCRIPTION
arcjet-py's bundled WebAssembly runtime (wasmtime) needs libgcc_s.so.1, which most distros ship by default but Alpine does not. Without it, `import arcjet` fails with OSError. Verified apk add libgcc resolves it.

See arcjet/arcjet-py#159.

I'm not sure if we want to mention it here or maybe in faq? Not sure. I have not yet updated the screenshots (will do if/when approved)