### PR TITLE
docs: add Codex CLI MCP setup

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -53,7 +53,11 @@ if ! command -v npm >/dev/null || [[ "$(npm --version)" != "11.14.1" ]]; then
 fi
 
 dependency_stamp="node_modules/.amp-dependency-hash"
-dependency_hash="$(cat package.json package-lock.json | sha256sum | awk '{print $1}')"
+dependency_hash="$(
+  cat package.json package-lock.json patches/* |
+    sha256sum |
+    awk '{print $1}'
+)"
 if [[ ! -f "$dependency_stamp" ]] || [[ "$(cat "$dependency_stamp")" != "$dependency_hash" ]]; then
   echo "Installing npm dependencies..."
   npm ci

--- a/src/content/docs/mcp-server.mdx
+++ b/src/content/docs/mcp-server.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Arcjet MCP server"
-description: "Connect AI assistants like Claude, Cursor, VS Code Copilot, and ChatGPT to your Arcjet account using the Model Context Protocol (MCP)."
+description: "Connect AI assistants like Claude, Codex, Cursor, VS Code Copilot, and ChatGPT to your Arcjet account using the Model Context Protocol (MCP)."
 prev: false
 next: false
 ---
@@ -39,6 +39,7 @@ is supported. This includes:
 
 - [ChatGPT](#chatgpt)
 - [Claude Code](#claude-code)
+- [Codex CLI](#codex-cli)
 - [Claude Desktop](#claude-desktop)
 - [Cursor](#cursor)
 - [VS Code with Copilot](#vs-code-with-copilot)
@@ -65,6 +66,15 @@ claude mcp add arcjet --transport http https://api.arcjet.com/mcp
 
 Claude Code will open a browser for OAuth authentication on first connection.
 Once authenticated, you can use the `/mcp` command to verify the connection.
+
+### Codex CLI
+
+```bash
+codex mcp add arcjet --url https://api.arcjet.com/mcp
+```
+
+Codex will prompt you to authenticate with Arcjet when it first connects to the
+server.
 
 ### Claude Desktop
 


### PR DESCRIPTION
## Summary

- add Codex CLI to the Arcjet MCP server's supported clients
- document the command for connecting Codex CLI to Arcjet
- include Codex in the page description
- invalidate the orb dependency cache when checked-in dependency patches change, ensuring `patch-package` fixes are applied

## Validation

- `git diff --check`
- `bash -n .agents/setup`
- `npx prettier --check src/content/docs/mcp-server.mdx`
- `npm run pw:run -- --update-snapshots=changed` (168 passed; no snapshots changed)