### PR TITLE
docs: document threat and billing metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,14 @@ See [Internal links](CONTRIBUTING.md#internal-links) in CONTRIBUTING.md.
 When editing MDX files, convert any plain markdown internal links to
 `<Link.Page>` or `<Link.ToSdk>`. Never split Link text across multiple lines.
 
+## Screenshot generation
+
+After making any changes, regenerate changed screenshots by running:
+
+```sh
+npm run pw:run -- --update-snapshots=changed
+```
+
 ## Dependency updates
 
 See the [Dependency updates](CONTRIBUTING.md#dependency-updates) section in

--- a/src/content/docs/guards/index.mdx
+++ b/src/content/docs/guards/index.mdx
@@ -515,6 +515,103 @@ decision = await arcjet.guard(
 </TabItem>
 </Tabs>
 
+#### Usage billing metadata
+
+Successful prompt-injection and content-moderation rule results can include the
+usage billed for that evaluation:
+
+<Tabs syncKey="language">
+<TabItem label="JavaScript / TypeScript">
+
+```ts
+const usageDecision = await arcjet.guard({
+  label: "tools.summarize",
+  rules: [piRule(userInput), moderate(userInput)],
+});
+
+const [promptResult] = piRule.results(usageDecision);
+
+if (promptResult?.billing) {
+  console.log(
+    `Prompt injection used ${promptResult.billing.count} ${promptResult.billing.unit}`,
+  );
+}
+
+const [moderationResult] = moderate.results(usageDecision);
+if (moderationResult?.billing) {
+  console.log(
+    `Moderation used ${moderationResult.billing.count} ${moderationResult.billing.unit}`,
+  );
+}
+```
+
+</TabItem>
+<TabItem label="Python">
+
+```python
+usage_decision = await aj.guard(
+    label="tools.summarize",
+    rules=[pi_rule(user_input), moderate(user_input)],
+)
+
+prompt_result = pi_rule.result(usage_decision)
+if prompt_result and prompt_result.billing:
+    print(prompt_result.billing.count, prompt_result.billing.unit)
+
+moderation_result = moderate.result(usage_decision)
+if moderation_result and moderation_result.billing:
+    print(moderation_result.billing.count, moderation_result.billing.unit)
+```
+
+</TabItem>
+<TabItem label="Go">
+
+```go
+promptScan, err := arcjet.GuardPromptInjection(
+	arcjet.GuardPromptInjectionOptions{Mode: arcjet.ModeLive},
+)
+if err != nil {
+	return err
+}
+
+moderate, err := arcjet.ExperimentalGuardModerateContent(
+	arcjet.ExperimentalGuardModerateContentOptions{Mode: arcjet.ModeLive},
+)
+if err != nil {
+	return err
+}
+
+usageDecision, err := guard.Guard(ctx, arcjet.GuardRequest{
+	Label: "tools.summarize",
+	Rules: []arcjet.GuardRuleInput{
+		promptScan.Text(userInput),
+		moderate.Text(userInput),
+	},
+})
+if err != nil {
+	return err
+}
+
+if result := promptScan.Result(usageDecision); result != nil && result.Billing != nil {
+	fmt.Println(result.Billing.Count, result.Billing.Unit)
+}
+
+if result := moderate.Result(usageDecision); result != nil && result.Billing != nil {
+	fmt.Println(result.Billing.Count, result.Billing.Unit)
+}
+```
+
+</TabItem>
+</Tabs>
+
+In JavaScript and Python, `billing.unit` is `"tokens"` for prompt-injection
+detection and `"text_units"` for content moderation; `billing.count` is the
+number of those units charged. The equivalent Go fields are `Billing.Unit` and
+`Billing.Count`. Billing is optional: it is `undefined`, `None`, or `nil` when
+absent, including when evaluation failed or did not run and on responses from
+older servers. Do not use its presence to determine whether the rule succeeded;
+check the result and decision conclusion instead.
+
 ### Custom rules
 
 Custom rules let you plug in arbitrary local evaluation logic with typed

--- a/src/content/docs/guards/index.mdx
+++ b/src/content/docs/guards/index.mdx
@@ -524,12 +524,20 @@ usage billed for that evaluation:
 <TabItem label="JavaScript / TypeScript">
 
 ```ts
+import {
+  detectPromptInjection,
+  experimental_moderateContent,
+} from "@arcjet/guard";
+
+const piRule = detectPromptInjection();
+const moderate = experimental_moderateContent();
+
 const usageDecision = await arcjet.guard({
   label: "tools.summarize",
   rules: [piRule(userInput), moderate(userInput)],
 });
 
-const [promptResult] = piRule.results(usageDecision);
+const promptResult = piRule.result(usageDecision);
 
 if (promptResult?.billing) {
   console.log(
@@ -537,7 +545,7 @@ if (promptResult?.billing) {
   );
 }
 
-const [moderationResult] = moderate.results(usageDecision);
+const moderationResult = moderate.result(usageDecision);
 if (moderationResult?.billing) {
   console.log(
     `Moderation used ${moderationResult.billing.count} ${moderationResult.billing.unit}`,
@@ -549,6 +557,11 @@ if (moderationResult?.billing) {
 <TabItem label="Python">
 
 ```python
+from arcjet.guard import DetectPromptInjection, experimental_ModerateContent
+
+pi_rule = DetectPromptInjection()
+moderate = experimental_ModerateContent()
+
 usage_decision = await aj.guard(
     label="tools.summarize",
     rules=[pi_rule(user_input), moderate(user_input)],

--- a/src/snippets/reference/shared/IPAnalysis.mdx
+++ b/src/snippets/reference/shared/IPAnalysis.mdx
@@ -110,8 +110,6 @@ if (threat && !threat.isSafe && threat.riskLevel === "critical") {
 - `entityName` (`string | undefined`): a specific entity name, when identified.
 - `service` (`string | undefined`): a known service or provider name, when
   identified.
-- `backgroundNoise` (`number`): amount of internet-wide noise from the IP;
-  `0` means none and higher values mean more noise.
 
 #### IP type
 

--- a/src/snippets/reference/shared/IPAnalysis.mdx
+++ b/src/snippets/reference/shared/IPAnalysis.mdx
@@ -79,6 +79,40 @@ the need for null-ish checks.
   IP address. This is the administrative country of the AS, not necessarily the
   country of the client IP address.
 
+#### IP threat intelligence
+
+When threat intelligence is available, it is exposed as `decision.ip.threat`.
+Always check for it because older responses and IPs without an assessment omit
+the property:
+
+```ts
+const threat = decision.ip.threat;
+
+if (threat && !threat.isSafe && threat.riskLevel === "critical") {
+  console.warn("High-risk IP activity", threat.activities);
+}
+```
+
+- `riskLevel` (`string`): overall risk assessment, such as `none`, `low`,
+  `medium`, `high`, or `critical`.
+- `confidence` (`string`): confidence in the assessment, such as `low`,
+  `medium`, or `high`.
+- `reputation` (`string`): upstream reputation, such as `malicious`,
+  `suspicious`, `known`, `safe`, `benign`, or `unknown`.
+- `isSafe` (`boolean`): whether the IP is trusted infrastructure and should not
+  be treated as a threat.
+- `networkTypes` (`string[]`): network classifications, such as `hosting`,
+  `vpn`, `proxy`, or `tor`.
+- `activities` (`string[]`): observed behaviors, such as `brute_force`,
+  `scanning`, or `botnet`.
+- `entities` (`string[]`): automated entity types, such as `crawler`,
+  `ai_crawler`, or `scanner`.
+- `entityName` (`string | undefined`): a specific entity name, when identified.
+- `service` (`string | undefined`): a known service or provider name, when
+  identified.
+- `backgroundNoise` (`number`): amount of internet-wide noise from the IP;
+  `0` means none and higher values mean more noise.
+
 #### IP type
 
 The `service` field may be `undefined`, but you can use the `hasService()`

--- a/tests/llms-txt.test.ts-snapshots/reference-astro-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-astro-chromium-linux.md
@@ -830,6 +830,28 @@ The IP AS fields may be `undefined`, but you can use the `hasASN()` method to ch
 *   `asnType` (`'isp' | 'hosting' | 'business' | 'education'`): the type of the AS of the client IP address. Real users are more likely to be on an ISP or business network rather than a hosting provider. Education networks often have a single or small number of IP addresses even though there are many users. A common mistake is to block a single IP because of too many requests when it is a university or company network using [NAT](https://en.wikipedia.org/wiki/Carrier-grade_NAT) (Network Address Translation) to give many users the same IP.
 *   `asnCountry` (`string | undefined`): the country code of the AS of the client IP address. This is the administrative country of the AS, not necessarily the country of the client IP address.
 
+#### IP threat intelligence
+
+When threat intelligence is available, it is exposed as `decision.ip.threat`. Always check for it because older responses and IPs without an assessment omit the property:
+
+```ts
+const threat = decision.ip.threat;
+
+if (threat && !threat.isSafe && threat.riskLevel === "critical") {
+  console.warn("High-risk IP activity", threat.activities);
+}
+```
+
+*   `riskLevel` (`string`): overall risk assessment, such as `none`, `low`, `medium`, `high`, or `critical`.
+*   `confidence` (`string`): confidence in the assessment, such as `low`, `medium`, or `high`.
+*   `reputation` (`string`): upstream reputation, such as `malicious`, `suspicious`, `known`, `safe`, `benign`, or `unknown`.
+*   `isSafe` (`boolean`): whether the IP is trusted infrastructure and should not be treated as a threat.
+*   `networkTypes` (`string[]`): network classifications, such as `hosting`, `vpn`, `proxy`, or `tor`.
+*   `activities` (`string[]`): observed behaviors, such as `brute_force`, `scanning`, or `botnet`.
+*   `entities` (`string[]`): automated entity types, such as `crawler`, `ai_crawler`, or `scanner`.
+*   `entityName` (`string | undefined`): a specific entity name, when identified.
+*   `service` (`string | undefined`): a known service or provider name, when identified.
+
 #### IP type
 
 The `service` field may be `undefined`, but you can use the `hasService()` method to check the availability. Using this method will also refine the type to remove the need for null-ish checks.

--- a/tests/llms-txt.test.ts-snapshots/reference-bun-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-bun-chromium-linux.md
@@ -817,6 +817,28 @@ The IP AS fields may be `undefined`, but you can use the `hasASN()` method to ch
 *   `asnType` (`'isp' | 'hosting' | 'business' | 'education'`): the type of the AS of the client IP address. Real users are more likely to be on an ISP or business network rather than a hosting provider. Education networks often have a single or small number of IP addresses even though there are many users. A common mistake is to block a single IP because of too many requests when it is a university or company network using [NAT](https://en.wikipedia.org/wiki/Carrier-grade_NAT) (Network Address Translation) to give many users the same IP.
 *   `asnCountry` (`string | undefined`): the country code of the AS of the client IP address. This is the administrative country of the AS, not necessarily the country of the client IP address.
 
+#### IP threat intelligence
+
+When threat intelligence is available, it is exposed as `decision.ip.threat`. Always check for it because older responses and IPs without an assessment omit the property:
+
+```ts
+const threat = decision.ip.threat;
+
+if (threat && !threat.isSafe && threat.riskLevel === "critical") {
+  console.warn("High-risk IP activity", threat.activities);
+}
+```
+
+*   `riskLevel` (`string`): overall risk assessment, such as `none`, `low`, `medium`, `high`, or `critical`.
+*   `confidence` (`string`): confidence in the assessment, such as `low`, `medium`, or `high`.
+*   `reputation` (`string`): upstream reputation, such as `malicious`, `suspicious`, `known`, `safe`, `benign`, or `unknown`.
+*   `isSafe` (`boolean`): whether the IP is trusted infrastructure and should not be treated as a threat.
+*   `networkTypes` (`string[]`): network classifications, such as `hosting`, `vpn`, `proxy`, or `tor`.
+*   `activities` (`string[]`): observed behaviors, such as `brute_force`, `scanning`, or `botnet`.
+*   `entities` (`string[]`): automated entity types, such as `crawler`, `ai_crawler`, or `scanner`.
+*   `entityName` (`string | undefined`): a specific entity name, when identified.
+*   `service` (`string | undefined`): a known service or provider name, when identified.
+
 #### IP type
 
 The `service` field may be `undefined`, but you can use the `hasService()` method to check the availability. Using this method will also refine the type to remove the need for null-ish checks.

--- a/tests/llms-txt.test.ts-snapshots/reference-nestjs-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-nestjs-chromium-linux.md
@@ -464,6 +464,28 @@ The IP AS fields may be `undefined`, but you can use the `hasASN()` method to ch
 *   `asnType` (`'isp' | 'hosting' | 'business' | 'education'`): the type of the AS of the client IP address. Real users are more likely to be on an ISP or business network rather than a hosting provider. Education networks often have a single or small number of IP addresses even though there are many users. A common mistake is to block a single IP because of too many requests when it is a university or company network using [NAT](https://en.wikipedia.org/wiki/Carrier-grade_NAT) (Network Address Translation) to give many users the same IP.
 *   `asnCountry` (`string | undefined`): the country code of the AS of the client IP address. This is the administrative country of the AS, not necessarily the country of the client IP address.
 
+#### IP threat intelligence
+
+When threat intelligence is available, it is exposed as `decision.ip.threat`. Always check for it because older responses and IPs without an assessment omit the property:
+
+```ts
+const threat = decision.ip.threat;
+
+if (threat && !threat.isSafe && threat.riskLevel === "critical") {
+  console.warn("High-risk IP activity", threat.activities);
+}
+```
+
+*   `riskLevel` (`string`): overall risk assessment, such as `none`, `low`, `medium`, `high`, or `critical`.
+*   `confidence` (`string`): confidence in the assessment, such as `low`, `medium`, or `high`.
+*   `reputation` (`string`): upstream reputation, such as `malicious`, `suspicious`, `known`, `safe`, `benign`, or `unknown`.
+*   `isSafe` (`boolean`): whether the IP is trusted infrastructure and should not be treated as a threat.
+*   `networkTypes` (`string[]`): network classifications, such as `hosting`, `vpn`, `proxy`, or `tor`.
+*   `activities` (`string[]`): observed behaviors, such as `brute_force`, `scanning`, or `botnet`.
+*   `entities` (`string[]`): automated entity types, such as `crawler`, `ai_crawler`, or `scanner`.
+*   `entityName` (`string | undefined`): a specific entity name, when identified.
+*   `service` (`string | undefined`): a known service or provider name, when identified.
+
 #### IP type
 
 The `service` field may be `undefined`, but you can use the `hasService()` method to check the availability. Using this method will also refine the type to remove the need for null-ish checks.

--- a/tests/llms-txt.test.ts-snapshots/reference-nextjs-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-nextjs-chromium-linux.md
@@ -1150,6 +1150,28 @@ The IP AS fields may be `undefined`, but you can use the `hasASN()` method to ch
 *   `asnType` (`'isp' | 'hosting' | 'business' | 'education'`): the type of the AS of the client IP address. Real users are more likely to be on an ISP or business network rather than a hosting provider. Education networks often have a single or small number of IP addresses even though there are many users. A common mistake is to block a single IP because of too many requests when it is a university or company network using [NAT](https://en.wikipedia.org/wiki/Carrier-grade_NAT) (Network Address Translation) to give many users the same IP.
 *   `asnCountry` (`string | undefined`): the country code of the AS of the client IP address. This is the administrative country of the AS, not necessarily the country of the client IP address.
 
+#### IP threat intelligence
+
+When threat intelligence is available, it is exposed as `decision.ip.threat`. Always check for it because older responses and IPs without an assessment omit the property:
+
+```ts
+const threat = decision.ip.threat;
+
+if (threat && !threat.isSafe && threat.riskLevel === "critical") {
+  console.warn("High-risk IP activity", threat.activities);
+}
+```
+
+*   `riskLevel` (`string`): overall risk assessment, such as `none`, `low`, `medium`, `high`, or `critical`.
+*   `confidence` (`string`): confidence in the assessment, such as `low`, `medium`, or `high`.
+*   `reputation` (`string`): upstream reputation, such as `malicious`, `suspicious`, `known`, `safe`, `benign`, or `unknown`.
+*   `isSafe` (`boolean`): whether the IP is trusted infrastructure and should not be treated as a threat.
+*   `networkTypes` (`string[]`): network classifications, such as `hosting`, `vpn`, `proxy`, or `tor`.
+*   `activities` (`string[]`): observed behaviors, such as `brute_force`, `scanning`, or `botnet`.
+*   `entities` (`string[]`): automated entity types, such as `crawler`, `ai_crawler`, or `scanner`.
+*   `entityName` (`string | undefined`): a specific entity name, when identified.
+*   `service` (`string | undefined`): a known service or provider name, when identified.
+
 #### IP type
 
 The `service` field may be `undefined`, but you can use the `hasService()` method to check the availability. Using this method will also refine the type to remove the need for null-ish checks.

--- a/tests/llms-txt.test.ts-snapshots/reference-nodejs-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-nodejs-chromium-linux.md
@@ -623,6 +623,28 @@ The IP AS fields may be `undefined`, but you can use the `hasASN()` method to ch
 *   `asnType` (`'isp' | 'hosting' | 'business' | 'education'`): the type of the AS of the client IP address. Real users are more likely to be on an ISP or business network rather than a hosting provider. Education networks often have a single or small number of IP addresses even though there are many users. A common mistake is to block a single IP because of too many requests when it is a university or company network using [NAT](https://en.wikipedia.org/wiki/Carrier-grade_NAT) (Network Address Translation) to give many users the same IP.
 *   `asnCountry` (`string | undefined`): the country code of the AS of the client IP address. This is the administrative country of the AS, not necessarily the country of the client IP address.
 
+#### IP threat intelligence
+
+When threat intelligence is available, it is exposed as `decision.ip.threat`. Always check for it because older responses and IPs without an assessment omit the property:
+
+```ts
+const threat = decision.ip.threat;
+
+if (threat && !threat.isSafe && threat.riskLevel === "critical") {
+  console.warn("High-risk IP activity", threat.activities);
+}
+```
+
+*   `riskLevel` (`string`): overall risk assessment, such as `none`, `low`, `medium`, `high`, or `critical`.
+*   `confidence` (`string`): confidence in the assessment, such as `low`, `medium`, or `high`.
+*   `reputation` (`string`): upstream reputation, such as `malicious`, `suspicious`, `known`, `safe`, `benign`, or `unknown`.
+*   `isSafe` (`boolean`): whether the IP is trusted infrastructure and should not be treated as a threat.
+*   `networkTypes` (`string[]`): network classifications, such as `hosting`, `vpn`, `proxy`, or `tor`.
+*   `activities` (`string[]`): observed behaviors, such as `brute_force`, `scanning`, or `botnet`.
+*   `entities` (`string[]`): automated entity types, such as `crawler`, `ai_crawler`, or `scanner`.
+*   `entityName` (`string | undefined`): a specific entity name, when identified.
+*   `service` (`string | undefined`): a known service or provider name, when identified.
+
 #### IP type
 
 The `service` field may be `undefined`, but you can use the `hasService()` method to check the availability. Using this method will also refine the type to remove the need for null-ish checks.

--- a/tests/llms-txt.test.ts-snapshots/reference-nuxt-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-nuxt-chromium-linux.md
@@ -812,6 +812,28 @@ The IP AS fields may be `undefined`, but you can use the `hasASN()` method to ch
 *   `asnType` (`'isp' | 'hosting' | 'business' | 'education'`): the type of the AS of the client IP address. Real users are more likely to be on an ISP or business network rather than a hosting provider. Education networks often have a single or small number of IP addresses even though there are many users. A common mistake is to block a single IP because of too many requests when it is a university or company network using [NAT](https://en.wikipedia.org/wiki/Carrier-grade_NAT) (Network Address Translation) to give many users the same IP.
 *   `asnCountry` (`string | undefined`): the country code of the AS of the client IP address. This is the administrative country of the AS, not necessarily the country of the client IP address.
 
+#### IP threat intelligence
+
+When threat intelligence is available, it is exposed as `decision.ip.threat`. Always check for it because older responses and IPs without an assessment omit the property:
+
+```ts
+const threat = decision.ip.threat;
+
+if (threat && !threat.isSafe && threat.riskLevel === "critical") {
+  console.warn("High-risk IP activity", threat.activities);
+}
+```
+
+*   `riskLevel` (`string`): overall risk assessment, such as `none`, `low`, `medium`, `high`, or `critical`.
+*   `confidence` (`string`): confidence in the assessment, such as `low`, `medium`, or `high`.
+*   `reputation` (`string`): upstream reputation, such as `malicious`, `suspicious`, `known`, `safe`, `benign`, or `unknown`.
+*   `isSafe` (`boolean`): whether the IP is trusted infrastructure and should not be treated as a threat.
+*   `networkTypes` (`string[]`): network classifications, such as `hosting`, `vpn`, `proxy`, or `tor`.
+*   `activities` (`string[]`): observed behaviors, such as `brute_force`, `scanning`, or `botnet`.
+*   `entities` (`string[]`): automated entity types, such as `crawler`, `ai_crawler`, or `scanner`.
+*   `entityName` (`string | undefined`): a specific entity name, when identified.
+*   `service` (`string | undefined`): a known service or provider name, when identified.
+
 #### IP type
 
 The `service` field may be `undefined`, but you can use the `hasService()` method to check the availability. Using this method will also refine the type to remove the need for null-ish checks.

--- a/tests/llms-txt.test.ts-snapshots/reference-remix-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-remix-chromium-linux.md
@@ -613,6 +613,28 @@ The IP AS fields may be `undefined`, but you can use the `hasASN()` method to ch
 *   `asnType` (`'isp' | 'hosting' | 'business' | 'education'`): the type of the AS of the client IP address. Real users are more likely to be on an ISP or business network rather than a hosting provider. Education networks often have a single or small number of IP addresses even though there are many users. A common mistake is to block a single IP because of too many requests when it is a university or company network using [NAT](https://en.wikipedia.org/wiki/Carrier-grade_NAT) (Network Address Translation) to give many users the same IP.
 *   `asnCountry` (`string | undefined`): the country code of the AS of the client IP address. This is the administrative country of the AS, not necessarily the country of the client IP address.
 
+#### IP threat intelligence
+
+When threat intelligence is available, it is exposed as `decision.ip.threat`. Always check for it because older responses and IPs without an assessment omit the property:
+
+```ts
+const threat = decision.ip.threat;
+
+if (threat && !threat.isSafe && threat.riskLevel === "critical") {
+  console.warn("High-risk IP activity", threat.activities);
+}
+```
+
+*   `riskLevel` (`string`): overall risk assessment, such as `none`, `low`, `medium`, `high`, or `critical`.
+*   `confidence` (`string`): confidence in the assessment, such as `low`, `medium`, or `high`.
+*   `reputation` (`string`): upstream reputation, such as `malicious`, `suspicious`, `known`, `safe`, `benign`, or `unknown`.
+*   `isSafe` (`boolean`): whether the IP is trusted infrastructure and should not be treated as a threat.
+*   `networkTypes` (`string[]`): network classifications, such as `hosting`, `vpn`, `proxy`, or `tor`.
+*   `activities` (`string[]`): observed behaviors, such as `brute_force`, `scanning`, or `botnet`.
+*   `entities` (`string[]`): automated entity types, such as `crawler`, `ai_crawler`, or `scanner`.
+*   `entityName` (`string | undefined`): a specific entity name, when identified.
+*   `service` (`string | undefined`): a known service or provider name, when identified.
+
 #### IP type
 
 The `service` field may be `undefined`, but you can use the `hasService()` method to check the availability. Using this method will also refine the type to remove the need for null-ish checks.

--- a/tests/llms-txt.test.ts-snapshots/reference-sveltekit-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-sveltekit-chromium-linux.md
@@ -762,6 +762,28 @@ The IP AS fields may be `undefined`, but you can use the `hasASN()` method to ch
 *   `asnType` (`'isp' | 'hosting' | 'business' | 'education'`): the type of the AS of the client IP address. Real users are more likely to be on an ISP or business network rather than a hosting provider. Education networks often have a single or small number of IP addresses even though there are many users. A common mistake is to block a single IP because of too many requests when it is a university or company network using [NAT](https://en.wikipedia.org/wiki/Carrier-grade_NAT) (Network Address Translation) to give many users the same IP.
 *   `asnCountry` (`string | undefined`): the country code of the AS of the client IP address. This is the administrative country of the AS, not necessarily the country of the client IP address.
 
+#### IP threat intelligence
+
+When threat intelligence is available, it is exposed as `decision.ip.threat`. Always check for it because older responses and IPs without an assessment omit the property:
+
+```ts
+const threat = decision.ip.threat;
+
+if (threat && !threat.isSafe && threat.riskLevel === "critical") {
+  console.warn("High-risk IP activity", threat.activities);
+}
+```
+
+*   `riskLevel` (`string`): overall risk assessment, such as `none`, `low`, `medium`, `high`, or `critical`.
+*   `confidence` (`string`): confidence in the assessment, such as `low`, `medium`, or `high`.
+*   `reputation` (`string`): upstream reputation, such as `malicious`, `suspicious`, `known`, `safe`, `benign`, or `unknown`.
+*   `isSafe` (`boolean`): whether the IP is trusted infrastructure and should not be treated as a threat.
+*   `networkTypes` (`string[]`): network classifications, such as `hosting`, `vpn`, `proxy`, or `tor`.
+*   `activities` (`string[]`): observed behaviors, such as `brute_force`, `scanning`, or `botnet`.
+*   `entities` (`string[]`): automated entity types, such as `crawler`, `ai_crawler`, or `scanner`.
+*   `entityName` (`string | undefined`): a specific entity name, when identified.
+*   `service` (`string | undefined`): a known service or provider name, when identified.
+
 #### IP type
 
 The `service` field may be `undefined`, but you can use the `hasService()` method to check the availability. Using this method will also refine the type to remove the need for null-ish checks.


### PR DESCRIPTION
Document the IP threat intelligence and Guard billing metadata introduced by arcjet/arcjet#8653.

The Guard examples cover JavaScript, Python, and Go, including language-specific field names, billing units, and optional-presence semantics.