### PR TITLE
docs(node): trim old caveats about unsupported Node.js versions

### DIFF
--- a/src/snippets/bot-protection/quick-start/nodejs/Step4.mdx
+++ b/src/snippets/bot-protection/quick-start/nodejs/Step4.mdx
@@ -1,5 +1,4 @@
 import { Link } from "@/components/link";
-import { Aside } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 
 ### 4. Start server
@@ -19,13 +18,6 @@ Start your Node.js server:
   ```
   </div>
 </SelectableContent>
-
-<Aside type="note" title="env files">
-  Node 20+ supports loading environment variables from a local file with
-  `--env-file`. If you're using an older version of Node, you can use a package
-  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
-  variables from a `.env.local` file.
-</Aside>
 
 Make a `curl` request from your terminal to your application. You should see a
 `403 Forbidden` response because `curl` is considered an automated client by

--- a/src/snippets/email-validation/quick-start/nodejs/Step4.mdx
+++ b/src/snippets/email-validation/quick-start/nodejs/Step4.mdx
@@ -1,4 +1,3 @@
-import { Aside } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 
 ### 4. Start server
@@ -20,13 +19,6 @@ node --env-file .env.local index.js
 
   </div>
 </SelectableContent>
-
-<Aside type="note" title="env files">
-  Node 20+ supports loading environment variables from a local file with
-  `--env-file`. If you're using an older version of Node, you can use a package
-  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
-  variables from a `.env.local` file.
-</Aside>
 
 Make a `curl` `POST` request from your terminal to your application with various
 emails to test the result.

--- a/src/snippets/get-started/fastify/Requirements.mdx
+++ b/src/snippets/get-started/fastify/Requirements.mdx
@@ -1,2 +1,2 @@
 - Fastify 5.0.0 or later
-- Node.js 22.21.0 or later (24.3.0 or later for native TypeScript support)
+- Node.js 22.21.0 or later

--- a/src/snippets/get-started/fastify/Step4.mdx
+++ b/src/snippets/get-started/fastify/Step4.mdx
@@ -1,6 +1,5 @@
 import { Link } from "@/components/link";
 import SelectableContent from "@/components/SelectableContent";
-import { Aside } from "@astrojs/starlight/components";
 
 ## 4. Start app
 
@@ -10,15 +9,6 @@ import { Aside } from "@astrojs/starlight/components";
     ```sh
     node --env-file .env.local server.ts
     ```
-
-    <Aside type="note" title="TypeScript support">
-    Node.js 24.3.0+ supports running TypeScript files natively. If you're using
-    an older version of Node, you can use a package like [`tsx`](
-    https://tsx.is/getting-started) to run TypeScript files, or you can compile
-    your TypeScript files to JavaScript first. Learn more in the
-    [Fastify docs](https://fastify.dev/docs/latest/Reference/TypeScript/).
-    </Aside>
-
   </div>
   <div slot="JS" slotIdx="2">
     ```sh

--- a/src/snippets/get-started/node-js-express/Step4.mdx
+++ b/src/snippets/get-started/node-js-express/Step4.mdx
@@ -1,5 +1,4 @@
 import { Link } from "@/components/link";
-import { Aside } from "@astrojs/starlight/components";
 
 ## 4. Start app
 
@@ -7,13 +6,6 @@ import { Aside } from "@astrojs/starlight/components";
 ```sh
 node --env-file .env.local index.js
 ```
-
-<Aside type="note" title="env files">
-  Node 20+ supports loading environment variables from a local file with
-  `--env-file`. If you're using an older version of Node, you can use a package
-  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
-  variables from a `.env.local` file.
-</Aside>
 
 Visit [`http://localhost:3000`](http://localhost:3000) in your browser and
 refresh a few times to hit the rate limit.

--- a/src/snippets/get-started/node-js-hono/Step2.mdx
+++ b/src/snippets/get-started/node-js-hono/Step2.mdx
@@ -1,5 +1,3 @@
-import { Aside } from "@astrojs/starlight/components";
-
 Add your key to a `.env.local` file in your project root.
 You can also set
 [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env)
@@ -24,10 +22,3 @@ Next you need to update the dev command in your `package.json` to use the
   ...
 }
 ```
-
-<Aside type="note" title="env files">
-  Node 20+ supports loading environment variables from a local file with
-  `--env-file`. If you're using an older version of Node, you can use a package
-  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
-  variables from a `.env.local` file.
-</Aside>

--- a/src/snippets/get-started/node-js/Step4.mdx
+++ b/src/snippets/get-started/node-js/Step4.mdx
@@ -1,6 +1,5 @@
 import { Link } from "@/components/link";
 import SelectableContent from "@/components/SelectableContent";
-import { Aside } from "@astrojs/starlight/components";
 
 ## 4. Start app
 
@@ -17,13 +16,6 @@ import { Aside } from "@astrojs/starlight/components";
     ```
   </div>
 </SelectableContent>
-
-<Aside type="note" title="env files">
-  Node 20+ supports loading environment variables from a local file with
-  `--env-file`. If you're using an older version of Node, you can use a package
-  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
-  variables from a `.env.local` file.
-</Aside>
 
 Visit [`http://localhost:8000`](http://localhost:8000) in your browser and
 refresh a few times to hit the rate limit.

--- a/src/snippets/rate-limiting/quick-start/nodejs/Step4.mdx
+++ b/src/snippets/rate-limiting/quick-start/nodejs/Step4.mdx
@@ -1,4 +1,3 @@
-import { Aside } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 
 ### 4. Start server
@@ -20,13 +19,6 @@ node --env-file .env.local index.js
 
   </div>
 </SelectableContent>
-
-<Aside type="note" title="env files">
-  Node 20+ supports loading environment variables from a local file with
-  `--env-file`. If you're using an older version of Node, you can use a package
-  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
-  variables from a `.env.local` file.
-</Aside>
 
 Then make some requests to hit the rate limit:
 

--- a/src/snippets/shield/quick-start/nodejs/Step4.mdx
+++ b/src/snippets/shield/quick-start/nodejs/Step4.mdx
@@ -1,4 +1,3 @@
-import { Aside } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 
 ### 4. Start server
@@ -20,10 +19,3 @@ node --env-file .env.local index.js
 
   </div>
 </SelectableContent>
-
-<Aside type="note" title="env files">
-  Node 20+ supports loading environment variables from a local file with
-  `--env-file`. If you're using an older version of Node, you can use a package
-  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
-  variables from a `.env.local` file.
-</Aside>

--- a/src/snippets/signup-protection/quick-start/nodejs/Step4.mdx
+++ b/src/snippets/signup-protection/quick-start/nodejs/Step4.mdx
@@ -1,4 +1,3 @@
-import { Aside } from "@astrojs/starlight/components";
 import SelectableContent from "@/components/SelectableContent";
 
 ### 4. Start server
@@ -16,13 +15,6 @@ import SelectableContent from "@/components/SelectableContent";
   ```
   </Fragment>
 </SelectableContent>
-
-<Aside type="note" title="env files">
-  Node 20+ supports loading environment variables from a local file with
-  `--env-file`. If you're using an older version of Node, you can use a package
-  like [`dotenv`](https://www.npmjs.com/package/dotenv) to load the environment
-  variables from a `.env.local` file.
-</Aside>
 
 Make a `curl` `POST` request from your terminal to your application with various
 emails to test the result.


### PR DESCRIPTION
- Old `.env` file loading patterns
- Old `tsx` notices