### PR TITLE
fix: links to well-known bots list in documentation

### DIFF
--- a/src/content/docs/bot-protection/identifying-bots.mdx
+++ b/src/content/docs/bot-protection/identifying-bots.mdx
@@ -20,7 +20,7 @@ the `BotCategory` enum.
 ## Individual bots
 
 The [bot
-list](https://github.com/arcjet/arcjet-js/blob/main/protocol/well-known-bots.ts)
+list](https://github.com/arcjet/arcjet-js/blob/main/protocol/src/well-known-bots.ts)
 contains a list of known bots that Arcjet can identify.
 
 For example:
@@ -88,7 +88,7 @@ We provide the following categories:
 - `CATEGORY:YAHOO`: Scrape data for Yahoo products and services
 
 The [bot
-list](https://github.com/arcjet/arcjet-js/blob/main/protocol/well-known-bots.ts)
+list](https://github.com/arcjet/arcjet-js/blob/main/protocol/src/well-known-bots.ts)
 contains a list of categories and which bots are in each category.
 
 <Tabs syncKey="language">


### PR DESCRIPTION
Updated links to the correct path for the well-known bots list.