### PR TITLE
chore: add the Arcjet writing style skill

### DIFF
--- a/.claude/skills/arcjet-writing-style/SKILL.md
+++ b/.claude/skills/arcjet-writing-style/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: arcjet-writing-style
+description: Write and edit technical documentation to the Arcjet writing style, based on the Google developer documentation style guide (developers.google.com/style) – voice and tone, second person, active voice, sentence-case headings, list and procedure structure, code and UI formatting, punctuation, accessibility, inclusive language, and the A-Z word list. Use this whenever the user is writing, reviewing, editing, or restructuring developer-facing documentation – READMEs, API reference, quickstarts, tutorials, how-to guides, release notes, SDK docs, CLI docs, error messages, or docs-site pages – and whenever they ask to "follow the Google style guide," "make this sound like good docs," "edit my docs," or "review this documentation." Also use it for questions about a specific usage decision (hyphenation, capitalization, whether a term is allowed, how to format a placeholder or a command).
+---
+
+# Arcjet writing style
+
+Editorial rules for developer documentation, condensed from Google's public style guide.
+The guide is a house style, not an industry standard – apply it consistently, and depart
+from it where doing so serves the reader better. When you depart, be consistent within
+the document.
+
+Precedence, highest first: the project's own style guide → this skill → Merriam-Webster
+for spelling, Chicago Manual of Style for non-technical style.
+
+Adapting outside Google: guidance naming Google products is a worked example of a general
+rule. Substitute the product being documented and keep the rule.
+
+## Project deviations from Google style
+
+These override the guide wherever they conflict. Apply them without comment; they are
+house rules, not mistakes.
+
+- **Dashes.** Never an em dash (`—`). Use a spaced en dash (`–`) for a break in the flow
+  of a sentence. Google's guidance is the reverse; ignore it. Ranges keep the hyphen.
+
+## The rules that carry most of the weight
+
+1. **Second person.** Address the reader as *you*. Use the imperative for instructions.
+   Reserve third person for what the software or the reader's own end users do. Use *user*
+   only for the user of the software the reader is building.
+2. **Active voice.** Make clear who performs each action. Passive is acceptable to
+   de-emphasize the actor or when the actor is irrelevant.
+3. **Present tense.** *The server sends an acknowledgment*, not *will send*. Reserve future
+   tense for genuinely later events.
+4. **Sentence case** for every title, heading, caption, table cell, label, and list item.
+   No period at the end of a heading.
+5. **Conditions before instructions.** *To delete the document, click Delete* – not the
+   reverse. Location before action: *In the Cloud console, click Save*.
+6. **Serial comma**, always: *zones, regions, and multi-regions*.
+7. **Code font for anything code-like** – filenames, paths, class and method names, flags,
+   env vars, HTTP status codes, ports, IP addresses, data types, console output,
+   placeholders. **Bold for UI element names.** Both, if an element is both.
+8. **Descriptive link text.** Never *click here*, *this document*, or a bare URL. Introduce
+   cross-references with *For more information about X, see Y* – *about*, not *on*.
+9. **No directional language.** Not *above*, *below*, *left-hand side*. Use *preceding*,
+   *following*, *earlier*, or a screenshot.
+10. **Timeless.** Cut *currently*, *now*, *new*, *latest*, *soon*, *existing*. Document how
+    the product works, not how it changed.
+11. **No excessive claims.** Avoid *best*, *fastest*, *simplest*, *always*, *never*,
+    *guarantees*. Security features *help with* security; they don't *prevent* incidents.
+12. **Contractions are good.** *Don't*, *isn't*, *you're*. Negative contractions especially – a scanning reader misses a standalone *not*.
+
+## Voice and tone
+
+Aim for a knowledgeable friend: conversational, friendly, respectful, never frivolous.
+Not pedantic, not chatty.
+
+Avoid: *please* in instructions; *simply*, *easy*, *just*, *quickly* (they shame the reader
+who is stuck); exclamation points; jargon and buzzwords; pop-culture references; humor
+(it doesn't translate); *let's*; internet abbreviations; metaphor and figurative language;
+anthropomorphism (*a Delimiter object specifies where to split a string*, not *tells the
+splitter*).
+
+If a sentence resists you, ask "what am I trying to say?" – the answer is usually the
+sentence.
+
+## Sentences and paragraphs
+
+Short sentences; aim under 26 words. One idea per paragraph, roughly five or six sentences
+at most. Put the load-bearing information first in the sentence and first in the paragraph.
+Standard subject-verb-object order; subject and verb early.
+
+Keep helper words that conversational English drops – *that*, *then*, *of*, and relative
+pronouns. *If the key isn't found, then the default is returned.* *The rules that you
+defined*, not *the rules you defined*.
+
+Use the simple word: *use* not *utilize* or *leverage*, *start* not *commence*, *so* not
+*consequently*. Avoid phrasal verbs where a single verb exists (*uses*, not *makes use of*).
+Don't stack more than two nouns as modifiers.
+
+Don't use the same word as both noun and verb nearby, and place *only* immediately before
+what it modifies.
+
+## Headings
+
+Task sections take a bare infinitive: *Create an instance*, never *Creating an instance*.
+Concept sections take a noun phrase that doesn't start with an *-ing* verb: *Migration to
+Cloud Run*. Prefix optional sections with *Optional:*.
+
+One `h1` per page, and don't repeat the page title as a section heading. Don't skip levels,
+don't leave a heading with no content under it, don't number headings for sequence, don't
+put links in headings, and avoid bare code items (add a descriptive noun). Keep articles in:
+*Create a VM instance*, not *Create VM instance*.
+
+To introduce a group of subsections, say *the following sections* – not *this section*.
+
+## Lists and procedures
+
+Numbered for sequence, bulleted for everything else, description lists for term-definition
+pairs. Never a one-item list. Use a table instead when each item carries three or more
+pieces of related data.
+
+Introduce a list with a complete sentence, not a fragment the items complete. *Use the
+Submit button for any of the following purposes:* – not *Use the Submit button to:*.
+
+Capitalize each item. End with a period unless the item is a single word, has no verb, is
+entirely code font, or is entirely link text. Keep items parallel; if punctuation ends up
+inconsistent, rewrite for parallelism.
+
+A one-step procedure is a bulleted item, not a numbered list of one. Sub-steps get
+lowercase letters, then lowercase Roman numerals. Within a step: action, then command, then
+placeholder explanations, then output. State the goal before the action, the location
+before the action, the result after the action. *Optional:* leads the step. Combine menu
+selections with `>` rather than splitting them across steps. Include the `Enter` keypress in
+the step that needs it. Don't say *run the following command* – say what the command does.
+Where there are several ways to do something, document the best one.
+
+## Code, commands, and UI
+
+Put in code font: filenames, paths, directories, class/method/function names, flags,
+keywords, env vars, data types, enum names, HTTP verbs and status codes, ports, IP
+addresses, query parameters, command output, and text the reader types. Keep in ordinary
+font: product names, organization names, domain names, and URLs the reader visits.
+
+Don't inflect code items – no plurals, no possessives, no verbing. Add a noun and inflect
+that: *the `wordCount` method's return value*, *send a `POST` request*.
+
+Placeholders are `UPPERCASE_WITH_UNDERSCORES`, always explained. One placeholder: *Replace
+`BUILD_ID` with ...*. Two or more: *Replace the following:* then a list, in order of
+appearance, each *`NAME`: lowercase description*.
+
+Wrap code at 80 characters, mark omissions with a comment in the sample's own language
+(never an ellipsis), and introduce samples with a sentence ending in a colon.
+
+Bold every UI element name, matching the on-screen capitalization unless it's inconsistent
+or all-caps (then sentence case). Don't verb UI labels – *In the Name field, enter a name*,
+not *Name the account*. Prepositions: *in* a dialog, field, list, menu, pane, or window;
+*on* a page, tab, or toolbar. Use *select* and *clear* for checkboxes, *enter* for boxes,
+*press* for keys. Spell out modifier keys: `Control+Shift+S`.
+
+## Notices
+
+Four types, used sparingly – two in a row means the content needs reorganizing.
+**Note**: useful but skippable. **Caution**: proceed carefully. **Warning**: don't do this,
+or it's irreversible. **Success**: interactive content only.
+
+Never use a note for a prerequisite, a cross-reference, a required step, or anything the
+reader must know to succeed.
+
+## Numbers, dates, and units
+
+Spell out zero through nine; numerals for 10 and up. Always numerals for versions,
+technical quantities, measurements, percentages, dimensions, and anything with a decimal.
+Spell out a number that starts a sentence, or rewrite. Ordinals are words: *first*, *fifth*.
+
+Dates: *January 19, 2017*. Numeric only when forced, and then ISO 8601: `2017-04-15`.
+Never slashes. Times: 12-hour, `3 PM`, `3:45 PM`. Avoid seasons – use months or quarters.
+
+Units: nonbreaking space between number and unit (`64&nbsp;GB`), no space for `$10`, `65%`,
+`180°`. Repeat the unit across a range and join with *to*, not a hyphen: *-40 °C to 85 °C*.
+Don't write MB when you mean MiB.
+
+## Reference files
+
+Read the file that covers the question rather than guessing; the details are dense and
+mostly not derivable.
+
+| File | Covers |
+|---|---|
+| `references/word-list.md` | 600+ A-Z term decisions: spelling, hyphenation, capitalization, allowed and forbidden terms. **Check this before settling any individual word.** |
+| `references/language-and-grammar.md` | Person, voice, tense, pronouns, articles, possessives, plurals, abbreviations, capitalization, jargon, *must/can/might/should* |
+| `references/punctuation.md` | Commas, dashes, hyphens and compounds, colons, semicolons, periods, quotation marks, slashes, parentheses, ellipses |
+| `references/formatting.md` | Headings, lists, procedures, tables, notices, links, images and alt text, numbers, dates, units, footnotes, text-formatting summary |
+| `references/code-and-ui.md` | Code in text, code samples, command-line syntax, placeholders, UI elements, keyboard keys, API reference comments |
+| `references/global-and-inclusive.md` | Accessibility, inclusive language, writing for translation, excessive claims, timeless docs, example names and domains, third-party content |
+
+## Document workflow
+
+**Writing new:** decide task page or concept page – it sets the heading style and the
+document title. Draft, then run the checklist below.
+
+**Editing existing:** fix in this order, because later passes depend on earlier ones –
+structure (headings, list vs. table, procedure shape), then sentences (person, voice,
+tense, length), then terminology (word list), then mechanics (punctuation, code font,
+numbers). Preserve the author's technical claims; you're editing style, not facts. If a
+sentence is technically ambiguous, flag it rather than guessing at the meaning.
+
+Report substantive changes compactly – grouped by category, not line by line – and leave
+the trivia silent.
+
+**Checking your own output:** run `scripts/style_check.py FILE` for the mechanical
+violations that are easy to miss – `please`, `simply`, *click here*, `e.g.`, curly quotes,
+`&`, directional language, title-case headings, timeless-docs words, em dashes, exclamation
+points. It's a regex pass, so it catches a narrow class of errors with a low false-positive
+rate. It doesn't replace reading the text.
+
+The same command runs a code font consistency pass. It harvests identifiers from the
+document's own code blocks and inline code, then reports any that also appear bare in
+prose – the failure that produces a page where `guardTool` is monospaced in the body and
+plain in the FAQ. It reads each fenced block's language label, or infers it, so that
+keywords are never mistaken for identifiers: `class`, `type`, `range`, `set`, `map`,
+`input`, `filter`, and `from` are code in one language and ordinary English in prose, and
+a document can mix Python and JavaScript without either one poisoning the other.
+
+| Flag | Effect |
+|---|---|
+| *(default)* | Reports identifiers used inconsistently within one document |
+| `--strict-code-font` | Also reports identifier-shaped tokens that never appear in code font – usually missing backticks, sometimes a product name |
+| `--no-code-font` | Skips the pass |
+| `--only CATEGORY` | Restricts output to `tone`, `wording`, `timeless`, `claims`, `inclusive`, `a11y`, `mechanics`, `heading`, `code-font`, or `maybe` |
+
+Bare single words qualify only when prose writes them as a call – `protect()` is flagged,
+*the tool* is not. Single-word capitalized tool names such as `Bash` and `Write` are below
+the detection threshold; check those by eye.
+
+## Review checklist
+
+- Second person, active voice, present tense throughout
+- Every heading sentence case; task headings bare infinitive; hierarchy unbroken
+- Lists introduced by complete sentences; items parallel; punctuation consistent
+- Procedures: location before action, goal before action, one action per step
+- Code font on code items, applied consistently in every section including FAQs
+- Bold on UI names; placeholders uppercase and explained
+- Link text descriptive and meaningful out of context
+- No directional language, no *please*, no *simply*, no exclamation points
+- No time-anchored words, no superlatives, no unverifiable claims
+- Abbreviations defined on first use; terms consistent across the document
+- Example names, domains, IPs, and phone numbers drawn from the reserved sets
+- Alt text on every image; nothing conveyed by color or position alone
+- Contested terms checked against the word list
+
+---
+
+Adapted from the [Google developer documentation style guide](https://developers.google.com/style),
+used under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).

--- a/.claude/skills/arcjet-writing-style/references/code-and-ui.md
+++ b/.claude/skills/arcjet-writing-style/references/code-and-ui.md
@@ -1,0 +1,235 @@
+# Code, commands, and UI
+
+Code font · Code samples · Command-line syntax · Placeholders · Command output · UI
+elements · Keyboard keys · API reference comments
+
+## Code font in running text
+
+Code font signals that text is meant literally, shows where the literal text starts and
+stops, and separates the entity from the prose around it. HTML `code`; Markdown backticks.
+
+**Use code font for:**
+
+attribute names and values · class names · command output · command-line utility names
+(`kubectl`, `gcloud`, `bq`) · data types · database rows and columns · defined constants ·
+DNS record types · element names, HTML and XML (without angle brackets) · enum names ·
+environment variables · filenames, extensions, paths, directories, folders · HTTP
+content-type values · HTTP status codes · HTTP verbs · IAM role names · IP addresses ·
+language keywords · method and function names · namespace aliases · package names · port
+numbers · query parameter names and values · strings such as URLs or domain names used
+inside commands and code · text the reader types · placeholder variables · UI elements
+whose labels are generated from text the reader entered
+
+**Keep in ordinary font:** product, service, and organization names; domain names in prose;
+URLs the reader visits in a browser (better: make them descriptive links).
+
+**Sometimes:**
+
+- *Boolean values* – code font for the literal value (*returns `true`*), ordinary font for
+  the evaluation of a condition (*If true, validates the certificate*).
+- *Command-line utility names* – code font for the command, ordinary font for the project:
+  *the options for the `curl` command are explained on the curl project website*.
+- *Email addresses* – code font as computer input or output, ordinary font (and a link)
+  as a way to contact someone.
+
+Don't put quotation marks around code unless the quotation marks are part of the code.
+
+**Code in UI elements:** an element that qualifies for code font and appears in the UI gets
+both – *In the **Network** list, select **`my-net-2`***.
+
+**Method names:** drop the class name unless it's needed to disambiguate – *call its `get`
+method*, not *call its `animal.get` method*.
+
+**HTTP status codes:** *an HTTP `400 Bad Request` status code*. Call it a *status code*,
+never a *response code* or *error code*. Ranges: *an HTTP `2xx` status code* or *a status
+code in the `200`-`299` range*, with the numbers in code font either way.
+
+**Grammar of code elements:** don't inflect them and don't use them as English verbs or
+nouns. Add a noun and inflect the noun.
+
+| Recommended | Not recommended |
+|---|---|
+| The `ADDRESS` constant's value is defined in the `settings.h` file. | `ADDRESS`'s value is defined in `settings.h`. |
+| To add the data, send a `POST` request. | `POST` the data. |
+| You can't call the `close` method for a file before you call `open`. | `Close`ing the file requires you to have `open`ed it first. |
+| Takes an array of `INT64` values and returns `BYTES` values. | Takes an ARRAY of INT64 and returns BYTES. |
+
+Give technical keywords a qualifying noun: *the `example.yaml` file*, not *`example.yaml`*
+by itself.
+
+## Code samples
+
+- Follow the language's own style guide for indentation – usually spaces, two per level.
+- Wrap at 80 characters.
+- Mark blocks as preformatted: `pre` in HTML, a fence or four-space indent in Markdown.
+- Mark omissions with a comment in the sample's language – never `...` or `…`. A block
+  containing an omission shouldn't be click-to-copy.
+- Introduce with a sentence, colon if the sample follows immediately, period if other
+  material intervenes or the last sentence isn't about the sample.
+
+## Command-line syntax
+
+**Best practices.** Link to the command reference in the text that introduces the command.
+Use as few optional arguments as possible; let the reference carry the full list. Give a
+click-to-copy example the reader doesn't need to edit – ideally only runnable code and
+placeholders.
+
+**Formatting.** Break lines over 80 characters before a hyphen, double hyphen, underscore,
+or quotation mark, and indent continuation lines four spaces. Every line but the last needs
+the continuation character: ` \` on Linux and Cloud Shell, ` ^` on Windows. Follow the
+command with the placeholder explanations. End-punctuate documented options only when
+they're complete sentences.
+
+**Prompts.** Start each line with the prompt symbol when showing multiple input lines. Don't
+show the working directory. Add a new prompt indicator when the context changes (local to
+remote). The `$` is optional for a single line, but be consistent within a document. Put
+input and output in separate blocks.
+
+**Syntax conventions** – avoid all of these in click-to-copy examples, because the
+characters break the command if the reader doesn't strip them:
+
+| Notation | Meaning |
+|---|---|
+| `[FLAG]` | Optional; bracket each optional item separately |
+| `{A\|B}` | Mutually exclusive – choose exactly one |
+| `[FLAG ...]` | Argument can repeat |
+
+Instead of bracket notation in a copyable example, do one of: drop the optional arguments
+and link to the reference; give a separate code block per option; split the options into
+separate task sections; or state plainly that the command contains optional arguments.
+
+**Terminology.** In `gcloud`, a *flag* is any element other than the command or group name,
+and a flag or command may take an *argument*; *option* is the safe catchall. In Linux,
+commands take *options*, *parameters*, and *arguments*, plus metacharacters, globbing, and
+redirection. Describe what the whole command does rather than naming every part, and don't
+map `gcloud` nomenclature onto Linux nomenclature.
+
+**Linux signals** are the one place where *kill*, *terminate*, *quit*, *suspend*, and
+*stop* are the correct words – use each signal's own verb (`SIGKILL` kills, `SIGTERM`
+terminates, `SIGINT` interrupts, `SIGSTOP` stops) and don't substitute synonyms.
+
+## Placeholders
+
+Placeholders stand for values the reader replaces, and for varying values in example
+output. Give each a descriptive name; don't use `x` or a run of `x`s except where it's the
+standard (HTTP status ranges).
+
+**Format:** `UPPERCASE_WITH_UNDERSCORES`. Not `API-name`, `API_name`, `api_name`,
+`apiName`. Never include possessives – no `MY_API_NAME` or `YOUR_API_NAME`. In HTML, wrap
+in `var` inside `code`; in Markdown, `` *`PLACEHOLDER`* `` inline, or plain inside a fence.
+Brackets, braces, and ellipses stay outside the `var` element.
+
+**Explain on first use.** Repeat the explanation only in long documents, after several
+other placeholders, or in documents readers won't read start to finish.
+
+One placeholder:
+
+> Replace `BUILD_ID` with the ID of the `WORKING` build that you copied in the preceding
+> step.
+
+Two or more – introduce with *Replace the following:*, list in order of appearance, colon
+after each, description starting lowercase:
+
+> Replace the following:
+>
+> - `ADMIN_PROJECT_ID`: the project that owns the reservation
+> - `LOCATION`: the location of the reservation
+> - `CONCURRENCY`: the maximum concurrency target
+
+Introduce an example inside a description with an en dash or *such as* – *`ZONE`: a zone
+close to your location – for example, `us-east1`*.
+
+Placeholders in output follow the same pattern, introduced with *This output includes the
+following values:*.
+
+## Command output
+
+Show output only when it earns its place – the reader needs to copy a value from it or
+verify something in it.
+
+Introduce with *The output is similar to the following:* or *The output is the following:*.
+Customize when you want to point at something: *The output is similar to the following, in
+which the `IP` column shows the address for each resource:*.
+
+Mark omitted lines with `...` on its own line – three periods, not the ellipsis character.
+
+## UI elements
+
+State instructions in terms of what the reader accomplishes, not the widget: *Refresh the
+page*, *Expand the **Advanced options** section*. Drop to widget level when the procedure
+is genuinely about navigating the UI or the control is hard to find.
+
+**Bold every UI element name** – buttons, menus, dialogs, windows, list items, anything with
+a visible label. Don't bold a product or feature name unless it's labeling an on-screen
+element. Give context for an element mentioned outside a procedure: *the **Current jobs**
+section of the service console*.
+
+Match on-screen capitalization, except that all-caps and inconsistently cased labels become
+sentence case: *Click **Refresh***, not *Click **REFRESH***.
+
+Don't verb UI labels:
+
+| Recommended | Not recommended |
+|---|---|
+| In the **Name** field, enter an account name. | **Name** the account. |
+| To save the settings, click **Save**. | **Save** the settings. |
+| For **Service account ID**, enter a name. | Specify a **Service account ID**. |
+
+**Terminology.** *Window* – an application window or a dockable module. *Page* – a web page
+or a console subpage. *Dialog* – a small detached window (not *pop-up*). *Pane* or *panel* – a rectangular region inside a window (not *section*, *area*, or *column*). *Section* – a
+labeled grouping of controls within a window or pane. *Menu bar* holds *menus*, which hold
+*commands* (not *choices*, *menu items*, or *options*). *Navigation menu*, not *navigation
+bar/pane/panel*. *Toolbar* holds buttons; one with a menu is a *menu button*. *Tab*,
+*text box* (*field* in Google Cloud and Workspace), *list box*, *combo box*, *spin box*,
+*checkbox*, *radio button*, *expander arrow*, *toggle*.
+
+No slang: not *hamburger icon*, *zippy*, *expando*, *drop-down* (as a noun for *menu*).
+
+**Angle brackets** abbreviate menu paths: *Select **View > Tools > Developer Tools***. Put a
+nonbreaking space before each bracket, bold the whole sequence as one span, and wrap each
+bracket in `<span aria-label="and then">` so screen readers don't say "greater than". Only
+for menu items – don't chain different element types.
+
+**Buttons and icons.** Refer to a button by its label: *Click **OK***, not *Click the "OK"
+button*. For an icon button, show the icon and then the tooltip name: *Click ⋮ **Settings
+and utilities***. Never the icon alone, and never *Click the bell icon*. Drop trailing
+ellipses from labels: **Save ...** is documented as **Save**. If a button has no tooltip,
+file a bug – tooltips are an accessibility requirement.
+
+For hard-to-find elements, use the icon plus name, add context (*On the Cloud Run toolbar*),
+or supply a screenshot. Never directional language.
+
+**Verbs:** click, choose, drag, enable, enter, type, go to, hold the pointer over, press,
+select, tap, turn on, turn off. Use *select* and *clear* for checkboxes rather than *check*
+and *uncheck*; refer to state as *selected* or *not selected*. Don't use *toggle* as a verb.
+
+**Prepositions:** *in* a dialog, field, list, menu, pane, or window; *on* a page, tab, or
+toolbar.
+
+## Keyboard keys
+
+Use `kbd` in HTML, monospace elsewhere. Uppercase letter keys: `Control+S`, never
+`Control+s`. Spell out modifier keys – Command, Control, Option, Shift – and never use
+symbols. Spell out confusable characters: comma, hyphen, period, plus.
+
+Refer to a key by name, adding *key* if it would otherwise be ambiguous: *Press `Esc`* or
+*Press the `Esc` key*. Combination form is `MODIFIER+KEY`, with Shift in the middle:
+`Control+Shift+?`.
+
+Put the macOS shortcut in parentheses after the Windows and Linux one: *press `Control+C`
+(or `Command+C` on macOS)*.
+
+Use *press* for triggering an action and *enter* or *type* for entering text. Call it a
+*keyboard shortcut* or a *key combination*. Use `code`, not `kbd`, when the key's value is
+being entered as text.
+
+## API reference comments
+
+Phrase a method's main description in terms of what the method does – third person with the
+*-s*: *Creates a new task on the specified task list*, not *Create a new task*.
+
+In Android reference material, link the first mention of each API element (class, method,
+constant, XML attribute) in a section, in code font; later mentions in the same section use
+code font without the link. When a term is used as a concept rather than a class, don't
+capitalize it and don't use code font – *the user interface for an activity* versus *the
+`Activity` class*.

--- a/.claude/skills/arcjet-writing-style/references/formatting.md
+++ b/.claude/skills/arcjet-writing-style/references/formatting.md
@@ -1,0 +1,349 @@
+# Formatting and organization
+
+Text formatting · Headings · Lists · Procedures · Tables · Notices · Links · Images and alt
+text · Numbers · Dates and times · Units · Footnotes · Math · Filenames · HTML and Markdown
+
+## Text-formatting summary
+
+| Style | Use for |
+|---|---|
+| **Bold** (`<b>`, `**`) | UI element names; run-in headings, including the label at the start of a notice |
+| *Italic* (`<i>`, `_`) | New terms on first definition; words as words; titles of full-length works; mathematical and version variables; genuine emphasis |
+| `Code` (`<code>`, backticks) | Anything code-like in running text (see `code-and-ui.md`) |
+| Code block (`<pre>`, fences) | Code samples, commands, output |
+| Underline | Links only |
+
+In Markdown, use `**` for bold and `_` for italics – `__` and `*` are hard to tell apart in
+source. Don't override font family, size, or color inline. Never use `&` as a conjunction,
+including in headings and navigation; the exception is a UI element whose own label
+contains `&`.
+
+## Headings
+
+**Task sections** start with a bare infinitive: *Create an instance*. **Concept sections**
+use a noun phrase that doesn't start with an *-ing* verb: *Migration to Google Cloud*.
+Mixing both styles in one document is fine – match each heading to its own section.
+
+Gerunds as the first word translate inconsistently and eat character budget. Established
+noun gerunds (*Billing*, *Pricing*) are fine, as is an *-ing* form later in a heading
+(*Introduction to BigQuery monitoring*).
+
+Prefix optional sections with *Optional:* rather than trailing *(optional)*.
+
+Rules:
+
+- Sentence case; no terminal period; keep articles.
+- One `h1` per page. Don't repeat the page title as a section heading – page *Create and
+  start VM instances* with sections *Create a VM* and *Start a VM*.
+- Never skip a level; never leave a heading with no content beneath it.
+- Don't number headings for sequence – hierarchy and order convey it.
+- Don't put links in headings. Avoid bare code items; add a descriptive noun.
+- Keep punctuation simple; complex punctuation means the heading needs rewriting.
+- Abbreviate only when the abbreviation is the better-known form; define it in the first
+  paragraph below.
+- Use heading elements for structure, CSS for appearance.
+
+Introduce a group of subsections with *the following sections*, never *this section*.
+
+For anchors, use lowercase and hyphens. Add a custom anchor when you expect frequent
+inbound links or when revising a heading would otherwise break existing links; if you
+change a heading that has an auto-generated anchor, add the old ID as a custom anchor.
+
+## Lists
+
+| Type | Use for | Elements |
+|---|---|---|
+| Numbered | Sequence: steps, phases, priorities | `ol`, `li` |
+| Bulleted | Non-sequential sets; make clear whether all items are required | `ul`, `li` |
+| Description | Term-and-definition pairs, glossaries | `dl`, `dt`, `dd` |
+| Description with run-in headings | Several concepts to highlight and explain compactly | `ul`, `li` |
+
+Never make a list of one item. Nested numbered lists take lowercase letters, then lowercase
+Roman numerals. A list item can hold multiple paragraphs – use `p` elements, not `br`.
+
+**Introductions.** Precede a list with a complete sentence, not a fragment the items
+complete. Colon if the list follows immediately, period if other material intervenes. A
+list needs no introduction if the preceding heading supplies the context.
+
+| Recommended | Not recommended |
+|---|---|
+| Use the **Submit** button for any of the following purposes: | Use the **Submit** button to: |
+| To get the USB driver, follow these steps: | To get the USB driver: |
+| If you need to add an instance manually, do the following: | If you need to add an instance manually: |
+
+**Capitalization and end punctuation.** Capitalize each item unless case carries meaning.
+End with a period, except when the item is a single word, has no verb, is entirely code
+font, or is entirely link text or a document title. If punctuation ends up inconsistent
+across items, rewrite for parallelism rather than mixing.
+
+**Description lists.** Capitalize each term; no period after the term; period at the end of
+each description.
+
+**Run-in headings.** Capitalize; end with a period or a colon, consistently within the
+list. After a period, the description starts capitalized and ends with a period. After a
+colon, the description starts lowercase and takes a period only if it contains a verb or
+expresses a standalone thought:
+
+- **Coffee**: latte, mocha, cappuccino, espresso
+- **It increases fuel economy by reducing baggage weight**. By charging astronomical prices
+  for anything larger than a wallet...
+
+Never separate an item from its description with a dash.
+
+**Comma-separated lists in prose** take serial commas. Don't end with *etc.* or *and so
+on* – introduce the list so it's clear it isn't exhaustive: *The service processes data like
+event logs, clickstream data, and e-commerce transactions.*
+
+## Procedures
+
+Introduce with a complete sentence, ending in a colon if the steps follow immediately:
+*To customize the buttons, follow these steps:* or *To customize the buttons, do the
+following:* – not *To customize the buttons:*. Skip the introduction when the heading
+already says everything.
+
+A one-step procedure is a single bulleted item, not a numbered list of one.
+
+Sub-steps use lowercase letters, then lowercase Roman numerals. A step that has sub-steps
+ends with a colon or period, like any introduction.
+
+**Order within a complex step:** describe the action → give the command → explain the
+placeholders → explain the command if needed → show the output if needed → explain the
+result in a separate paragraph.
+
+**Rules for steps:**
+
+- Start with an imperative verb; write complete sentences; keep verb forms parallel.
+- State the location before the action: *In the Google Cloud console, go to the
+  **Monitoring** page* – not the reverse. Restate the context at the start of each
+  procedure, even if it's unchanged from the last one.
+- State the goal before the action: *To start a new document, click **File > New >
+  Document***. If that framing makes a required step look optional, use the colon form:
+  *Start a new document: click **File > New > Document***.
+- State the result after the action, in the same paragraph: *Click **Run**. The query
+  results appear after the query runs.* Don't announce a dialog in one step and then
+  re-describe it in the next.
+- Lead an optional step with *Optional:* – not *(Optional)*.
+- Combine sequential menu selections into one step with `>`: *Click **File > New >
+  Document***. Don't stretch this to mixed element types.
+- Include the `Enter` keypress in the step that needs it, not as its own step.
+- Don't document keyboard shortcuts as the primary path.
+- Don't introduce a command with *run the following command* – say what the command does.
+- When there's more than one way, document one: prefer the keyboard-accessible path, then
+  the shortest, then the language your audience knows best. If you must document several,
+  separate them by page, heading, or tab.
+- Don't repeat a procedure – link to it.
+- Tell readers what they need before they start; limit interruptions; one decision per step.
+- Avoid tables mid-procedure.
+
+## Tables
+
+Use a table when each item carries three or more related pieces of data. One item that's a
+single unit belongs in a list; a pair of data belongs in a description list.
+
+Don't use tables for page layout, code snippets, single-column data, or long
+one-dimensional lists split into columns. Avoid them inside numbered procedures.
+
+- Introduce every table with a complete sentence – many screen readers don't preannounce
+  tables. Refer to position: *the following table*.
+- Never put a table in the middle of a sentence.
+- Sentence case everywhere: headings, cells, captions.
+- Concise column headings, no terminal punctuation.
+- `th` for the first row and first column only; add `scope` for accessibility.
+- Never merge cells; no `colspan` or `rowspan`. No styling on the table element, and never
+  use color or font alone to signal a header.
+- Sort rows logically, or alphabetically if there's no logical order. Split long or
+  multi-header tables.
+- Caption only when the document has several tables in proximity: `<b>Table 1.</b>
+  Description`, sentence case, no terminal period. Refer to it by number – *as shown in
+  table 2* – with *table* lowercase mid-sentence.
+- Any image or symbol in a cell needs descriptive alt text.
+
+## Notices
+
+Use sparingly. Several notices in a row means the content needs restructuring. If you're
+unsure, write it as body text first and see whether it still needs setting off.
+
+| Type | Meaning |
+|---|---|
+| Note | Useful aside or tip; the reader still succeeds if they skip it |
+| Caution | Proceed carefully |
+| Warning | Don't do this, or it's irreversible – data loss, cost, security exposure |
+| Success | A successful action or error-free status; interactive content only |
+
+Create a note only when all three hold: the information is relevant but not necessary;
+interrupting here doesn't derail the reader; and it isn't just a continuation of the
+surrounding text.
+
+Never use a note for a cross-reference, a prerequisite, a step the reader should have taken
+earlier, a full procedural step, expected results, or anything required for success.
+
+## Links and cross-references
+
+Every link is a decision and a chance to lose the reader. Prefer giving the information in
+place when it's a definition, a brief concept, or two steps. Link rather than reproduce
+someone else's standards.
+
+Don't duplicate links on a page, except when linking to a specific section, when the page
+is very long, or when there are genuinely multiple entry points.
+
+**Link text** is either the exact page title or a descriptive phrase capitalized as part of
+the sentence. Put the important words first; keep it short; don't reuse the same text for
+different targets. It must make sense read out of context – screen reader users jump link
+to link.
+
+- Recommended: For more information, see Load balancing and scaling.
+- Not recommended: See this blog post. / Want more? Click here! / For more information, see
+  this document.
+
+Don't use a URL as link text. Include both the long form and the abbreviation when the text
+has one: *Google Kubernetes Engine (GKE)*. Include the descriptive noun with a code
+element: *the `gcloud instances create` command with the `--hostname` flag*.
+
+**Introductions:** *For more information, see X* or *For more information about Y, see X*.
+Use *about*, never *on*. Use *see*, not *read* or *check out*. Add the *about* clause
+whenever the link text alone doesn't explain why you're sending the reader there.
+
+**Explain unexpected behavior:** downloads (name the file type), mailto links, on-page
+jumps (*see the X section of this document*), and links to a section on another page. Don't
+force links to open in a new tab; if one must, say so in the link text.
+
+## Images and alt text
+
+Introduce every image with a complete sentence – colon if it immediately precedes the
+image, period otherwise. Screenshots that directly follow the procedural text describing
+the UI need no introduction.
+
+**Alt text** is required on every `img`, even if empty. Omitting the attribute makes some
+screen readers read the filename aloud. Use `alt=""` for decorative images and for images
+that only restate adjacent text – UI screenshots showing how to fill in fields, icons,
+ornamental images.
+
+Write alt text as a full sentence or noun phrase, under 155 characters, with punctuation
+(screen readers pause on it). Don't start with *Image of* or *Photo of*. Avoid all-caps.
+Keep it consistent for repeated images. Consider context, not just content. If the image
+carries more than 155 characters' worth of information, summarize in `alt` and give the
+full description in the body text.
+
+**Figure captions** are optional. Format: `<b>Figure 1.</b> Description.` Complete
+sentences, always end-punctuated. Refer to figures by number (*as shown in figure 1*), not
+by position. Don't use a caption as a substitute for alt text.
+
+**Figure descriptions** carry in text whatever the image conveys – new information must
+never appear only in an image. Avoid embedding explanatory text in graphics; it breaks
+accessibility, search, and localization. When text in an image is unavoidable, keep it
+brief, sentence case, no new abbreviations, full product names.
+
+Prefer SVG to PNG. Never use images of text, code, or terminal output.
+
+## Numbers
+
+Spell out zero through nine; use numerals for 10 and above. Spell out a number that starts
+a sentence, or rearrange the sentence. Spell out a number immediately followed by a
+numeral: *fifteen 100,000-byte files*. Spell out casual approximations: *thousands of
+combinations*, *a million songs*.
+
+Always numerals, even below 10: version numbers; technical quantities (memory, disk,
+queries, limits); page, chapter, and step numbers; prices; numbers without units; negative
+numbers; fractions; percentages; dimensions; decimals; measurements; numbers in a range;
+and any number below 10 sharing a sentence with a number above 9.
+
+Ordinals are always words: *first*, *fifth*, *forty-third*.
+
+Decimals: leading zero below one (`0.3 inches`); treat as plural even at 1.0 (`1.0 inches`).
+Fractions: prefer decimals; hyphenate spelled-out fractions (*two-fifths*).
+
+Percentages: numeral plus `%`, no space – `40%`. Spell out both if the percentage starts a
+sentence.
+
+Ranges: hyphen, no spaces – `2012-2016`. (With units, repeat the unit and use *to*.)
+
+Digit grouping: commas every three digits left of the decimal, including four-digit
+numbers (`2,000`); nothing to the right of the decimal. Period for the decimal point.
+
+Currency: `$10,000`, `$0.006653`. Make the currency unambiguous – `US$10` when it could be
+read otherwise.
+
+Dimensions: numerals with a lowercase `x`, no spaces – `192x192`.
+
+Avoid Roman numerals except for sub-sub-steps.
+
+## Dates and times
+
+Spell out months and days of the week; give the full four-digit year: *January 19, 2017*;
+*Tuesday, April 27, 2021*. No comma between a bare month and year: *January 2017*. A full
+date mid-sentence takes a comma after the year: *The January 19, 2017, release of...*
+
+Three-letter abbreviations are acceptable where space is tight (*Mon, Sep 3, 2018*) – but
+abbreviate the whole date, not part of it, and do it consistently across the document.
+
+Never numeric dates with slashes – `04/05/09` means three different dates in three parts of
+the world. If a numeric date is unavoidable, use ISO 8601: `2017-04-15`. In invented
+examples, pick a day above 12 so the order is self-evident.
+
+Times: 12-hour clock unless the product uses 24-hour. Capitalize `AM` and `PM` with a space
+before them. Drop `:00` from round hours – `3 PM`, `3:45 PM`. Hyphen, no spaces, in ranges:
+`5-10 minutes`. Date before time: *May 4, 2009, at 6 PM*.
+
+Time zones: avoid unless necessary. When required, spell out the region and give the offset
+in parentheses – *US and Canadian Pacific Standard Time (UTC-8)*. Never abbreviate the zone
+name. Prefer telling readers the time is local to them.
+
+Avoid seasons – they invert across hemispheres. Use months, quarters, or temperature:
+*During warmer months*, not *During summer months*.
+
+## Units of measurement
+
+Nonbreaking space between number and unit: `64&nbsp;GB`, `25&nbsp;mm`. No space for
+currency, percent, or degrees of an angle: `$10`, `65%`, `180°`. Temperature takes a
+nonbreaking space before the degree symbol and none between symbol and scale:
+`50&nbsp;&deg;C`. Kelvin drops the degree symbol: `300&nbsp;K`.
+
+In a range, repeat the unit and join with *to* – a hyphen reads as a minus sign:
+*-40 °C to 85 °C*.
+
+Hyphenate multiplied units: *5 vCPU-hours*. Don't hyphenate number-plus-abbreviated-unit
+before a noun: *200 GB disk*.
+
+Use *per*, not a slash, when space permits: *requests per day*. Shorten to *p* only in
+established rate abbreviations: *Gbps*, *MBps*.
+
+Match the byte system to the technology you're documenting: decimal `kB`/`MB`/`GB` versus
+binary `KiB`/`MiB`/`GiB`. Don't write one when you mean the other.
+
+Lowercase `k` for thousands is acceptable with no space and an explicit noun: *55k download
+operations*.
+
+## Footnotes
+
+Avoid them – they're poor for accessibility and localization. Use a cross-reference, a
+note, or a parenthetical instead. If unavoidable, use a superscript number and place
+footnotes immediately after a table.
+
+## Mathematical notation
+
+Italicize variables, never operators. Use HTML entities for operators (`&minus;`, `&times;`,
+`&ne;`, `&le;`) rather than keyboard characters, with nonbreaking spaces on both sides:
+`<i>a</i>&nbsp;&minus;&nbsp;<i>b</i>`. Don't use an asterisk for multiplication in text.
+Keep short expressions inline. Don't put a space between a base and its exponent.
+
+## Filenames
+
+Lowercase, hyphens (not underscores – search engines read hyphens as word breaks), standard
+ASCII only, no generic names like `document1.html`. Stay consistent with an existing
+directory's convention even if it conflicts with this.
+
+Refer to files in code font with the word *file*: *the `pg_hba.conf` file*. Name file types
+formally – *a PNG file*, not *a .png file*.
+
+## HTML, Markdown, and semantic tagging
+
+Either format is fine; follow whatever the project already uses. Markdown is easier to read
+and write; HTML is more expressive, especially for semantic tagging and special characters.
+
+Use elements for their semantics, not their appearance: `em` for emphasis and `i` for
+non-emphasis italics; `strong` for importance and `b` for visual weight; `cite` for titles
+of standalone works; `p` plus CSS for spacing, never `br`; heading elements only for
+hierarchy, never to change type size; CSS, never tables, for layout.
+
+Two-space indentation, no tabs, lowercase elements and attributes, no trailing whitespace,
+80-character lines – except `meta` elements and long URLs, which can't break.

--- a/.claude/skills/arcjet-writing-style/references/global-and-inclusive.md
+++ b/.claude/skills/arcjet-writing-style/references/global-and-inclusive.md
@@ -1,0 +1,260 @@
+# Accessibility, inclusion, and global audiences
+
+Accessibility · Inclusive language · Global audiences · Excessive claims · Timeless
+documentation · Example names and reserved values · Third-party content
+
+## Accessibility
+
+Roughly 15% of the world has an accessibility need. Documentation written for accessibility
+reads better for everyone.
+
+**General**
+
+- Ensure everything – tabs, buttons, interactive elements – is reachable by keyboard alone.
+- Test with a screen reader; it doubles as a self-edit.
+- Use semantic HTML and native elements over custom styling. Screen readers announce text
+  modifications, so don't add formatting that carries no meaning.
+- Don't force line breaks inside sentences or paragraphs; they break on resize and at large
+  text sizes.
+- Avoid camel case and all-caps – some screen readers read capitals letter by letter, and
+  some languages are unicase.
+- Not all punctuation is read aloud. The meaning must survive without it, which is another
+  reason to avoid exclamation points, question marks, and semicolons.
+- Never `&` for *and* in headings, body text, navigation, or contents.
+
+**Ease of reading**
+
+- Break up walls of text with paragraphs, headings, and lists.
+- Under 26 words per sentence.
+- Define acronyms on first use and again if usage is sparse.
+- Parallel structure for parallel things.
+- Put the distinguishing information in the first sentence of a paragraph.
+- Avoid double negatives and exceptions to exceptions: *You can continue without a path*,
+  not *A missing path won't prevent you from continuing.*
+- Left-align. Never center or justify.
+
+**Headings** – hierarchy unbroken, no skipped levels, no empty headings, real heading
+elements, one `h1`, CSS for appearance.
+
+**Links** – meaningful out of context; never *click here* or *read this document*; use
+*see*; explain unexpected behavior; avoid adjacent links or separate them with a character.
+
+**Images** – `alt` on every image, empty when decorative; never introduce new information
+only in an image; never images of text, code, or terminal output; SVG over PNG.
+
+**Video** – captions, transcripts, or descriptions; captions translatable; nothing that
+flickers or flashes.
+
+**Tables** – introduce in the preceding text; `th` for first row and column only; `scope`
+where relevant; `headers` and unique IDs for multiple header rows; never merged cells;
+avoid tables mid-procedure; no information carried by an image or symbol without alt text.
+
+**Interactive elements** – introduce in the text before them.
+
+**Forms** – `label` on every input, placed outside the field; error messages that say what
+went wrong and how to fix it.
+
+**Custom CSS and JavaScript** – 4.5:1 contrast for text; never `visibility:hidden` or
+`display:none` for content; avoid mouseover-only interactions, or pair them with focus and
+blur handlers; keep visual order consistent with DOM order.
+
+**Rendering test.** The document must convey everything without sound, without images,
+without color, without punctuation, using only sound, using only a keyboard, and under
+magnification. Never let color, size, or position be the only carrier of meaning – pair a
+color or icon state change with a text label change.
+
+**Directional language.** Not *above*, *below*, *left-hand side*. In a document, use
+*earlier*, *preceding*, *following*: *In the preceding diagram...*. In a UI, name the
+element (*Click ☰ **Menu***) or provide a screenshot.
+
+## Inclusive language
+
+**Gendered language.** *person-hours*, not *man-hours*. *humanity*, not *mankind*. Singular
+*they*.
+
+**Ableist language.** Not *crazy*, *insane*, *sanity check*, *blind to*, *cripple*, *dumb*,
+*dummy variable*.
+
+| Recommended | Not recommended |
+|---|---|
+| Give everything a final check for completeness. | Give everything a final sanity-check. |
+| There are some baffling outliers in the data. | There are some crazy outliers in the data. |
+| It slows down the service. | It cripples the service. |
+| Replace the placeholder in this example. | Replace the dummy variable in this example. |
+
+**Graphic and metaphorical language.** Prefer the precise term: *If the connection doesn't
+respond, check for errors*, not *If the connection hangs*. *Point to **File**, and then
+click **New***, not *Hover over **File**, and hit **New***. Don't build explanations on
+metaphors like *pets versus cattle*. Where an industry term has a specific technical
+meaning with no accurate synonym (*terminate*, *execute*), use it.
+
+**Divisive framing.** Avoid *native speakers* / *non-native speakers*, *first-class
+citizen*, *native feature*. Usually the document doesn't need the distinction at all.
+
+**Replacing established non-inclusive terms.** When replacing outright would confuse
+readers, name the old term once in parentheses and use the replacement thereafter:
+
+> To make sure that administrators get the notification, add them to an allowlist
+> (sometimes called a *whitelist*).
+
+Often rewriting is better than substituting: *You can allow requests from a range of IP
+addresses...*, rather than *You can allowlist a range of IP addresses...*.
+
+**Non-inclusive terms inside code.** When the term is a name or keyword you can't change,
+minimize it rather than propagating it. Refer to it once, in code font, in parentheses if
+possible – *creates a parent node (which is named `master` in the file)*; *start the replica
+by using the `START SLAVE` statement* – and use the preferred term (*parent node*,
+*replica*) everywhere else. Never use such a term outside code font.
+
+**Disability and accessibility.** Research how the communities you're writing about prefer
+to be described.
+
+- Don't call people without disabilities *normal* or *healthy*. Use *nondisabled person*,
+  *sighted person*, *hearing person*, *neurotypical person*.
+- Avoid terms that erase personhood – not *the disabled*, *a quadriplegic*. Use *people with
+  disabilities*, *a quadriplegic person*. Note that many autistic, blind, and Deaf people
+  prefer identity-first language; follow community preference over a blanket rule.
+- Avoid judgment and pity: not *victim of*, *suffering from*, *wheelchair-bound*. Use
+  *experiencing*, *living with*, *uses a wheelchair*.
+- Avoid euphemisms: not *physically challenged*, *special*, *differently abled*,
+  *handi-capable*.
+
+**Diverse examples.** Vary names, ages, and locations. Avoid US-specific holidays, sports,
+and cultural practices. For older adults, use *older adults* or *aging population*, not
+*the elderly*, *seniors*, or *80 years young*. Watch for stereotypes in which personas get
+which job roles.
+
+## Global audiences and translation
+
+Three distinct things: *localization* adapts a product to a country (currency, units);
+*translation* converts language; *internationalization* designs to minimize localization
+effort.
+
+**Simplify.**
+
+- Simple words: *start* not *commence*, *so* not *consequently*, *use* not *utilize* or
+  *leverage*. (These are fine in their special senses – *utilizes up to 100% of the
+  available CPU*.)
+- One word instead of a phrase: *some* or *many*, not *a number of*.
+- Short sentences. English is compact; a long English sentence becomes longer in
+  translation, which hurts comprehension, breaks layouts, and raises cost.
+- Avoid phrasal verbs where a single verb exists: *This document uses the following terms*,
+  not *makes use of*. Some have no good substitute – *set up*, *log in*, *sign in*.
+- No more than two nouns modifying another noun: *a cloud-native DevSecOps pipeline in a
+  hybrid environment*, not *a hybrid cloud-native DevSecOps pipeline*.
+- Place *only* immediately before what it modifies: *Request only one token*.
+
+**Use words in their primary sense.** Don't use the same word to mean different things,
+and especially don't use a word as both noun and verb nearby. Watch *once*, *while*, *as*,
+*since*.
+
+**Keep helper words.** Conversational English drops *then*, *that*, *of*, and relative
+pronouns; translation needs them.
+
+| Recommended | Not recommended |
+|---|---|
+| If the attribute key is not found, then the default value is returned. | If the attribute key is not found, the default value is returned. |
+| ...and assumes that you have the following knowledge: | ...and assumes you have the following knowledge: |
+| Identify all of the datasets. | Identify all the datasets. |
+| Start the profiler, and then run the app. | Start the profiler, then run the app. |
+| You can update the rules that you previously defined. | ...the rules you previously defined. |
+
+Repeat a word when the redundancy prevents ambiguity: *creates both IAM segmentation and
+network segmentation*, not *both IAM and network segmentation*.
+
+**Clarify antecedents.** Translators often work on disconnected strings. Replace an
+ambiguous pronoun with the noun: *If you use the term* green beer *in an ad, then make sure
+that the ad is targeted*, not *...that it's targeted*.
+
+**Be consistent.** Use exactly the same term, with the same capitalization, for the same
+concept everywhere – different names read as different concepts and multiply translation
+cost. Use standardized phrasing for recurring moves (introducing links, output, samples).
+Standard subject-verb-object order, subject and verb early, conditional clause first,
+parallel list items, consistent formatting.
+
+**Avoid.** Colloquialisms and idioms (*ballpark figure*, *back burner*, *hang in there*),
+humor, culturally specific references, seasons, and unnecessary negative constructions.
+Define abbreviations. Use unambiguous date formats. Use screenshots sparingly – images
+aren't translated, so no new information can live only in them.
+
+## Excessive claims
+
+An excessive claim asserts something about performance, cost, or security that the reader
+can't verify, that a single incident would falsify, or that reads as subjective or
+disparaging – especially about third-party products. Judge it against what might be true in
+future, not just today.
+
+- Avoid superlatives: *best*, *simplest*, *fastest*, *never*, *always*. Use *ensure* and
+  *guarantee* only where something truly is guaranteed.
+- Cite the source of any specific performance claim.
+- Security features *help with* security or are *designed for* security. A product that
+  "is secure" is falsified the day someone compromises it.
+- A claim about a competitor can be wrong today through misunderstanding and wrong tomorrow
+  through their next release.
+
+| Recommended | Not recommended |
+|---|---|
+| Our product distributes datasets in memory across a cluster, and therefore it can be faster for this scenario than ExampleCorp's product. For more information, see Performance comparison. | Our product is faster than ExampleCorp's product. |
+| Using our security product is part of an overall strategy that helps prevent account takeovers from phishing attacks. | Our security product prevents account takeovers from phishing attacks. |
+
+## Timeless documentation
+
+Document how the product works now – not how it changed, not how it might change. Words
+that anchor text to a moment go stale and mislead.
+
+Avoid in product and reference documentation: *as of this writing*, *currently*, *does not
+yet*, *eventually*, *existing*, *future*, *in the future*, *latest*, *new*, *newer*, *now*,
+*old*, *older*, *presently*, *at present*, *soon*.
+
+| Recommended | Not recommended |
+|---|---|
+| These subcommands let you interact with HTTP load balancing. | These new subcommands let you... |
+| The following command-line options aren't supported: | ...aren't currently supported: |
+| The emulator supports the following filters: | The emulator now supports the following filters: |
+
+*Currently* is implied by the documentation existing at all. If you need *new*, anchor it:
+*The January 14, 2021 release includes a new resource panel.*
+
+Time-stamped content – release notes, blog posts, press releases – is exempt. *Soon* is also
+fine in procedures describing a state change: *The VM goes offline soon after you send the
+shutdown command.*
+
+**Never pre-announce.** Don't document future features or products, however innocuously,
+without legal approval.
+
+## Example names and reserved values
+
+Never use real domains, email addresses, names, phone numbers, project names, or anything
+personally identifiable.
+
+| Kind | Use |
+|---|---|
+| Domains | `example.com`, `example.org`, `example.net` (IANA-reserved) |
+| Email | A reserved domain plus an example name – `dana@example.com`; generic addresses like `support@example.net` are fine |
+| Given names | Alex, Amal, Ariel, Bola, Charlie, Cruz, Dana, Dani, Hao, Ira, Izumi, Jie, Kai, Kalani, Kim, Kiran, Lee, Lucian, Luka, Mahan, Noam, Nur, Quinn, Raha, Rosario, Sasha, Tal, Taylor, Tristan, Yuri |
+| Surnames | An initial after the given name – Quinn N., Dana A. |
+| Companies | Example Organization; differentiate with Enterprise Example Organization, Startup Example Organization |
+| Phone numbers | US numbers in `800-555-0100` through `800-555-0199` |
+| IPv4 | `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24` (RFC 5737) |
+| IPv6 | The RFC 3849 range |
+
+Use singular *they* for example people and avoid specifying gender unless it matters. Watch
+for stereotypes in which personas get which roles. Don't use Alice and Bob unless you're
+documenting a specification that uses them; if you do, stay within that cast.
+
+Format real phone numbers with nonbreaking hyphens (`&#8209;`) so they don't wrap:
+`415‑555‑0132`. International numbers take a plus sign and country code: `+1‑415‑555‑0132`.
+Extensions follow the number: `415‑555‑0132, extension 987`.
+
+## Third-party content
+
+Don't copy from other sources – it risks copyright infringement. Paraphrase and link
+instead. This covers text, images, code, logos, and speech.
+
+Treat as unsafe to reuse: third-party documentation, websites, books, blogs, videos, images,
+and podcasts; dictionaries, encyclopedias, and Wikipedia; open source project documentation
+(licenses vary widely); and GitHub content (licenses vary per user). When in doubt, don't.
+
+| Recommended | Not recommended |
+|---|---|
+| A recovery point objective (RPO), which is the maximum acceptable length of time during which data might be lost from your app due to a major incident. | Recovery Point Objective (RPO): "RPO is the maximum targeted period in which data (transactions) might be lost..." (Wikipedia) |

--- a/.claude/skills/arcjet-writing-style/references/language-and-grammar.md
+++ b/.claude/skills/arcjet-writing-style/references/language-and-grammar.md
@@ -1,0 +1,248 @@
+# Language and grammar
+
+Person and voice · Tense · Pronouns · Articles · Possessives · Plurals · Abbreviations ·
+Capitalization · Product names · Jargon · Anthropomorphism · Prescriptive word choice ·
+Reference verbs
+
+## Person
+
+Address the reader as *you*; assume the reader is the one doing the task. Use *user* only
+for the user of the software the reader is building.
+
+| Recommended | Not recommended |
+|---|---|
+| The following sections describe how you can create a website. | ...how we can create a website. |
+| Consider adding a description to your table. | Let's add a description to our table. |
+| This document shows you how to develop an app. | This document shows the user how to develop an app. |
+
+For instructions, use the imperative – the *you* is implied: *Click Submit*. Imperative in
+running text is fine once you've established who's addressed, but consider whether it
+should be a formal procedure instead.
+
+Use third person for what the software or an end user does. In API documentation, state
+facts about programming elements in third person and address the reader as *you* when
+telling them what to do.
+
+First-person plural (*we*, *our*, *us*) is acceptable for the organization authoring the
+document, provided the antecedent is unmistakable: *Example Organization provides A and B,
+but we don't provide C.* Otherwise avoid first person, except in FAQ questions and
+signed commentary.
+
+Identify who *you* is – developer, administrator, operator – and hold it constant. State
+it explicitly near the top when it isn't obvious.
+
+## Voice
+
+Active voice by default: the grammatical subject performs the action.
+
+- Recommended: Send a query to the service. The server sends an acknowledgment.
+- Not recommended: The service is queried, and an acknowledgment is sent.
+
+Naming the actor with *by* is worse than recasting. Passive is fine to emphasize an object
+(*The file is saved*), to de-emphasize the actor (*Over 50 conflicts were found in the
+file* – better than accusing the reader of creating them), or when responsibility is
+irrelevant (*The database was purged in January*).
+
+## Tense
+
+Present tense for general behavior. Future tense only for something that genuinely happens
+later:
+
+- Recommended: Add the filename to the backup list. The file will be archived the next time
+  the backup process runs.
+- Recommended (asynchronous delivery): A message is sent that will notify any subscribers.
+
+Never use future tense for how a product will work after a future release. Avoid
+hypothetical *would*: *If you send an unsubscribe message, the server removes you from the
+list*, not *the server would then remove you*.
+
+## Pronouns
+
+Every pronoun needs an unmistakable antecedent.
+
+- Recommended: If you type text in the field, the text doesn't change.
+- Not recommended: If you type text in the field, it doesn't change.
+
+Follow demonstratives with a noun: *Set this value to true*, not *Set this to true*.
+
+Gender-neutral: use singular *they*. Never *he/she*, *(s)he*, or a generic *he*.
+
+*That* introduces a restrictive clause, no comma: *The echidna that has a long snout is
+furry* (one particular echidna). *Which* introduces a nonrestrictive clause, preceded by a
+comma: *The echidna, which has a long snout, is furry* (all echidnas). Use *who* for
+people; *that* is acceptable if you're unsure. *Whose* works for people, animals, and
+things.
+
+Don't drop relative pronouns: *the rules that you previously defined*.
+
+## Articles
+
+Include *a*, *an*, and *the*, including in headings – dropping them for brevity hurts
+comprehension and translation. *Create a VM instance*, not *Create VM instance*.
+
+Don't put *the* before a product name unless the name modifies something else. Do use
+*the* before tool and API names: *the Transcoder API*, *the `gcloud` CLI*, *the Cloud
+Datastore options page*.
+
+*A* or *an* follows sound, not spelling – including for abbreviations, based on how your
+audience pronounces them.
+
+## Prepositions
+
+A preposition at the end of a sentence is fine. *See the client library documentation for
+the language you're interacting with* beats *...the language with which you're
+interacting.* Include prepositions that add clarity; drop the ones that don't.
+
+## Possessives
+
+Singular nouns, including those ending in *s*: add *'s* – *each vector's record*, *the
+storage class's quota*. Plural nouns ending in *s*: apostrophe only – *the models'
+capabilities*. Plural nouns not ending in *s*: *'s*.
+
+If a possessive reads awkwardly, rewrite: *Analyze the business data*, not *Analyze the
+businesses' data*. *The rule that the Federal Trade Commission (FTC) issued*, not *The
+Federal Trade Commission's (FTC's) rule*.
+
+Never form a possessive from a product, feature, or trademark when describing function:
+*monitor Google Search performance* or *the performance of Google Search*, not *Google
+Search's performance*. Company names can take *'s* when not used as a trademark.
+
+Never form a possessive from a code item. Attach it to the following noun: *the
+`wordCount` method's return value*, or rewrite: *the value returned by the `wordCount`
+method*.
+
+## Plurals
+
+Standard US English plurals. Never form a plural with *'s* – it collides with possessives
+and contractions, and it mistranslates.
+
+Abbreviations pluralize as ordinary words: *APIs*, *IDEs*. Add *es* after *s*, *sh*, *ch*,
+or *x*: *OSes*, *BMXes*. Don't pluralize a unit abbreviation after a number: *64 GB*, not
+*64 GBs*. Spell out the unit in singular only for one: *0 degrees*, *0.5 degrees*, *1
+degree*, *15 degrees*.
+
+Match plurality between spelled-out term and abbreviation: *virtual machines (VMs)*.
+
+Use a plural after *one or more* and a singular after *more than one*: *If one or more
+tests fail...*; *You can create more than one instance*.
+
+Never use parenthetical optional plurals: write *To find your API key* or use *one or more*,
+not *key(s)* or *child(ren)*.
+
+Don't manually pluralize class names – add a noun: *`Intent` objects*, not *`Intent`s*.
+
+## Abbreviations
+
+Acronyms are pronounced as words (*NATO*, *scuba*); initialisms are spelled out letter by
+letter (*CIA*, *PR*); shortened words are fragments, sometimes with a period (*Dr.*,
+*etc.*, *min*). Calling them all *acronyms* is fine in practice. Short forms of words
+(*app*, *demo*, *sync*) aren't abbreviations and take no period.
+
+Spell out on first mention with the abbreviation in parentheses, and italicize both:
+*Establish* Border Gateway Protocol *(*BGP*) sessions...* Capitalize the spelled-out form
+only if it's independently a proper noun – *data manipulation language (DML)*, not *Data
+Manipulation Language (DML)*. If the first mention is in a heading, define it in the first
+paragraph below. Include the abbreviation in link text.
+
+Don't abbreviate terms peripheral to the document's topic. Don't spell out an abbreviation
+when the expansion doesn't help (*PDF*). Rarely need expansion: AI, API, DVD, HTML, PC,
+RAM, REST, URL, USB, file formats, units of measurement.
+
+Periods: none in acronyms and initialisms; one at the end of a shortened word, except date
+and time abbreviations; none after country, US state, or DC abbreviations.
+
+Don't use *i.e.* or *e.g.* – write *that is* and *for example*. Don't use internet slang
+(*tl;dr*, *ymmv*, *RTFM*). Don't use abbreviations as verbs: *Use SSH to log in*, not *ssh
+into*. Don't use *10x* for *10 times*.
+
+## Capitalization
+
+Standard American English. Don't capitalize for emphasis. Don't rely on a capitalization
+difference to carry meaning (a reader new to Kubernetes won't catch *Pod* vs. *pod*).
+Avoid all-caps and camel case except in official names or in code.
+
+Sentence case for: titles and headings, captions, image labels and callouts, list items,
+every element of a table, glossary definitions. Glossary and index terms are lowercase
+unless independently capitalized. No period at the end of a title or heading.
+
+After a colon, lowercase – unless what follows is a proper noun, a heading, a quotation, or
+text after a label such as *Note* or *Caution*.
+
+When a hyphenated word starts a sentence or heading, capitalize only the first element
+unless a later element is a proper noun.
+
+In references to a title or heading from a document that follows this guide, use sentence
+case even if the original used title case. Retain original capitalization for outside works.
+
+Don't name casing styles – *camel case*, *snake case* don't localize and aren't
+standardized. Describe the requirement and show an example: *no spaces between words, first
+letter of each word capitalized – for example, `AssertionAccount`.*
+
+## Product and feature names
+
+Follow the official capitalization of every brand, product, service, and community-defined
+term. Google product names are title case; if an official name starts lowercase, keep it
+lowercase even at the start of a sentence – or better, rewrite so it isn't first.
+
+Feature names are generally lowercase unless officially capitalized. Match a UI label when
+you're referring to one.
+
+Use the full trademarked product name; don't abbreviate except to match a UI label. Once
+you've established the product, it's often better to talk about the general concept (*a
+service mesh*) than to repeat the name.
+
+Don't use product or feature names as verbs.
+
+## Jargon
+
+Jargon is a specialized group's figurative shorthand (*swim lane*, *out-of-the-box*,
+*break-glass procedure*) or a vague overloaded term (*solution*, *support*, *workload*).
+It blocks readers outside the group and translates badly.
+
+Before using a term, ask:
+
+- **Can you write around it?** *When the project is finished, review what worked* instead of
+  *Hold a post-mortem.*
+- **Is there a more specific term?** *affected area* for *blast radius*, *import* for
+  *ingest*, *ready-made* for *off-the-shelf*.
+- **Used once?** Describe it in plain language and put the jargon in parentheses, or link
+  to a definition.
+- **Used throughout?** Define it briefly in parentheses at first use: *a* cold standby *(a
+  redundant system identical to the primary)*.
+- **In a command or code sample?** Use the term only in direct reference to the code, in
+  code font, and make the referent explicit.
+
+Retain jargon when readers search for it – SEO is a legitimate reason.
+
+## Anthropomorphism
+
+Don't give software human qualities. It's imprecise and hard to translate.
+
+| Recommended | Not recommended |
+|---|---|
+| A Delimiter object specifies where to split a string. | A Delimiter object tells the splitter where a string should be broken. |
+| The PC detects a new device. | The PC sees a new device. |
+
+## Prescriptive word choice
+
+Write prescriptive documentation: recommend a path rather than listing options. Choose the
+auxiliary verb that says exactly what you mean.
+
+| Situation | Use |
+|---|---|
+| Action is required | *must*, or a plain imperative |
+| Action is recommended | *We recommend...* (*should* is acceptable for widely recognized practice) |
+| Action is optional | *can* |
+| Outcome is expected | describe it: *The process returns 10 items.* |
+| Outcome is possible | *might*, *can* |
+
+Avoid *should* generally – the reader can't tell whether it's required. For states,
+replace *The value should be true* with the specific meaning: *You must set the value to
+true*, or *The server sets the value to true*, or *If the value is false, follow these
+steps*.
+
+## Verbs in reference documentation
+
+Describe what a method does, not what the developer does with it – third person, with the
+*-s*: *tasks.insert: Creates a new task on the specified task list*, not *Create a new
+task*.

--- a/.claude/skills/arcjet-writing-style/references/punctuation.md
+++ b/.claude/skills/arcjet-writing-style/references/punctuation.md
@@ -1,0 +1,206 @@
+# Punctuation
+
+Commas · Dashes · Hyphens and compounds · Colons · Semicolons · Periods and end
+punctuation · Quotation marks · Slashes · Parentheses · Ellipses · Example introductions
+
+## Commas
+
+**Serial comma, always.** *Locations are divided into zones, regions, and multi-regions.*
+
+Put a comma after an introductory word or phrase: *Finally, only groups that contain
+parameters appear in this list.*
+
+Two independent clauses joined by a coordinating conjunction (*and*, *but*, *or*, *nor*,
+*for*, *so*, *yet*) take a comma before the conjunction, unless both clauses are very short:
+
+- The libraries make feed creation easier, and they ensure that only valid feeds are produced.
+- Type your ID and click **OK**. (both short – no comma)
+
+An independent clause plus a dependent clause takes a comma only if the sentence could be
+misread without one:
+
+- Direct-access flags are plain variables and can be read directly. (no comma)
+- The manager acknowledged the last team member who entered the room, and started the
+  meeting. (comma prevents misreading)
+
+Comma before *which* starting a nonrestrictive clause. Semicolon, period, or dash before a
+conjunctive adverb (*however*, *otherwise*, *therefore*), comma after it. No comma before
+*because* unless it starts a nonrestrictive clause.
+
+## Dashes
+
+**Project rule, replacing Google's.** Never use an em dash (`—`). Use an en dash (`–`)
+with a space on each side for a break in the flow of a sentence – like this – and for
+every other job Google's guide assigns to the em dash.
+
+Google's own guidance is the opposite: an unspaced em dash, and no en dashes anywhere.
+Project style outranks this guide, so the project rule is the rule. What matters most is
+that a document never mixes the two characters.
+
+Type an en dash as follows:
+
+HTML
+  `&ndash;`
+macOS
+  Press `Option+hyphen`.
+Linux
+  Press `Control+Shift+U`, release, type `2013`, and then press `Return`. Or press the
+  Compose key followed by two hyphens and a period.
+Windows
+  Turn num lock on, hold down the left `Alt` key, and type `0150` on the numeric keypad.
+
+Don't substitute a double hyphen (`--`).
+
+Ranges keep the hyphen – `2012-2016`, `5-10 minutes` – unless the project decides
+otherwise. Settle that question explicitly, because a half-adopted dash convention is
+worse than either convention on its own.
+
+Don't use a dash of any kind to separate an item from its description. Use a colon or a
+period, or a description list:
+
+- Recommended: Example: This is an example.
+- Not recommended: Example - This is an example.
+
+## Hyphens and compounds
+
+Whether to hyphenate depends on position, readability, and convention. Check, in order:
+the documentation you're working in, the word list, then Merriam-Webster.
+
+**Prefixes:** generally closed – *infrastructure*, *megabyte*, *metadata*, *preprocessing*,
+*pseudocode*, *semiconductor*. Hyphenate when:
+
+- the prefix is *self* or *cross* – *self-managing*, *cross-region*
+- the following word is capitalized or a number – *non-Google*, *post-2000*
+- it prevents misreading – *de-energize*, *re-mark*, *re-sign*, *intra-index*
+- the base term already has hyphens or spaces – *un-Google-like*
+- consistency within the document requires it – *pre-processing*, *post-processing*
+
+*non* is often hyphenated because it forms hard-to-parse words. Both patterns occur:
+*noncurrent*, *nonempty*, *noninteractive*, *nonpublic*; *non-existence*, *non-integer*,
+*non-key*, *non-negative*. Always hyphenate before a hyphenated compound: *non-KSA-based*.
+
+**Compound nouns:** prefer the closed form – *webpage*, *hostname*, *tradeoff*,
+*workaround*. The word list holds the exceptions (*multi-region*, *style sheet*).
+
+**Compound modifiers before a noun:** hyphenate for clarity – *a well-designed app*,
+*Android-specific techniques*. Hyphenate after *more* or *most* when it clarifies what
+they modify: *edge locations with more-reliable internet links*. Avoid three-word compound
+modifiers; move words after the noun instead – *test cases that are specific to the 2023
+edition*, not *edition-2023-specific test cases*.
+
+**Numbers and units:** hyphenate a number plus a spelled-out unit modifying a noun – *a
+64-bit system*, *100,000-byte files*, *a five-minute wait*. Don't hyphenate when the unit
+is abbreviated; use a nonbreaking space – *a 200 GB disk*. Hyphenate multiplied units:
+*5 vCPU-hours*, *40 person-hours*.
+
+**Suspended hyphens:** *one-, two-, or three-hour intervals*. A space can follow the
+hyphen but never precede it.
+
+## Colons
+
+The text before a colon must stand alone as a complete sentence: *The fields are defined as
+follows:* – not *The fields are:*.
+
+Lowercase the first word after a colon, except for proper nouns, headings, quotations, and
+text after a label such as *Note* or *Caution*.
+
+## Semicolons
+
+Avoid where possible. Legitimate uses: joining two closely related independent clauses;
+before a conjunctive adverb (*therefore*) or phrase (*that is*) joining independent
+clauses; separating series items that contain their own punctuation.
+
+Note that some screen readers skip semicolons – the meaning must survive without them.
+
+## Periods and end punctuation
+
+End every complete sentence with a period unless it's a question. Exceptions live in lists
+and headings.
+
+- **Lists:** see `formatting.md`.
+- **Headings and captions on figures:** no period on headings; captions do take end
+  punctuation.
+- **URLs:** don't end a sentence with a bare URL – the period looks like part of it.
+  Rewrite, or put the URL on its own line with no period.
+- **Quotation marks:** period goes inside, even when it isn't part of the quoted material – *you might say "Fixed typo."* No period if the quotation ends in a question or
+  exclamation mark.
+- **Parentheses:** period outside if the parenthetical closes a larger sentence; inside if
+  the parentheses contain a complete standalone sentence.
+- **Decimals:** a period, not a comma.
+- **Abbreviations:** period after a shortened word, none after an acronym or initialism.
+
+One space between sentences.
+
+**Exclamation points:** avoid. Never in concept or reference documentation. Avoid in
+procedures – use a period for completion steps (*The VM is created.*). Acceptable in blog
+posts to convey enthusiasm, sparingly in tutorials to mark a milestone, and wherever syntax
+requires them (`!=`) or a literal must match exactly. In Japanese and Korean especially,
+they read as shouting.
+
+## Quotation marks
+
+Straight quotation marks and apostrophes, never curly – code requires straight marks,
+automatic conversion makes mistakes, and the difference is nearly invisible in review.
+
+Technical writing uses quotation marks rarely. Use them for:
+
+- Titles of shorter works (articles, episodes) – unless the title is link text
+- A section of a larger document you can't link to directly
+- Direct citation of a person, slogan, or motto
+- A term used metaphorically, when that use isn't already established in the domain
+
+Full-length works take italics instead.
+
+Commas and periods go inside the quotation marks. **Exception:** when the quotation marks
+enclose a keyword or literal string, keep other punctuation outside so nothing extraneous
+appears inside the literal. Better still, use code font and no quotation marks: *If you
+enter `escape`, the program crashes.*
+
+Single quotation marks only in code that requires them, and for a quotation nested inside
+a quotation.
+
+## Slashes
+
+Avoid outside code.
+
+- No slashes in dates.
+- No slashes for alternatives – write *and* or *or*. Avoid *and/or*; usually *and* implies
+  *or*, and when it doesn't, spell out the options: *You can export raw events, processed
+  events, or both.*
+- No slashes in fractions – they're ambiguous. Use `0.75`, `75%`, or `¾`.
+- No slash abbreviations – write *care of*, *with*, not *c/o*, *w/*.
+- Forward slashes in paths and URLs (backslashes for Windows paths). Break a long URL after
+  a slash; never insert a hyphen to break it.
+
+## Parentheses
+
+Many readers skip parentheses entirely, so don't put important information there. Consider
+whether commas, dashes, or a separate sentence would work better. Keep mid-sentence
+parentheticals short.
+
+Prefer an en dash or *such as* when introducing an example at the end of a sentence: *Enter
+a name for the instance – for example, `my-instance-99`.* Parentheses are fine for a short
+mid-sentence example: *Enter a six-digit hex number (for example, `228B22`), and then click
+**OK**.*
+
+Don't use parentheses for optional plurals.
+
+## Ellipses
+
+Generally don't use them. Never as suspension points (*The answer is ... wait for it ...*).
+Omit them from UI element names: a button labeled **Save ...** is documented as **Save**.
+
+Acceptable in quoted text to mark an omission, but not at the start or end of the
+quotation. Three periods, one space before and after, no space after if punctuation
+immediately follows. Four dots when the omission spans a sentence boundary.
+
+For omitted code, use a comment in the sample's language – not an ellipsis. For omitted
+command output, use three periods on their own line.
+
+## Example introductions
+
+| Position | Approach |
+|---|---|
+| End of sentence | Set it off with a comma, parentheses, or an en dash: *Choose a strong encryption algorithm, such as AES-256.* *You can monitor various metrics – for example, CPU utilization and active connections.* Never a semicolon. |
+| Middle of sentence | Keep it short; set it off with dashes, commas, or parentheses: *Enter a six-digit hex number (for example, `228B22`), and then click **OK**.* |
+| Long example | Make it a separate sentence: *For example, you could tag instances by environment with `env:prod`.* |

--- a/.claude/skills/arcjet-writing-style/references/word-list.md
+++ b/.claude/skills/arcjet-writing-style/references/word-list.md
@@ -1,0 +1,1796 @@
+# Word list
+
+A-Z usage and spelling decisions from the Google developer documentation style guide.
+Search this file for a term before inventing a convention. If a term isn't here, follow
+Merriam-Webster (first spelling listed).
+
+Adapting this outside Google: entries marked **Google Cloud**, **Android**, or
+**Google Workspace** are product-specific – read them as examples of the pattern, then
+apply the equivalent decision for the product you're documenting. Entries that name
+Google products illustrate a rule about product names generally.
+
+Two levels of prohibition:
+
+- **Avoid / use with caution** – ambiguous or obscure. Prefer the alternative; use the
+  term if you need it, and define it on first use.
+- **Don't use** – ambiguous, non-inclusive, or offensive. Replace it or write around it.
+  If it appears in code you can't change, see `global-and-inclusive.md`.
+
+Format: term, then the guidance indented below it.
+
+---
+
+### Numbers and Symbols
+
+\+
+  OK to use _+_ with numbers in text, such as _customer records with 300+ demographic attributes_ , except in formal contexts.
+& (ampersand)
+  Don't use _&_ instead of _and_ in headings, text, navigation, or tables of contents.
+  It's OK to use _&_ when referencing UI elements that use _&_ , or in table headings and diagram labels where space constraints require abbreviation.
+  It's OK to use `&` for technical purposes in code.
+2-Step Verification
+  When referring to Google's 2-Step Verification, use initial caps.
+  When referring to generic 2-step verification, use lowercase.
+
+### A
+
+a and an
+  Use _a_ when the next word starts with a consonant _sound_ , regardless of what letter it starts with. For more information, see Articles (a, an, the).
+A/B testing
+  Capitalize and use slash notation for _A/B_.
+abnormal
+  Don't use to refer to a person.
+  OK to use to refer to a condition of a computer system.
+abort
+  Avoid in general usage. Instead, use words like _stop_ , _exit_ , _cancel_ , or _end_. In Linux, _abort_ refers to a type of signal that terminates an abnormal process.
+about versus on
+  When a cross-reference includes information that describes what the cross-reference links to, use _about_ instead of _on_.
+  Recommended: For more information about indexes, see  Managing indexes.
+  Not recommended: For more information on indexes, see Managing indexes.
+above
+  Don't use for a range of version numbers. Instead, use _later_.
+  Don't use to refer to a position in a document. Instead, use _earlier_ or _preceding_.
+  Don't use to refer to a position in the UI. Instead, write instructions that avoid directional language. For more information, see Writing accessible documentation.
+  It's OK to use _above_ in a non-directional way, such as when describing a hierarchy.
+access (verb)
+  Avoid when you can. Instead, use friendlier words like _see_ , _edit_ , _find_ , _use_ , or _view_.
+access token
+  Lowercase except at the beginning of a sentence, heading, or list item.
+account name
+  Don't use. Instead, use _username_.
+actionable
+  Avoid unless it's the clearest and simplest phrasing for your audience. Instead, leave it out or replace it with a phrase like _that you can act on_ or _useful_.
+  Don't use _actionable_ in the legal sense without consulting a lawyer.
+action bar
+  In Android documentation, don't use. Instead, use _app bar_.
+ad tech
+  Write out on first mention: _advertising technology (ad tech)_.
+  Don't use _adtech_ or _ad-tech_.
+address bar
+  Use to refer to the URL bar or the combined URL bar and search box in a browser.
+  Don't use _omnibox_.
+ad hoc
+  OK to use in database and analytics contexts to mean "free-form" or "user-written" (for example, _ad hoc queries_ or _an ad hoc chart_). For other contexts, try to find a more specific English equivalent.
+  Don't hyphenate or italicize the term.
+admin
+  Write out _administrator_ unless it's the name of a UI label or other element.
+  It's OK to use _admin_ in Android documentation.
+administrator
+  In Android documentation, don't use. Instead, use _admin_.
+advertised route priority
+  OK to also use _base advertised route priority_ when discussing region-to-region costs.
+  Don't shorten or use variations of these terms.
+agnostic
+  Don't use. Instead, use a more precise term like _platform-independent_.
+AI
+  In general, you can use _AI_ without spelling out _artificial intelligence_.
+  Most readers are familiar with the abbreviation _AI_. If you think your audience isn't familiar with the term, spell it out on first use.
+aka
+  Don't use. Instead, write out _also known as_ , or present an alternative term using parentheses or the word _or_. You can also write out a definition.
+  Recommended: Geographic data, also known as geospatial data, is ...
+  Recommended: Geographic data (geospatial data) is ...
+  Recommended: Geographic data, or geospatial data, is ...
+all apps screen
+  In Android documentation: Lowercase except at the beginning of a sentence, heading, or list item.
+allowlist (verb), allowlisted, allowlisting
+  Don't use as a verb. Instead, rewrite to improve clarity.
+  OK to use _allowlist_ as a noun.
+  For more information, see blacklist.
+allows you to
+  Don't use. Instead, use _lets you_. For more information, see enable.
+alpha
+  Lowercase except when part of a product name.
+  Recommended: PRODUCT_NAME Alpha
+  Recommended: PRODUCT_NAME is in alpha.
+America, American
+  Use only to refer to the _Americas_ or the _American continent_.
+  Don't use to refer to the United States. Instead, use a more precise term like _the US_ or _the United States_ , and _people in the US_. For more information, see US.
+among
+  See between versus among.
+AM, PM
+  To be consistent with Material Design, use all caps, no periods, and a space before.
+  Recommended: 9:00 AM
+  Recommended: 10:30 PM
+and/or
+  Don't use unless space is limited, such as in a table. For more information, see Slashes.
+Android
+  When referring to the operating system, capitalize _Android_.
+Android-powered device
+  Not _Android device_.
+and so on
+  Avoid using _and so on_ whenever possible. For more information, see etc.
+anti*
+  See guidance about hyphens with prefixes.
+anti-pattern
+  Avoid using _anti-pattern_ , particularly as a standalone heading. Instead, consider using a more specific and broadly understood term.
+  Recommended: Avoid these five SQL errors.
+  Recommended: Avoid these five programming practices that make SQL queries inefficient.
+  Not recommended: Avoid these five SQL anti-patterns.
+API
+  Use _API_ to refer to either a web API or a language-specific API.
+  Don't use _API_ when referring to a method or a class. For example, don't write _This resource has one API_ to mean "This resource has one method."
+API Console, APIs console, developer console, dev console, or Google API Console
+  Don't use. Instead, refer to the _Google APIs Explorer_ or to the _Google Cloud console_. For more information, see console.
+API Console key
+  In most contexts, use _API key_ instead of _API Console key_.
+  In Apps admin APIs, it's OK to use _API Console key_ to distinguish from other API keys.
+API key
+  Not _developer key_ or _dev key_.
+APIs Explorer
+  Not _API explorer_ or other variants.
+app
+  In general, use _app_ instead of _application_ when referring to programs for end users, especially in the context of mobile or web software.
+  In some contexts, such as enterprise software, it's OK to use _application_ to convey a sense of greater complexity.
+  Use _application_ in standard phrases such as _application programming interface_.
+app bar
+  In Android contexts, formerly _action bar_.
+appendix
+  Use the plural _appendixes_ , not _appendices_.
+application
+  See app.
+as
+  If you mean _because_ , then use _because_ instead of _as_. _As_ is ambiguous; it can refer to the passage of time. _Because_ refers to causation or the reason for something.
+as of this writing
+  Avoid because this phrase is implied. The phrase can also prematurely disclose product or feature strategy or inappropriately imply that a product or feature might change.
+  See also currently and  presently.
+  Recommended: BigQuery doesn't support that function.
+  Not recommended: As of this writing, BigQuery doesn't support that function.
+  For more information, see Timeless documentation.
+authentication and authorization
+In general, use the word _authenticated_ only to refer to users, and use _authorized_ only to refer to requests that are sent by a client app on behalf of an authenticated user.
+
+A user _authenticates_ their identity by entering their password (or giving some other proof of identity). The _authenticated user_ then _authorizes_ the client app to send an _authorized request_ to the server on the user's behalf.
+
+  When you want to use a preposition with _authenticate_ , use _against_.
+authN, authZ
+  Don't use. Instead, use _authentication_ or _authorization_.
+auto*
+  See guidance about hyphens with prefixes.
+autohealing
+  Not _auto-healing_.
+auto mode VPC network
+  Not _auto mode network_.
+autopopulate
+  Not _auto populate_ or _auto-populate_.
+autoscaling
+  Not _auto-scaling_.
+autotagging
+  Not _auto-tagging_.
+autoupdate
+  Don't use. Instead, use _automatically update_.
+-aware
+  Avoid using as a compound modifier, as in _healthcare-aware_.
+  OK to use when it's part of a product name, such as _Identity-Aware Proxy_.
+
+### B
+
+backend
+  Not _back-end_ or _back end_.
+bar
+  Avoid when possible. For more information, see foo.
+bare metal
+  Lowercase except at the beginning of a sentence, heading, or list item.
+  Hyphenate when used as a compound modifier, such as _bare-metal server_.
+base64
+  Lowercase except at the beginning of a sentence, heading, or list item. Otherwise, capitalize _Base64_ only if it's part of a formal name.
+  Write _base64_ in code font _only_ if it's a string literal or otherwise quoted from code.
+baz
+  Avoid when possible. For more information, see foo.
+below
+  Don't use for a range of version numbers. Instead, use _earlier_.
+  Don't use to refer to a position in a document. Instead, use _later_ or _following_.
+  Don't use to refer to a position in the UI. Instead, write instructions that avoid directional language. For more information, see Writing accessible documentation.
+  It's OK to use _below_ in set phrases such as _below (the) average_ , _below the mean_ , _below zero_.
+  It's OK to use _below_ in a non-directional way, such as when describing a hierarchy.
+best effort
+  Avoid where possible. Instead, use more specific wording. After providing a description, you can add a phrase like "sometimes referred to as _best effort_."
+beta
+  Lowercase except when part of a product name.
+  Recommended: PRODUCT_NAME Beta
+  Recommended: PRODUCT_NAME is currently in beta.
+between versus among
+  It's fine to use _between_ when talking about more than two things; however, _between_ isn't interchangeable with _among_.
+  Use _between_ when you're talking about two or more distinct things:
+  Recommended: JavaScript introduces dependencies between the DOM, the CSSOM, and JavaScript execution.
+  Use _among_ when you're talking about things that are part of a group or things that aren't distinct:
+  Recommended: ... a conventional SQL database that can be shared among multiple apps.
+  More examples:
+  Recommended: Because screen dimensions vary widely among devices (for example, between phones and tablets, and even among different phones), you should configure the viewport so that your pages render correctly on many different devices.
+  Not recommended: Because screen dimensions vary widely between devices (for example, between phones and tablets, and even between different phones), you should configure the viewport so that your pages render correctly on many different devices.
+  Recommended: You can share services among multiple clients.
+  Not recommended: You can share services between multiple clients.
+  See also Grammar Girl's discussion of _between_ and _among_.
+big-endian
+  Hyphenate. Lowercase except at the beginning of a sentence, heading, or list item.
+  Recommended: The codebase assumes big-endian byte ordering.
+  Not recommended: The codebase assumes Big Endian byte ordering.
+  Not recommended: The codebase assumes Big-endian byte ordering.
+  Not recommended: The codebase assumes big endian byte ordering.
+billing charges
+  Don't use _billing charges_ to mean charges that appear on a bill. Instead, use _billed charges_.
+  Use _billing charges_ to describe the cost of creating the bill.
+black-box
+  Avoid using _black-box_ , _blackbox_ , or _black box_ to describe monitoring and testing. Consider using a more precise term for clarity.
+
+  * For monitoring, use _synthetic monitoring_.
+  * For testing, use _opaque-box testing_.
+
+Black Friday
+  Avoid unless explicitly referring to an event in the US. Instead use _peak scale event_.
+blackhat, black hat, black-hat
+  Don't use. Instead, use precise terms for the kind of violation or practice, such as _illegal_ , _unethical_ , or _in violation of rules_.
+blackhole (verb), blackholed (adjective)
+  Don't use. Instead, use a more descriptive term or phrase, such as _dropped without notification_.
+blacklist, black list, black-list
+  Don't use _blacklist_ , _whitelist_ , and _graylist_. Instead, use more precise terms that are appropriate for your domain.
+  
+
+  * For the noun _blacklist_ , consider using a replacement such as _denylist_ , _excludelist_ , or _blocklist_.
+  * For the noun _whitelist_ , consider using a replacement such as _allowlist_ , _trustlist_ , or _safelist_.
+  * For the noun _graylist_ (_greylist_), consider using a replacement such as _provisional list_.
+
+  In all of these cases, consider that there might not actually be a list involved. When replacing problematic terms, be sure to be technically accurate for the specific context.
+  For the verb forms of these words, a simple word-for-word replacement typically isn't the best solution. Instead, replace verbs such as _blacklisted_ with phrases that accurately convey the relevant action. For example:
+  Recommended: To deny requests from an IP address, add it to the `dos.yaml` file.
+  Not recommended: To denylist an IP address, add it to the `dos.yaml` file.
+  Don't use: To blacklist an IP address, add it to the `dos.yaml` file.
+  If the command or code that you're documenting uses one of these words, then use the words only in direct reference to the code items (formatted as code), and make it clear what you're referring to.
+  Recommended: Add a user to the allowlist (`whitelist`) by entering the following: `whitelist adduser EMAIL_ADDRESS`.
+  Not recommended: Add a user to the whitelist by entering the following: `whitelist adduser EMAIL_ADDRESS`.
+  For more information, see the inclusive documentation page.
+blacklisted, black listed, black-listed
+  Don't use. See blacklist.
+blacklisting, black listing, black-listing
+  Don't use. See blacklist.
+blast radius
+  Don't use. Instead, use a more precise term like _affected area_ or _spatial impact_.
+blind
+  Avoid using _blind to_ or _blind eye to_. Instead, use more precise terms like _ignore_ , _unaware of_ , _disregard_ , _avoid_ , or _reject_.
+  Avoid using _blind writes_. Instead, use a more precise phrase, such as _a write operation without a read operation_.
+  Avoid using _blind change_ or _change blindly_. Instead, use a more precise phrase such as _change without first confirming the value_.
+  When referring to people, use terms like _person who is blind_ , _screen reader user_ (if applicable), _person who is visually impaired_ , _person who is low-vision_ , _magnification user_ (if applicable).
+blue-green
+  Not _blue/green_ or _blue green_.
+boolean
+  In most contexts, _boolean_ refers to a specific data type in a specific programming language. In such cases, use code font and the exact spelling and capitalization of the programming keyword.
+  When referring to the abstract data type, use lowercase.
+  If you refer to _Boolean mathematics_ or _Boolean logic_ , use uppercase.
+branding information
+  In the Google Cloud console, the phrase _branding information_ refers to the information that Google shows to users when the client asks them to authorize access: specifically, the project's name and logo, and the developer's Google Account. This information is set in the **Consent screen** page.
+break-glass
+  Don't use. Instead, use a more precise term depending on context:
+
+  * To describe a general emergency or procedure that grants emergency access, use _emergency access_.
+  * To describe a fallback procedure, use _manual fallback_ or _preplanned procedure_.
+
+brown bag, brown-bag
+  Don't use. Instead, use a more precise term like _learning session_ , _lunch and learn_ , _lunchtime learning session_ , _casual training_ , or _informal training_.
+build cop, build sheriff
+  Don't use. Instead, use a more precise term like _build monitor_.
+button
+  In a UI, a link isn't the same as a button; don't use the term _button_ to refer to a link.
+  Use _button_ to refer to mechanical buttons (like the volume control buttons on the side of a phone) and capacitive touch buttons on a phone (like the Home button). You _press_ mechanical buttons, and _tap_ capacitive and on-screen buttons.
+
+### C
+
+can
+Use _can_ in the following ways:
+
+  * To convey permission or ability (for example, "You can access the server").
+  * To refer to an optional action (for example, "You can also view logs with the Log Viewer").
+  * To describe a possible outcome (for example, "The process can take 30 minutes").
+
+  See also could, may, might, must, should, and would.
+  For information about clarifying who's performing an action, see Active voice.
+canary
+  Don't use _canary_ as a verb, and don't use _canarying_.
+  When possible, avoid jargon like _canary_ and _canary testing_. If you use one of these phrases, define it on first use or provide a link to the definition, and use it consistently throughout the document.
+cell phone, cellphone
+  Don't use. Instead, use _mobile phone_ , or if you're talking about more than phones, then use _mobile device_.
+  It's OK to use _phone_ (without _mobile_) when the context is clear.      cellular data
+  Don't use. Instead, use _mobile data_.
+cellular network
+  Don't use. Instead, use _mobile network_.
+chapter
+  When referring to documentation that isn't in the form of a book, don't use the term _chapter_. Instead, refer to documents, pages, or sections.
+check
+  Don't use to refer to marking a checkbox. Instead, use _select_.
+  Recommended: Select **Automatically check for updates**.
+  Not recommended: Check **Automatically check for updates**.
+checkbox
+  Not _check box_.
+choose
+  _Choose_ is fine to use for generic contexts. For UI elements, use select.
+chubby
+  Don't use. Instead, use a word that clearly explains what you mean, such as _unused_ or _overextended_.
+clear
+  Use (as a verb) to refer to clearing a check mark from a checkbox.
+  Recommended: Clear **Automatically check for updates**.
+  Not recommended: Uncheck **Automatically check for updates**.
+  Not recommended: Deselect **Automatically check for updates**.
+CLI
+  Don't use _CLI_ generically to refer to a command-line interface. Instead, refer to the specific command-line interface, such as the Google Cloud CLI.
+click
+  When the environment is a desktop with a mouse, use _click_ for most targets, such as buttons, links, list items, and radio buttons. Don't use _click on_.
+  Recommended: Click **OK**.
+  Not recommended: Click on **OK**.
+  Hyphenate _right-click_ , _left-click_ , and _double-click_.
+  When a click or tap action reveals a collapsed list, you can write _click to expand_ or simply _expand_.
+  It's OK to write _click in_ when referring to a region that needs focus (for example: _click in the window_), but not when referring to a control or a link.
+  For Android apps, don't use _click_. Instead, use tap.
+click here
+  Don't use. For information and alternatives, see Avoid vague link text.
+clickthrough (noun), click through (verb)
+client
+  In REST and RPC API documentation, _client_ is short for _client app_ – that is, the app that the developer is writing.
+  Don't use _client_ as an abbreviation for _client library_ ; instead, use _library_.
+client ID
+  Lowercase except at the beginning of a sentence, heading, or list item.
+client secret
+  Lowercase except at the beginning of a sentence, heading, or list item.
+Cloud
+  Don't use as short for _Google Cloud_.
+  For generic references such as _the cloud_ or _hybrid cloud_ , use lowercase.
+Cloud console
+  Don't use. Instead, refer to the full name _Google Cloud console_.
+  If you aren't discussing any other console (such as the Google Admin console), you can abbreviate to _the console_ after first mention.
+  Use _the_ before the tool name. For more information, see console.
+Cloud SDK
+  Not _Google Cloud SDK_.
+co*
+  See guidance about hyphens with prefixes.
+codebase
+  Not _code base_.
+codelab
+  Not _code lab_ or _code-lab_. For more information, see documentation.
+cold
+  When possible, avoid jargon like _cold failover_ , _cold standby_ , and _cold spare_. If you use one of these phrases, define it on first use and use it consistently throughout the document.
+colocate
+  Not _co-locate_ or _colo_.
+compliant, compliance
+  Use with caution. A claim that a product or its output is _compliant_ with a standard is a strong statement.
+comprise
+  Don't use. Instead, use _consist of_ , _contain_ , or _include_.
+config
+  Avoid when possible. Instead, spell out the full word when it's used in a non-code sense: _configuration_ or _configuring_. Use the verbatim code item name when referring to, for example, a data structure or a file with that name.
+confidential
+  _Confidential_ data is data that is protected to prevent unauthorized access. See sensitive.
+cons
+  Don't use. Instead, use a more precise term, such as _disadvantages_.
+console
+  Don't use in isolation. Instead, use the name of the specific console, such as the Google Cloud console or the Google Admin console.
+  Use _the_ before the name of a console.
+  After giving the full name of a console, you can use a shortened version of the name, such as the _Admin console_.
+  If you're only discussing the Google Cloud console, after giving the full name you can refer to _the console_.
+  To refer to a sub-page of a console, use the term _page_.
+  If a specific term for a browser-based interface is unavailable, use _web interface_.
+content type
+  Be as specific as possible when writing about a content type, and use the term only when applicable. For example, you can use this term if you're referring to the value of the `Content-Type` HTTP header. Also see media type.
+Control+S, Command+S, and other keyboard commands
+  To refer to a `Control` character, use `Control`+CHARACTER.
+  Don't use _Ctl-S_ , _Cmd-S_ , or _Cloverleaf-S_.
+  In most cases, use an uppercase letter for CHARACTER.
+  In macOS, many keyboard commands use the `Command` key instead of the `Control` key, and there's an `Option` key instead of an `Alt` key. If your audience includes macOS users and Windows or Linux users, then mention both keyboard commands.
+  Recommended: `Control+S` (`Command+S` on macOS)
+Copy and paste
+  Avoid using. Instead, explain what to enter into a field and not how.
+  Recommended: In the **Query** field, enter the output from the previous step.
+  Not recommended: Copy the output from the previous step and paste into the **Query** field.
+could
+  Avoid using. Instead, use _can_ where possible.
+  See also can, may, might, must, should and would.
+  For information about clarifying who's performing an action, see Active voice.
+  For information about tenses, see Present tense.
+CPU
+  All caps. No need to expand the abbreviation on first mention.
+crazy, bonkers, mad, lunatic, insane, loony
+  Don't use. Instead, use _complicated_ , _complex_ , _baffling_ , _strange_ , or _unexpected_ , and only for inanimate objects.
+Create a new ...
+  Avoid using unless you need to distinguish the item from another recently created item. Instead, use _Create a ..._
+  Recommended: Create a project.
+  Not recommended: Create a new project.
+cripple
+  Don't use. Instead, use more precise language. For example, instead of _it crippled the server_ , write _it slowed the server down_.
+  When referring to people, use terms that specifically describe a physical impairment, such as _person with a motor disability_ ; _person with a mobility impairment_ (refers to walking or moving about); _person with dexterity impairment_ (refers to using a standard mouse or keyboard); _person who uses a wheelchair, walker, or cane_ ; _wheelchair user_ ; _person with restricted or limited mobility_.
+cross-site request forgery
+  Lowercase except at the beginning of a sentence, heading, or list item.
+curated roles
+  Don't use. Instead, use _predefined roles_.
+currently
+  Avoid because this word is implied. The word can also prematurely disclose product or feature strategy or inappropriately imply that a product or feature might change.
+  See also as of this writing and presently.
+  Recommended: Windows isn't supported.
+  Not recommended: Windows isn't currently supported.
+  For more information, see Timeless documentation.
+custom mode VPC network
+  Not _custom mode network_.
+curl
+  Not _cURL_.
+  For information about when to use code format, see  Items that are sometimes in code font.
+Cyber Monday
+  Avoid unless explicitly referring to an event in the US. Instead use _peak scale event_.
+
+### D
+
+dash
+  A dash (`–`) isn't the same character as a hyphen (`-`). The characters are used for different purposes. Therefore, don't use the word _dash_ to refer to a hyphen.
+dashboard
+  Don't use to refer to the Google Cloud console. For more information, see console.
+  Use _dashboard_ not _Dashboard_ unless it's officially part of a product name.
+data
+  Use _data_ as singular, not plural; _the data is_ , not _the data are_.
+  Use data as a mass noun, not a count noun; _less data_ , not _fewer data_.
+data center
+  Not _datacenter_.
+data center campus
+  Use when referring to an entire physical location, which can encompass one or more data centers.
+data cleaning
+  Not _data cleansing_.
+data flow (noun); dataflow (noun)
+  If it's possible to replace with the phrase _flow of data_ , then use two words: _data flow_.
+  If that replacement doesn't work, such as when referring to something like stream processing or reactive programming, then use one word: _dataflow_.
+data source
+  Not _datasource_.
+datastore
+  Not _data store_.
+data type
+  Not _datatype_.
+dead-letter queue, dead letter
+  Define on first use, for example _dead-letter queue (unprocessed messages queue)_.
+deep linking
+  Not _deep-linking_. However, if you can replace with _linking_ , then do so.
+deficient
+  Don't use to refer to a person.
+  OK to use to refer to a condition of a computer system.
+deformed
+  Don't use to refer to a person.
+  OK to use to refer to a condition of a computer system or inanimate object.
+demilitarized zone (DMZ)
+  Don't use. Instead, use a more precise term like _perimeter network_.
+denigrate
+  Don't use. Instead, use _disparage_.
+denylist (verb), denylisted, denylisting
+  Don't use as a verb. Instead, rewrite to improve clarity.
+  OK to use _denylist_ as a noun.
+  For more information, see blacklist.
+deprecate
+  To _deprecate_ an item is to recommend against the item's use, typically as a warning that the item will soon be unavailable or unsupported. Don't use _deprecated_ to mean _removed_ , _deleted_ , _shut down_ , or _turned down_.
+deselect
+  Don't use to refer to clearing a check mark from a checkbox. Instead, use _clear_.
+  Recommended: Clear **Automatically check for updates**.
+  Not recommended: Deselect **Automatically check for updates**.
+  Not recommended: Uncheck **Automatically check for updates**.
+desire, desired
+  Don't use. Instead, use a word like _want_ or _need_.
+  Recommended: Set the value to the size that you want.
+  Not recommended: Set the value to the size that you desire.
+  Not recommended: Set the value to the desired size.
+Developers Console
+  Don't use. For more information, see console.
+DevOps
+  Short for _development operations_. No need to spell out on first mention unless the audience requires it. For more information, see DevOps.
+dialog
+  Use _dialog_ for the UI element sometimes called a dialog box.
+  Use _dialogue_ only for verbal interaction between people.
+directory, folder
+  If the context that you're documenting (such as an IDE's GUI) uses one term or the other, use that term. If not, then use _directory_ in a command-line context, and _folder_ in a GUI context. When in doubt, default to _directory_.
+disable
+  Don't use _disable_ or _disabled_ to describe something that's broken.
+  When describing a user action or the state of a UI element, use a more precise term where possible. You can use _inactive_ , _unavailable_ , _deactivate_ , _turn off_ , or _deselect_ , depending on the context. Use the same term consistently throughout your document. See also enable.
+disclosure triangle, disclosure widget
+  Don't use. Instead, use _expander arrow_.
+display (verb)
+  Don't use as an intransitive verb. _Display_ is a transitive verb; therefore, it requires an object. It is often misused in technical documentation, as demonstrated by the following example:
+  Recommended: The Output Directories area appears.
+  Recommended: The Output Directories area is displayed.
+  Not recommended: The Output Directories area displays.
+  The following example demonstrates correct usage of the verb _display_ but means something quite different from the preceding examples.
+  Recommended: The Output Directories area displays the vector image.
+distributed denial-of-service (DDoS)
+  Hyphenate as shown. On subsequent mention, use _DDoS_.
+DNS server policy
+  Lowercase _server policy_.
+DNSKEY
+  One word, all capital letters.
+documentation or document or documents
+To refer specifically to the text on a page that explains a product, feature, or service, use _this document_ , and not _this article_ , _this topic_ , _this doc_ , or _this page_. It's OK to use _this tutorial_ , _this quickstart_ , or _this codelab_ for those specific documentation types.
+
+Always spell out _documentation_ except in cases where space is limited, such as in tabs and URLs.
+
+See also page.
+
+  Recommended: You can find many examples in this document.
+  Not recommended: You can find many examples in this article.
+  Recommended: This document provides guidance about creating tables.
+  Not recommended: This page provides guidance about creating tables.
+documentation set
+  Not _doc set_ or _docset_.
+does not yet
+  Avoid in timeless documentation because this phrase can become outdated. The phrase can also prematurely disclose product or feature strategy or inappropriately imply that a product or feature might change.
+  Recommended: The Google Cloud console doesn't support this IAM role.
+  Not recommended: The Google Cloud console does not yet support this IAM role.
+  For more information, see Timeless documentation.
+dojo
+  Don't use. Instead, use a precise term that is accurate for the context, such as _training_ or _workshop_.
+domain name registrar
+  Lowercase except at the beginning of a sentence, heading, or list item.
+Domain Name System Security Extensions (DNSSEC)
+  Write out and capitalize each word on first use. OK to abbreviate as _DNSSEC_ after first use.
+double-tap
+  Hyphenate. Lowercase except at the beginning of a sentence, heading, or list item.
+downscope
+  Consider using a more descriptive term like _constrain scope_ or _reduce scope_. Because _downscope_ might not be broadly understood, if you use the term, make sure to define it on first use.          Don't use _down scope_ or _down-scope_
+  Recommended: Reducing the scope of a token helps you follow the principle of least privilege.
+  Recommended (first use): The IAM recommender helps you _downscope_ (reduce) the permissions that are available to your users.
+drag
+  Use _drag_ , not _click and drag_ and not _drag and drop_.
+  OK to use _drag-and-drop_ as an adjective.
+  Recommended: Drag the USER to the **Authorized** box.
+drop-down
+  In most cases, you can omit _drop-down_ from phrases like _drop-down list_ or _drop-down menu_ , and just use _list_ or _menu_. Include _drop-down_ as a modifier only if the omission would cause ambiguity. Don't use _drop-down_ as a standalone noun.
+dumb down
+  Don't use. Instead, use a word or phrase what's happening, such as _simplify_ or _remove technical jargon_.
+dummy variable
+  Don't use to refer to placeholders. Instead, use _placeholder_.
+  Also don't use if referring to the concept in statistics known as a dummy variable. Instead, use alternate terms such as _indicator variable_ , _design variable_ , _one-hot encoding_ , _Boolean indicator_ , _binary variable_ , or _qualitative variable_.
+
+### E
+
+each
+  _Each_ refers to every individual item taken individually, not to a group of items taken collectively. In other words, _each_ isn't a synonym for _all_. For example, _a list of each item_ is ambiguous; _a list of all the items_ or _a list of the items_ is generally clearer.
+earlier
+  Use for a range of version numbers, not _lower_.
+  Recommended: Use version 2.2 or earlier.
+  Not recommended: Use version 2.2 or lower.
+  In Android documentation, don't use _earlier_ for a range of version numbers. Instead, use _lower_.
+  When referring to a position in a document, use _earlier_ or _preceding_ , not _higher_.
+easy, easily
+  What might be easy for you might not be easy for others. Try eliminating this word from the sentence because usually the same meaning can be conveyed without it.
+ecommerce
+  Not _e-commerce_.
+edge availability domain
+  Don't use _edge availability zone_ , _metro availability domain_ , or _metro availability zone_. Don't shorten to _EAD_.
+e.g.
+  Don't use. Instead, use phrases like _for example_ or _such as_. Many people confuse _e.g._ and _i.e._
+egress
+  When referring to the networking term, use lowercase.
+either
+  When using _either_ , use parallel syntax.
+  Recommended: Do either option 1 or option 2.
+  Recommended: Either do option 1 or do option 2.
+  Not recommended: Either do option 1 or option 2.
+  In general, use _either_ only for a choice between two things, not for a choice among multiple things. Writing _either A or B or C_ will distract some readers, but if it's the best phrasing for your situation, then use it.
+element
+  In HTML and XML, a tag is a component of an element that indicates the start or end of the element. (For example, the `<i>` start tag indicates the beginning of the `<i>example</i>` element.) In general, don't use the term _tag_ to refer to an entire element.
+email
+  Not _e-mail_ , _Email_ , or _E-mail_.
+  Don't use as a verb.
+  Use a specific verb in front of the word. For example, _send email_. This construction is better for translation and a global audience.
+emoji
+  Use _emoji_ for both singular and plural forms. See Don't know the difference between emoji and emoticons? Let me explain and What's the Plural of Emoji?
+enable
+  In procedures, use the appropriate label and action for the UI element that the user interacts with. When describing a user action or the state of a UI element, use a more precise term where possible. It's OK to use _enable_ when not referring to a person.
+  For turning on or activating an option or feature, use _enable_ or _turn on_ consistently:
+
+  * Use the same term in introductory text as described in the procedure.
+  * Use the same term throughout the document unless there's a difference in the UI elements for different procedures.
+
+  Recommended: To enable the API, click the toggle.
+  Recommended: Enable the API for your project.
+  For making it feasible to do something, use _lets you_.
+  Recommended: The API lets you detect features in images.
+  Not recommended: The API enables you to detect features in images.
+  Not recommended: The API allows you to detect features in images.
+  In Google Workspace documentation, if possible, use _turn on_ or _on_ instead. If referring to the state of a UI element, use _available_.
+endpoint
+  Not _end point_.
+enter
+  Use _enter_ to refer to the user entering text. If it's important to not press `Enter`, explicitly say so. See also _type_.
+  Recommended: In the **Owner** box, enter your name.
+  Recommended: In the **Size** box, type a font size.
+ephemeral external IP address
+  Don't use _ephemeral IP address_ or _external IP address_ to refer to ephemeral external IP addresses.
+error-prone (adjective)
+  Hyphenate. Lowercase except at the beginning of a sentence, heading, or list item.
+etc.
+  Avoid using _etc._ , _and so forth_ , and _and so on_ wherever possible. If you really need to use one, use _etc._ Always include the period, even if a comma follows immediately after.
+  Recommended: Your app might experience problems such as instability or high latency.
+  Recommended: Your app might experience problems, including instability or high latency.
+  Not recommended: Your app might experience instability, high latency, and so on.
+  Not recommended: Your app might experience instability, high latency, etc.
+  Not recommended: If your app experiences instability, high latency, etc., follow these steps:
+eventually
+  Avoid in timeless documentation because this word can become outdated. The word can also prematurely disclose product or feature strategy or inappropriately imply that a product or feature might change.
+  See also future and soon.
+  Recommended: This version of the SDK is deprecated.
+  Not recommended: This version of the SDK is deprecated and eventually will be no longer supported.
+  For more information, see Timeless documentation.
+execute
+  Verb commonly used to refer to function calls, SQL queries, and other processes. When the meaning is the same, use the simpler word _run_ instead. If you need to use a more precise term for your context, use that term.
+expander arrow
+  The UI element used to expand or collapse a section of navigation or content. If you describe this element, use the terms _expander arrow_ and _expandable section_
+  Don't use terms like _expando_ or _zippy_.
+exploit
+  Don't use _exploit_ to mean "use."
+  Only use _exploit_ in the negative sense, such as to describe _exploiting a security vulnerability_.
+external VPN gateway
+  Write _external_ and _gateway_ all lowercase except at the beginning of a sentence, heading or list item.
+extract
+  Use instead of _unarchive_ , _uncompress_ , _untar_ , or _unzip_.
+
+### F
+
+fail over (verb), failover (noun, adjective)
+fat
+  Don't use. Instead, use a precise modifier that conveys the appropriate meaning. For example, use _high-capacity network connection_ instead of _fat connection_ or _full-featured client_ instead of _fat client_.
+  Instead of using fat in a negative sense, such as _trim the fat_ , refer in a more concrete manner to the _removal of unused items_.
+  OK to use as an acronym when referring to file allocation table (FAT).
+female adapter
+  Don't use. Instead, use a genderless word like _socket_.
+Fast Healthcare Interoperability Resources (FHIR)
+  Refer to _a FHIR_ (pronounced "a fire," as in "a FHIR store"), not _an FHIR_. For more information, see Indefinite articles before abbreviations.
+filename
+  Not _file name_
+file system
+  Not _filesystem_.
+fill in; fill out
+  Use _fill in_ when referring to entering information in individual fields.
+  Use _fill out_ when referring to completing an entire form.          Recommended: Fill out the questionnaire. Be sure to fill in the required fields.
+final solution
+  Don't use. Instead, use _solution_ as a standalone term or, depending on the context, _definitive_ , _optimal_ , _best_ , or _last solution_.
+fintech
+  Write out on first mention: _financial technology (fintech)_. Don't use _FinTech_ or _fin-tech_.
+firewalls
+  Don't use in Compute Engine or networking documentation. Instead, use _firewall rules_.
+  Exception: If you're explaining how firewall rules work, you can explain that every network has an implied virtual distributed firewall.
+  Outside of Compute Engine or networking documentation, the term _firewalls_ is acceptable.
+first class, first-class, first-class citizen
+  Don't use _first class_ or _first-class citizen_. Instead, use another term that's appropriate for the context, such as _higher-order_ , _anonymous_ , or _nested_ , or loosely describe the specific characteristics or features of the entity, resource, language, or framework.
+  Recommended: These widgets have full access to the event system and lifecycle hooks.
+  Not recommended: The widgets are first-class components in the UI framework.
+  Recommended: Virtual machines are higher-order resources that can participate in resource groups and are integrated in a variety of identity, networking, and storage services.
+  Not recommended: Virtual machines are treated as first-class resources across the identity, networking, and storage services.
+  For more information, see Write inclusive documentation.
+following
+  It's not necessary to use a noun after _following_ unless it helps provide clarity and enables accessibility. See Tables.
+  Recommended: ... in the following code sample ...
+  Recommended: ... in the following table ...
+  Recommended: ... do the following: ...
+foo
+  Avoid when possible even though it's a common term in the developer community. Instead, use a clearer and more meaningful placeholder name.
+for example
+  When you introduce an example using the phrase _for example_ , follow the phrase by a comma. For clarity, when introducing an example, separate the example using dashes, commas, or parentheses from the rest of the sentence as appropriate, or introduce the example in a separate sentence.
+  Recommended: Enter a name for the instance – for example, `my-instance-99`.
+  Recommended: Enter a six-digit hex number (for example, `228B22`), and then click **OK**.
+  Recommended: Enter a six-digit hex number, and then click **OK**. For example, if you want the color forest green, enter `228B22`.
+  For more information, see Format examples.
+for instance
+  Don't use the phrase _for instance_ to introduce examples to avoid confusion with the noun _instance_. Instead, use _for example_ , _like_ , or _such as_. For more information, see for example.
+frontend
+  Not _front-end_ or _front end_.
+functionality
+  Use with caution. With respect to hardware or software, _functionality_ refers to a set of associated functions or capabilities and how they work. However, the word is sometimes overused, especially when the intended meaning is _capabilities_ or _features_.
+future, in the future
+  Avoid in timeless documentation because this word or phrase can become outdated.
+  See also eventually and soon. For more information, see Timeless documentation.
+
+### G
+
+GBps
+  Short for _gigabytes per second_. By convention, we don't use _GB/s_. For more information, see  Units of measurement.
+Gbps
+  Short for _gigabits per second_. By convention, we don't use _Gb/s_. For more information, see  Units of measurement.
+`gcloud` CLI
+  Use the full name _Google Cloud CLI_ the first time that you mention the product on a page.
+gender-neutral he, him, or his (or she or her)
+  Don't use. Instead, use the singular _they_ (see  Jane Austen and other famous authors violate what everyone learned in their English class). Don't use _he/she_ or _(s)he_ or other such punctuational approaches. For more information, see Pronouns.
+generative AI
+  Spell out _generative_. Use sentence case.
+  Don't use _gen AI_ or _Gen AI_.
+  Don't hyphenate _generative AI_ as an adjective unless you must do so for clarity. See also AI.
+ghetto
+  Don't use. Instead use more precise terms like _clumsy_ , _workaround_ , or _inelegant_ to refer to code that isn't in a production-ready state.
+gimp, gimpy
+  Don't use. Instead, use precise, non-figurative language to refer to a deficiency in a component.
+  OK to use in reference to companies, tools, software packages, and other entities that use the term in their names.
+GKE node
+  Use when first introducing GKE nodes on a given page. For subsequent mentions, you can use _node_. A GKE node is a worker machine that runs containerized applications and other workloads. The machine is a Compute Engine VM that GKE creates during cluster creation. See also virtual machine (VM) instance.
+Google, Googling
+  Don't use as a verb or gerund. Instead, use _search with Google_.
+Google Account, Google Accounts
+  Capitalize _Account_.
+Google API Client Library for LANGUAGE (Java, .NET, etc.)
+  On second and subsequent use, you can abbreviate to _LANGUAGE client library_.
+Google API Console, Google APIs Console
+  Don't use. For more information, see console.
+Google Cloud
+  Not _GCP_ , _Cloud Platform_ , or _Cloud_.
+Google Cloud console
+  If you're only discussing the Google Cloud console, it's OK to shorten to _the console_ after first use on a given page.
+  Use _the_ before the console name. For more information, see console.
+Google Cloud project ID
+  Not _Cloud project ID_ or _GCP project ID_. You can also shorten to _project ID_ , but be aware that that term is ambiguous in some contexts.
+Google Developers Console
+  Don't use. For more information, see console.
+Google I/O
+  Not _I-O_ or _IO_.
+Google Play services
+  Write _services_ in lowercase.
+Google Play services SDK
+  Write _services_ in lowercase.
+grandfather clause, grand-father clause, grand father clause
+  Don't use. See grandfathered.
+grandfathered
+  Don't use to refer to something that is allowed to violate a rule because it predates the rule. Instead, use an adjective like _legacy_ or _exempt_ or a verb like _made an exception_.
+  Recommended: The app is exempt because it was released before the new requirements were announced.
+  Not recommended: The app is grandfathered in because it was released before the new requirements were announced.
+gray-box, grey-box
+  Avoid using _gray-box_ , _graybox_ , or _gray box_ to describe testing.
+  To refer to testing that's a combination of clear and opaque testing methods, describe exactly what it's doing.
+  If you need to refer to this type of testing after you describe it, consider using a more precise term for clarity, such as _translucent-box testing_.
+grayed-out, greyed-out, gray out, grey out
+  Don't use. Instead, use _unavailable_.
+grayhat, greyhat, gray hat, grey hat
+  Don't use. Follow the guidance for black hat when referring to someone violating rules or laws.
+graylist, greylist, gray list, grey list, gray-list, grey-list
+  Don't use. See blacklist.
+graylisted, greylisted, gray listed, grey listed, gray-listed, grey-listed
+  Don't use. See blacklist.
+graylisting, greylisting, gray listing, grey listing, gray-listing, grey-listing
+  Don't use. See blacklist.
+`gsutil`
+  In the Google Cloud context, use code font for both the name of the command-line utility and the command.
+guru
+  If possible, use a more precise term. For example, if you mean _expert_ or _teacher_ , use those terms.
+guys, you guys
+  When referring to a group of people use non-gendered language, such as _everyone_ or _folks_.
+gypsy
+  Don't use. To refer to the people, use _Romani_ , _Roma_ , or _Traveller_ , as appropriate for the specific group you're referring to. In place of metaphorical uses of the term, use more precise phrases.
+
+### H
+
+hamburger, hamburger menu
+  Don't use. Instead use the `aria-label` for that particular icon. For example, menu **Menu**. For more information, see Buttons and icons.
+hands off, hands-off
+  Use a less figurative phrase, such as _automated_. If you're referring to a group that doesn't do anything during a process, write a description.
+hands on, hands-on
+  Use a less figurative phrase, such as _customizable_ , or write a description of the activity.
+hang, hung
+  Don't use to refer to a computer or system that is not responding. Instead, use _stop responding_ or _not responding_. For more information, see Avoid figurative language.
+happiness and satisfaction
+  Use _happiness_ when referring to a customer's perception of a site's reliability. Use _satisfaction_ when referring to whether the site meets the customer's needs.
+  Site reliability engineering (SRE) content generally refers to measuring _customer happiness_ instead of _customer satisfaction_. The two phrases are not equivalent.
+  The distinction the SRE documentation makes is between satisfying a need (a dispassionate act) and establishing an emotional response (creating happiness). Although it is difficult to measure happiness precisely, SRE uses service level indicators (SLIs) to quantify user perception. For example, a customer might feel a "need" to watch a show on TV. If the show is available, the customer's need is satisfied. But if playback is slow or choppy, the customer might not be happy.
+  For more information about SRE and measuring reliability, see  The Happiness Test.
+hardcode (verb), hardcoded (adjective)
+  Don't hyphenate.
+he, him, his
+  Don't use a gendered pronoun except for a specific individual of known gender. Use _they_ and _their_ for the general singular pronoun.
+healthcare
+  Not _health care_ or _health-care_.
+health check
+  Use with caution. When describing an action taken for a computer system, only use the term _health check_ if this is the term that appears in the interface. Be certain to remove any ambiguity regarding whether the term refers to health in the medical sense.
+  Use detailed, non-figurative language as much as possible, such as referring to a node _being responsive_ instead of referring to a node being healthy.
+healthy
+  Don't use. See health check.
+high availability (noun), high-availability (adjective)
+  Spell as _high availability_ when used as a noun and as _high-availability_ when used as an adjective. See also load balancing (noun), load-balancing (adjective).
+  Lowercase except when part of a product name, but OK to abbreviate as _HA_ after first use.
+higher
+  Don't use for a range of version numbers. Instead, use  _later_.
+  Don't use to refer to a position in a document. Use _earlier_ or _preceding_.
+  Don't use to refer to a position in the UI. Instead, write instructions that avoid directional language. For more information, see Writing accessible documentation.
+  In Android documentation, use _higher_ for a range of version numbers, not _later_.
+  A release with the highest version number might not be the latest version. For example, if version 2.0 of an operating system receives a bug-fix update after version 3.0 has been released, then version 2.0.1 might be the latest version, even though its version number is lower than 3.0.
+high performance computing (HPC)
+  Don't hyphenate. Lowercase except at the beginning of a sentence, heading, or list item.
+hit
+  Don't use as a synonym for _click_ , _press_ , or _type_.
+hold the pointer over
+Only use this verb phrase in the following cases:
+
+  * When the user needs to hold their mouse over a UI element, but not click the UI element. This action involves waiting for the UI to react – for example, waiting for a tooltip to open or waiting for a submenu to open.
+  * When the duration of time is important.
+
+The phrase _point to_ is more common.
+
+  See also point to.
+  Recommended: In the **Admin** menu, hold the pointer over **File** , and then click **New**.
+  Not recommended: In the **Admin** menu, hover over **File** , and then click **New**.
+holiday, the holidays
+  Don't use to refer to the end of the year. Instead, refer to specific quarters or months.
+home screen
+  Two words in Android contexts; not _homescreen_ or _home-screen_.
+hostname
+  Not _host name_.
+hot
+  When possible, avoid jargon like _hot failover_ , _hot standby_ , and _hot spare_. If you use one of these phrases, define it on first use and use it consistently throughout the document. However, see hotspot.
+hotspotlink
+  In databases, _hotspots_ occur when a small number of nearby rows are accessed frequently in a short period of time, causing CPU spikes and affecting performance. Use _hotspot_ and _hotspots_ as nouns. Don't use verb and gerund forms such as _hotspotting_ , because they translate less consistently.
+  When you use _hotspot_ , define it the first time that you use it on a page as you normally do with jargon.
+  Recommended: Hotspots in one table can affect the performance of other tables.
+  Not recommended: Hotspotting in one table can affect the performance of other tables.
+housekeeping, house keeping, house-keeping
+  Don't use. Instead, use less figurative and more precise terms, such as _maintenance_ and _cleanup_.
+hover
+  Don't use. Instead use _hold the pointer over_.
+HTTPS
+  Not _HTTPs_.
+
+### I
+
+IaaS
+  Write out on first mention: _infrastructure as a service (IaaS)_.
+IAM
+  When referring to the Google Cloud product, spell it out on first use: _Identity and Access Management (IAM)_.
+  When referring to UI text, write this term the way it's written in the UI.
+  When referring to the general practice of identity and access management, spell it out in lowercase on first use and include a parenthetical comment:
+  Recommended: Identity and access management (generally referred to as _IAM_) is the practice of granting the right individuals access to the right resources for the right reasons.
+ID
+  Not _Id_ or _id,_ except in string literals or enums.
+  In some contexts, it's best to spell out as _identifier_ or _identification_.
+i.e.
+  Don't use. Instead, use phrases like _that is_. Many people confuse _e.g._ and _i.e._
+if
+  Wondering whether to use _if_ or _whether_? See whether.
+  Although it is common in casual usage to omit the word _then_ in _if...then_ statements, you should include helper words like _then_ in technical documentation. For more information, see Use clear, precise, and unambiguous language.
+image
+  _Image_ by itself doesn't localize well because of its many meanings. Consider adding context – for example, _disk image_ or _container image_.
+impact
+  Use only as a noun. Instead of writing that something _has an impact_ , use the word _affect_.
+  Recommended: This issue affects user experience.
+  Acceptable: This issue has an impact on user experience.
+  Not recommended: This issue impacts user experience.
+index
+  Use the plural _indexes_ unless there is a domain-specific reason (for example, a mathematical or financial context) to use _indices_.
+ingest
+  Use _import_ , _load_ , or _copy_ when referring to simple movement of data. Use _ingest_ only when referring to such operations that also involve significant processing of the data.
+ingress
+  When referring to the networking term, use lowercase. When referring to the GKE term or API, capitalize _Ingress_.
+in order to
+  Avoid _in order to_ ; instead, use _to_.
+  Use _in order to_ when needed to clarify meaning or to make something easier to read.
+  Recommended: You can use monitoring to help identify issues.
+  Not recommended: You can use monitoring in order to help identify issues.
+  Recommended: The infrastructure is required in order to support search.
+  Not recommended: The infrastructure is required to support search.
+inline
+  One word as an adjective, _inline_ , not _in line_ or _in-line_.
+instance group
+  Don't abbreviate to _IG_. See also managed instance group.
+intercluster
+  Use unhyphenated _intercluster_ , not _inter-cluster_.
+interconnectAttachment
+  Use when referring to the API. Otherwise, use  _VLAN attachment_.
+Interconnect connection
+  Only use _Interconnect connection_ relative to a product as follows:
+
+  * CDN Interconnect connection
+  * Cloud Interconnect connection
+  * Dedicated Interconnect connection
+  * Partner Interconnect connection
+
+OK to use _connection_ on subsequent mentions.
+
+  When you're referring to a Google Cloud product, always specify the product name. Don't use _Interconnect_ or _interconnect_ as standalone terms, and don't use generic terms like _cloud interconnect connection_ or _cross-connect_.
+Interconnect connection location
+  Only refer to an _Interconnect connection location_ in context of a specific product, for example _CDN Interconnect_.
+  OK to also use _colocation facility_.
+interconnect type
+  Don't use. Instead, use _connection type_. Examples of connection types are a _dedicated connection_ or a _connection provided by a service provider_.
+interface
+  OK to use as a noun.
+  Don't use as a verb. Instead, use _interact_ , _talk_ , _speak_ , _communicate_ , or other similar terms.
+internal DNS
+  Write _internal_ all lowercase except at the beginning of a sentence, heading, or list item.
+Internationalized Domain Name (IDN)
+  Write out and capitalize each word on first use. OK to abbreviate as _IDN_ after first use.
+internet
+  Lowercase except at the beginning of a sentence, heading, or list item.
+Internet Key Exchange (IKE)
+  Write out and capitalize each word on first use. OK to abbreviate _IKE_ after first use.
+I/O (see also Google I/O)
+  Not _I-O_ or _IO_.
+IoT
+  OK to use as an abbreviation for _Internet of Things_. Note the lowercase _o_.
+IPsec
+  Not _IPSec_ or _IPSECShort_.
+  Short for _Internet Protocol Security_. No need to spell out on first mention.
+
+### J
+
+jank, janky
+  Use only to refer to a glitch or problem with graphics that is caused by a loss of data or inadequate refresh rate. Don't use otherwise. Use a less figurative term to refer to something of poor or unreliable quality.
+just
+  Avoid. Usually, _just_ is a filler word that you can delete without affecting your meaning.
+  Recommended: BigQuery skips the row.
+  Not recommended: BigQuery just skips the row.
+  If your meaning is unclear without _just_ , then use a more specific term such as _only_ , _instead_ , or _previously_ , or revise your language to be more specific. (Even if one of these replacement terms fits, you often don't need it.)
+  Recommended: You can run DML statements in the same way that you'd run a `SELECT` statement.
+  Not recommended: You can run DML statements just as you'd run a `SELECT` statement.
+  Recommended: Let a user query only the table without full dataset access.
+  Recommended: Let a user query the table without full dataset access.
+  Not recommended: Let a user query just the table without full dataset access.
+  Sometimes, _just_ is useful for conveying that one approach is simpler than another. In those cases, use _just_ instead of _simply_.
+  Recommended: Use the namespace ID `namespace:example-kind` or just `example-kind`.
+
+### K
+
+k8s
+  Don't use. Instead, use _Kubernetes_.
+KBps
+  Short for _kilobytes per second_. By convention, we don't use _KB/s_. For more information, see  Units of measurement.
+Kbps
+  Short for _kilobits per second_. By convention, we don't use _Kb/s_. For more information, see  Units of measurement.
+kebab, kabob, kebab menu, kabob menu
+  Don't use. Instead use the `aria-label` for that particular icon. For example, more_vert **More**. For more information, see Buttons and icons.
+kebab case, kabob case, kebab-case, kabob-case
+  Don't use. Instead, use _dash-case_.
+key
+  Don't use as an adjective in the sense of _crucial_ or _important_.
+  If you use _key_ as a noun, specify which kind of key you're referring to on first mention, because there are many kinds of keys in technical contexts.
+key pair
+  A pair of keys, such as a public key and a private key. Contrast with _key-value pair_ , which refers to a pairing that specifies a value for a variable (as in configuration files).
+key ring
+  Use instead of _keyring_ (without the space) when referring to a grouping of Cloud KMS keys.
+key-value pair
+  Use instead of _key/value pair_ or _key value pair_.
+kill
+  Avoid when possible. Instead, use words like _stop_ , _exit_ , _cancel_ , or _end_. For exceptions to this rule, see Documenting command-line syntax.
+
+### L
+
+lame
+  Don't use. Instead, use precise, non-figurative language to refer to a deficiency in a component.
+later
+  Use for a range of version numbers, not _higher_.
+  Recommended: Use version 2.2 or later.
+  Not recommended: Use version 2.2 or higher.
+  Not recommended: Use version 2.2+.
+  A release with the highest version number might not be the latest version. For example, if version 2.0 of an operating system receives a bug-fix update after version 3.0 has been released, then version 2.0.1 might be the latest version, even though its version number is lower than 3.0.
+  In Android documentation, don't use _later_ for a range of version numbers. Instead, use _higher_.
+  When referring to a position in a document, use _later_ or _following_ , not _below_.
+latest
+  Avoid in timeless documentation because this word can become outdated.
+  If you must use _latest_ , give the reader a reference point – for example, a version number or release date.
+  Recommended: To help keep your system secure, install the latest version of the tools.
+  Recommended: The June 2021 release includes the latest tools that help secure your system.
+  Not recommended: The product includes the latest tools that help secure your system.
+  For more information, see Timeless documentation.
+learnings
+  Don't use. Instead, refer to _knowledge_ or _things that you learned_.
+left-nav, right-nav
+  Don't use directional language. For more information, see Writing accessible documentation.
+  If referring to applications, use _navigation menu_.
+  If referring to navigational elements for documentation, use _content navigation menu_.
+legacy
+  If possible, use a more precise term. If you do use _legacy_ , include or point to a definition to clarify what you mean in the current context. Don't use _legacy_ with any sort of pejorative connotation.
+let's (as a contraction of _let us_)
+  Don't use if at all possible.
+  Not recommended: Let's click the **OK** button now.
+Letter of Authorization and Connecting Facility Assignment (LOA-CFA)
+  Write out and capitalize each word on first use. OK to abbreviate as _LOA-CFA_ after first use.
+leverage
+  Avoid using if you mean _use_. If possible, use a more precise term. For example, _use_ , _build on_ , or _take advantage of_.
+lifecycle
+  Not _life cycle_ or _life-cycle_.
+lift and shift
+  See rehost. like
+  It's OK to use _like_ for either drawing comparisons (in the sense of _similar to_) or introducing examples (in the sense of _such as_).
+  Recommended: Common I/O operations, like reading files or making network requests, can be asynchronous.
+  Recommended: The new compression algorithm works like a dictionary encoder, replacing repeated strings with shorter codes.
+  See also such as. For more information, see Format examples.
+limits
+  In an API context, _limit_ often refers to usage limits (number of queries allowed per second or per day). Where possible, specify the kind of limit that you mean, such as _usage limit_ or _service limit_ ; the word _limit_ can refer to many different kinds of limits, including rules about acceptable use. See also  quota.
+lint
+  Write both command-line tool name and command in lowercase. Use code font except where inappropriate.
+little-endian
+  Hyphenate. Lowercase except at the beginning of a sentence, heading, or list item.
+  Recommended: The codebase assumes little-endian byte ordering.
+  Not recommended: The codebase assumes Little Endian byte ordering.
+  Not recommended: The codebase assumes Little-endian byte ordering.
+  Not recommended: The codebase assumes little endian byte ordering.
+livestream
+  Not _live stream_.
+load balancing (noun), load-balancing (adjective)
+  Spell as _load balancing_ when used as a noun and as _load-balancing_ when used as an adjective. See also high availability (noun), high-availability (adjective).
+lock screen
+  Two words in Android contexts; not _lockscreen_ or _lock-screen_.
+login (noun or adjective), log in (verb)
+  For the verb form, _sign in_ is generally better.
+  If you're documenting a tool that uses the term _log in_ , then use that term.
+long press
+  In Android documentation, don't use. Instead, use _touch & hold_. (Not _touch and hold_.)
+long-running operation
+  Not _long running operation_.
+  OK to abbreviate as _LRO_ after the first use.
+lower
+  Don't use for a range of version numbers. Instead, use _earlier_.
+  Don't use to refer to a position in a document. Instead, use _later_ or _following_.
+  Don't use to refer to a position in the UI. Instead, write instructions that avoid directional language. For more information, see Writing accessible documentation.
+  In Android documentation, use _lower_ for a range of version numbers, not _earlier_.
+
+### M
+
+male adapter
+  Don't use. Instead, use a genderless word like _plug_.
+man hours, manhours, man-hours
+  Avoid using gendered terms. Instead use terms like _person hours_.
+man-in-the-middle (MITM)
+  Avoid using gendered terms. Instead use terms like _on-path attacker_ or _person-in-the-middle (PITM)_.
+managed instance group (MIG)
+  OK to abbreviate to _MIG_ on subsequent mention. See also instance group.
+manmade, man made
+  Avoid using gendered terms. Instead use a word like _artificial_ , _manufactured_ , or _synthetic_.
+manned
+  Avoid using gendered terms. Instead use terms like _staffed_ or _crewed_.
+manpower, man power, man-power
+  Avoid using gendered terms. Instead use terms like _staff_ or _workforce_.
+Markdown
+  Always capitalized, even when you're referring to a nonstandard version.
+master
+  Use with caution. Never use in conjunction with _slave_. Where possible, replace _master_ with a specific term that is accurate for the context, such as _primary_ , _main_ , _original_ , _parent_ , _initiator_ , _driver_ , _controller_ , _manager_ , _mixer_ , _aggregator_ , _publisher_ , _leader_ , or _active_.  Guidance | Recommended | Not recommended |  Don't use _master_ in conjunction with _slave_ in any context.  | Cloud SQL primary/replica | Cloud SQL master/slave
+---|---|---
+Avoid using _master_ where possible. |
+
+  * GKE control plane
+  * Jenkins controller
+  * root key (in security)
+  * primary key (in databases)
+
+|
+
+  * GKE master plane
+  * Jenkins master
+  * master key (in security)
+  * master key (in databases)
+
+
+  If the command or code that you're documenting uses the literal word _master_ , then use this word only in direct reference to the code item (formatted as code), make it clear what you're referring to, and use the new term thereafter.
+  See also _slave_.
+Material Design
+  Capitalize each word in _Material Design_.
+matrix
+  Use the plural _matrixes_ unless there is a domain-specific reason (for example, a mathematical context) to use _matrices_.
+may
+  In general, reserve for official policy or legal considerations.
+  To convey _possibility_ , use _can_ or _might_ instead.
+  To convey _permission_ , use _can_ instead.
+  See also can, could, might, must, should, and would.
+  For information about clarifying who's performing an action, see Active voice.
+MBps
+  Short for _megabytes per second_. By convention, we don't use _MB/s_. For more information, see Units of measurement.
+Mbps
+  Short for _megabits per second_. By convention, we don't use _Mb/s_. For more information, see Units of measurement.
+media type
+  In general, use the term _media type_. In contexts where you need to refer to a _content type_ – For example, if you mention the `Content-Type` HTTP header – it's okay to use _content type_ instead, to avoid confusion. Don't use _MIME type_.
+meta*
+  See guidance about hyphens with prefixes.
+metafeed
+  Not _meta-feed_.
+metageneration
+  Not _meta-generation_.
+method
+  In programming contexts where _method_ refers to a member of a class (as in Java), avoid also using the word generically to mean "approach" or "manner."
+metropolitan area (metro)
+  In networking, a _metro_ is a city where a colocation facility is located.
+microservices
+  Not _Microservices_ or _micro-services_.
+might
+  Use to convey possibility or an uncertain outcome (for example, "You might be prompted to enter your credentials").
+  See also can, could, may, must, should, and would.
+  For information about clarifying who's performing an action, see Active voice.
+MIME type
+  _MIME_ stands for "Multipurpose Internet Mail Extensions," and was originally used to refer to email standards. Don't use _MIME_ when you mean _media type_. If you feel that might be ambiguous to an audience familiar with the term _MIME_ , then you can write _media (MIME) type_ for clarity.
+mobile
+  Don't use _mobile_ as a standalone noun. Instead, specify _mobile phone_ , or if you're talking about more than phones, then use _mobile device_.
+mobile data
+  Use instead of _cellular data_.
+mobile device
+  Use _mobile device_ when you're referring to more than phones (for example, tablets and phones). It's OK to use _phone_ (without _mobile_) when the context is clear.
+mobile network
+  Use instead of _cellular network_.
+mobile phone
+  If you're talking about more than phones, then use _mobile device_. It's OK to use _phone_ (without _mobile_) when the context is clear.
+mom test
+  Don't use _mom test_ , _grandmother test_ , _grandma test_ , or _girlfriend test_. Instead, use terms like _beginner user test_ or _novice user test_.
+monkey, monkey test
+  Don't use _monkey_ to refer to people. When referring to tests, refer to the specific function. For example: _automated, random tests_.
+multi*
+  See guidance about hyphens with prefixes.
+multi-cluster
+  Hyphenate. We generally prefer to close prefixed words, but this is an exception because it's an established term.
+multi-region, multi-regional
+  Hyphenate when referring to a Google Cloud location that consists of more than one region.
+  You can use _multi-regional_ as an adjective in the context of multi-regions, but consider _multi-region_ as an attributive noun instead, such as in "The dataset is in the EU multi-region location." Use _multiregional_ in other contexts.
+multi-service
+  Hyphenate. We generally prefer to close prefixed words, but this is an exception because it's an established term.
+multi-tenancy
+  Hyphenate. We generally prefer to close prefixed words, but this is an exception because it's an established term.
+must
+  Use to describe a required action or state (for example, "You must have the Editor role"). You can also write _you need_ in order to convey a requirement.
+  See also can, could, may, might, should, and would.
+  For information about clarifying who's performing an action, see Active voice.
+
+### N
+
+N/A
+  Not _NA_. Spell out as _not available_ or _not applicable_ on first reference.
+name server
+  Not _nameserver_.
+namespace
+  Not _name space_.
+native
+  Avoid using _native_ to refer to people.
+  When referring to software products, try to use a more precise term – for example, use _built-in_ to describe a feature that's part of a product.
+  The term _native_ isn't necessarily clear – for example, _cloud-native_ could mean that something was written for the cloud, or that it's built in to a cloud platform, or that it currently exists in a cloud platform.
+  Alternatives to a term like _cloud-native_ could include: _modern cloud_ , _born in the cloud_ , _cloud first_ , and _cloud-born_.
+navigation bar
+  Don't use to refer to a _navigation menu_. For more information, see Navigation menu.
+neither
+  Write _neither A nor B_ , not _neither A or B_.
+network IP address
+  Don't use. Instead, use _internal IP address_.
+new, newer
+  Avoid in timeless documentation because this word can become outdated.
+  _New_ also implies that the reader knows the older product and that labeling something as _new_ is therefore meaningful.
+  If you must use _new_ , give the reader a reference point – for example, a version number or release date.
+  Don't use _newer_ to refer to a specific version of a product. Instead, use _later_. Make sure that you provide a version number or release date by which to understand _later_.
+
+In Android documentation, use _higher_ instead of _later_.
+
+  Recommended: The service's network analysis feature reports on network health.
+  Not recommended: Network analysis, a new feature in the service, reports on network health.
+  For more information, see Timeless documentation.
+ninja
+  Don't use to refer to a person. Instead, use a term such as _expert_. OK to use in reference to companies, tools, software packages, and other entities that use the term in their names.
+non*
+  See guidance about hyphens with prefixes.
+nonce
+  Use with caution: this term has a secondary slang meaning that can cause confusion for global readers. Always define the term on first use, and only use it in specific technical contexts such as authentication and blockchain.
+  In end-user documentation and other contexts, use a more descriptive phrase, such as _a number that will be used only once_.
+non-key
+  An exception to our usual preference for closed forms.
+NoOps
+  Don't use. Instead, use _fully managed_. If you must include the term, define it at first use with language such as _fully managed_ or _no operations_ , but not _non-operational_. Don't use _noops_.
+  For an instruction that does nothing, use _no-op_ or the specific instruction name for your context.
+NoSQL
+  Not _No-SQL_ or _No SQL_.
+notification drawer
+  In Android contexts, don't hyphenate. Lowercase except at the beginning of a sentence, heading, or list item.
+now
+  Avoid when describing features of products or services because this word is implied.
+  If the intent of the text is a comparison between past and present, you can use _now_ – for example, "In versions of the tool earlier than 1.10, you could use only the default value, but now you can assign a custom value."
+  Recommended: This feature lets you use combinations of user properties.
+  Not recommended: This feature now lets you use combinations of user properties.
+  For more information, see Timeless documentation.
+nuke
+  Don't use. Instead use _remove_ or _attack_. For example, a _denial-of-service attack_.
+
+### O
+
+OAuth 2.0
+  Not _OAuth 2_ , _OAuth2_ , or _Oauth_.
+off-the-shelf, commercial off-the-shelf (COTS)
+  Use more widely understood terms like _ready-made_ , _prebuilt_ , _standard_ , or _default_.
+old, older
+  Don't use to refer to a previous version of a product. Instead, use _earlier_.
+  Make sure that you provide a version number by which to understand _earlier_.
+  In Android documentation, use _lower_ instead of _earlier_.
+  Recommended: This functionality doesn't work in versions earlier than 1.17.0.
+  Not recommended: This functionality doesn't work in older versions.
+  For more information, see Timeless documentation.
+omnibox
+  Don't use. Instead, use _address bar_.
+once
+  If you mean _after_ , then use _after_ instead of _once_.
+on-premises
+  Not _on prem_ , _on premise_ , or _on-premise_. Hyphenate when used as any part of speech.
+  Use to refer to a customer's resources that they manage in their own facilities. Don't use _peer_.
+  It can be acceptable to use _on-premises_ as a noun when it would be awkward to repeatedly write out a full phrase like _an on-premises environment_. However, it's preferable to use the more complete phrase whenever possible.
+  Recommended: An on-premises database.
+  Recommended: The database runs on-premises.
+  OK: Moving data from on-premises to Google Cloud.
+OS
+  OK to use as a shortening of "operating system."
+outpost
+  Don't use. Instead, use _channel_.
+  Recommended: social media channels
+outside the box, out of the box, out-of-the-box
+  Avoid using in a figurative way. OK to use literally.
+overview screen
+  In Android documentation, don't use. Instead, use _recents screen_.
+
+### P
+
+PaaS
+  Write out on first mention: _platform as a service (PaaS)_.
+page
+Use _page_ to refer to the following:
+
+  * A whole web page, which can include text, images, links, banners, navigational panes, and other features.
+  * A sub-page of a console in particular.
+
+See also documentation or document or documents.
+
+  Recommended: To refresh the page, press `F5`.
+parameter
+  In our API documentation, _parameter_ is usually short for _query parameter_ ; it's a `NAME=VALUE` pair that's appended to a URL in an HTTP `GET` request. In some contexts, however, the term can have other meanings.
+parent-child or parent/child
+  Not _parent – child_ or _parent – child_.
+path
+  Avoid using _filepath_ , _file path_ , _pathname_ , or _path name_ if possible.
+peer gateway
+  Don't use _on-premises gateway_ when you mean a _peer gateway_. A peer gateway can be an on-premises device or service or another cloud gateway.
+peer network
+  Don't use _on-premises network_ when you mean a _peer network_. A peer network can be an on-premises network or another cloud network.
+peering zone
+  Not _peer zone_.
+per
+  To express a rate, use _per_ instead of the division slash (/), unless space constraints require the use of the slash. For more information, see Units of measurement.
+  Avoid _per_ in contexts other than rate units.
+  Recommended: requests per day
+  Recommended: create a policy for each Pod
+  Recommended: according to the style guide
+  Recommended: in response to your request
+  Not recommended: requests/day
+  Not recommended: create a policy per Pod
+  Not recommended: per the style guide
+  Not recommended: as per your request
+performant
+  Avoid where possible. Instead, use a more precise term.
+  Recommended: an accurate machine learning model
+  Not recommended: a performant machine learning model
+persist
+  Don't use as a transitive verb. It's best to avoid using as a verb at all, especially in passive voice.
+  Recommended: To make the token persistent ...
+  OK: To make the token persist ...
+  Not recommended: The token is persisted ...
+  Not recommended: To persist the token ...
+persistent disk
+  Not _PD_.     Lowercase except at the start of a sentence.
+personally identifiable information (PII)
+  Some government agencies use the less common term _personally identifying information_ ; use this alternate term only in contexts where you're referring to a document that uses this term.
+pets versus cattle, pets vs. cattle, pets v. cattle
+  Don't use. Instead, use more precise terms like _persistent versus dynamic_ or _manually configured versus automated_. For more information, see Avoid figurative language.
+plain text
+  In most contexts, use _plain text_ , but use _plaintext_ in a cryptography context.
+please
+  Don't use _please_ in the normal course of explaining how to use a product, even if you're explaining a difficult task.
+  Don't use the phrase _please note_.
+  Use _please_ only when you're asking for permission or forgiveness – for example, when what you're asking for benefits you, inconveniences a reader, or suggests a potential issue with a product.
+  Recommended: If the issue persists, please contact your account representative.
+  For more information, see voice and tone. plugin (noun), plug-in (adjective), plug in (verb)
+  Use the noun form _plugin_ when referring to the software component. Use the adjective form _plug-in_ when referring to the action of installing a software component. Use the verb form _plug in_ when you're describing the process of installing a software component.
+PM
+  See AM, PM.
+point to
+  Use to refer to the action of pointing the mouse pointer (focus). This action doesn't imply a length of time waiting for the UI to react to user action.
+  This is similar to the action hold the pointer over (hover). In most cases, it's better to use the verb phrase _hold the pointer over_ if you want the user to wait for the UI to react.
+POJO
+  If you're not actually writing about a Plain Old Java Object for a Java audience, use _simple object_. You can write _a simple object, similar to a POJO in Java_ if that helps your audience.
+PoP
+  Acronym for _point of presence_.
+  Recommended: point of presence (PoP)
+  Not recommended: point of presence (POP)
+pop-up, popup
+  Don't use.
+  To describe a window that appears and asks for, or presents, additional information, use _dialog_.
+  To describe a menu that rises from an interface (such as a right-click context menu), use _menu_.
+populate
+  OK to use if you're writing about a process populating a table or other entity. If you're writing about a person, use _fill in_.
+  Recommended: The SQL command populates the table with sample data.
+  Recommended: When you have finished filling in the form ...
+  Not recommended: When you have finished populating the form ...
+port
+  Use _listen on_ (not _to_).
+portal
+  Don't use to refer to the Google Cloud console. For more information, see console.
+possible
+  Don't use _possible_ or _impossible_ to mean _you can_ or _you can't_.
+PostgreSQL
+  If the UI uses the name _Postgres_ , it's OK to match the UI. Don't use _PostgreSQL_.
+postmortem
+  Avoid in general usage. Instead, use _retrospective_.
+  In disaster recovery (DR) and DevOps contexts, use _blameless postmortem_.
+practitioner
+  Avoid using without any supporting information to define the roles that you're referring to.
+  Recommended: The framework describes best practices for architects, developers, administrators, and other cloud practitioners.
+  Not recommended: The framework describes best practices for cloud practitioners.
+pre*
+  See guidance about hyphens with prefixes.
+prebuilt
+  Not _pre-built_.
+precapture
+  Not _pre-capture_.
+preemptible
+  Not _pre-emptible_ or _pre-emptive_.
+pre-existing
+  Not _preexisting_.
+preferred pronouns
+  Don't use. Instead, use _pronouns_.
+prerecorded
+  Not _pre-recorded_.
+pre-shared key
+  Not _preshared key_.
+presently, at present
+  Avoid because this word or phrase is implied. The word or phrase can also prematurely disclose product or feature strategy or inappropriately imply that a product or feature might change.
+  See also as of this writing and currently.
+  Recommended: This setting is required.
+  Not recommended: At present, this setting is required.
+  For more information, see Timeless documentation.
+press
+  Use when referring to pressing a key or a key combination to cause an action to occur. Also use for mechanical buttons.
+  For on-screen and soft (capacitive) buttons, use _tap_.
+  Recommended: Press `Control+C` (or `Command+C` on macOS).
+presubmit
+  Not _pre-submit_.
+primitive
+  Use with caution. Don't use _primitive_ in a disparaging sense.
+project
+  In Google Cloud documentation, use _Google Cloud project_ on first mention and in any context in which there might be ambiguity about what kind of project you're referring to.
+pros
+  Don't use. Instead, use a more precise term, such as _advantages_.
+
+### Q
+
+quick, quickly
+  What might be quick for you might not be quick for others. Try eliminating this word from the sentence because usually the same meaning can be conveyed without it.
+quota
+  In API contexts, often refers to API usage limits. Where possible, it's best to use a more specific term, such as _usage limit_ ; the word _quota_ means many different things to many different people.
+  In some contexts, such as Google Cloud documentation, the standard term is _quota_ , so use that term.
+
+### R
+
+RDP
+  Don't use as a verb. Instead, use _connect using RDP_. If it's clear from context that they're using RDP, it's OK to use _connect_.
+re*
+  See guidance about hyphens with prefixes.
+read-only
+  Not _read only_. Always hyphenate _read-only_.
+recents screen
+  In Android contexts, use instead of _overview screen_.
+redline
+  Don't use as a verb. Instead, use precise terms appropriate to the context.
+  In the context of editing or providing a review, refer to those actions or to _tracking changes_.
+  In the context of setting priorities and planning work, refer to those actions or to _priority lining_.
+regex
+  Don't use. Instead, use _regular expression_.
+rehost
+  Use to describe the migration of an app or workload with no changes or minimal changes to that app or workload. Also known as _lift and shift_. For more information, see  Rehost: lift and shift in the Cloud Architecture Center.
+  On first mention, associate rehost with lift and shift. Okay to use _rehosting_ as needed after first mention.
+  Recommended: You can use this reference architecture to efficiently rehost (lift and shift) on-premises applications to the cloud.
+  Recommended: The first step to modernization is to rehost your application in the cloud (also known as lift and shift).
+  Don't use _the forklift approach_.
+repo
+  Don't use. Instead, use _repository_.
+Representational State Transfer
+  Don't use. To people unfamiliar with REST, this acronym expansion is meaningless; it's better to refer to it as REST and not explain what it stands for.
+reservation, off the
+  Don't use.
+resource record set
+  Not _resource recordset_.
+retarded
+  Don't use. If you are referring to a system or component being slowed, use the word _slowed_.
+retriable, triable
+  Don't use _retriable_ or _triable_ , unless a code item uses that spelling. Outside of code font, write around the term.
+retryable, tryable
+  Where possible, write around _retryable_ and _tryable_. For example, write out _you can try it again_ or _can be tried again_.
+review
+  If you mean "read, potentially for the first time," then use _read_ instead of _review_.
+  If you mean "read critically, commenting on problems" (as in _code review_), then _review_ is fine.
+  Avoid using phrasing like "If you've never heard of OAuth, then review the OAuth documentation."
+RFC
+  When referencing an RFC specification, use a space between _RFC_ and the number (for example, _RFC 2318_).
+roll out
+  Don't use to mean a sudden or instantaneous launch. If you use _roll out_ , define what you mean. When possible, use a more precise, non-figurative term like _gradual_ , _in stages_ , _phases_ , or _progressive_.
+RTFM
+  Don't use. Instead, use a more precise phrase like "For more information, see ...."
+runbook
+  Not _run book_.
+runtime, run time
+  Use the noun _runtime_ when referring to the environment in which software runs, such as a Ruby or Java runtime.
+  Use the noun phrase _run time_ when referring to the time during program execution when something occurs, as contrasted with _compile time_ , for example.
+  Recommended: The profiler collects data at run time, and the scheduler uses this data at compile time to improve performance for subsequent runs.
+  Recommended: The App Engine standard environment has two generations of runtime environments. The second-generation runtimes significantly improve the capabilities of App Engine.
+
+### S
+
+SaaS
+  Write out on first mention: _software as a service (SaaS)_.
+sane
+  Don't use. Instead use a word like _valid_ or _sensible_.
+sanity check
+  Don't use. Instead, use a term like _quick check_ , _confidence check_ , _preliminary check_ or _coherence check_.
+SAP
+  Pronounced as the individual letters _S_ , _A_ , _P_ , so write _an SAP system_ , not _a SAP system_. For more information, see Indefinite articles before abbreviations.
+scale
+  Don't use _scale_ alone to say that something is large or increasing. Include supporting words to indicate magnitude or direction of change in magnitude, whether scaling up or down, such as when you change a machine type to add or remove CPUs or RAM, or scaling out or in, such as adding or removing instances from a group.
+  Recommended: The system performs better at a larger scale.
+  Not recommended: The system performs better at scale.
+  Recommended: The system scales up quickly, but it scales down more slowly.
+  Not recommended: The system scales quickly.
+screenshot (noun)
+  Not _screen shot_ or _screensnap_.
+  Don't use as a verb; instead, use _take a screenshot_.
+scroll
+  OK to use _scroll_ as a verb, but if possible, instead use a term that isn't specific to implementation. For example, write _go to the section_ , instead of _scroll to the section_.
+  If you use _scroll_ , don't use directional language like _scroll up_. For more information, see Accessibility.
+Search (as part of product name)
+  Capitalize _Search_ when referring to a product like Google Search.
+Search Console
+  Capitalize each word in _Search Console_.
+see
+  OK as a general term and when referring to links and cross-references. Our research indicates that language relating to sight is OK for a wide range of readers. For more information, see Cross-references and linking.
+select
+  Use to describe choosing an item from among multiple options, selecting text, or marking a checkbox.
+  Recommended: Select **Automatically check for updates**.
+  Not recommended: Check **Automatically check for updates**.
+sensitive
+  _Sensitive_ data is data for which the release might be harmful. See confidential.
+service
+  It's OK to refer to Google products, such as Google Kubernetes Engine or Compute Engine, as _services_. However, if the term _services_ leads to ambiguity, then use the product names.
+service level agreement
+  Lowercase when referring to service level agreements in general.
+  It's OK to use title case (_Service Level Agreement_) when referring to a specific document.
+  OK to abbreviate as _SLA_ after first use.
+service level indicator
+  Lowercase except at the beginning of a sentence, heading, or list item.
+  OK to abbreviate as _SLI_ after first use.
+service level objective
+  Lowercase except at the beginning of a sentence, heading, or list item.
+  OK to abbreviate as _SLO_ after first use.
+setup (noun or adjective), set up (verb)
+sexy
+  Don't use. Instead, use precise, positive words, such as _fast_ , _powerful_ , or _elegant_.
+SHA-1
+  Not _SHA1_ , except in string literals/enums and in hyphenated phrases such as _HSA-SHA1_.
+shall
+  Avoid _shall_ except under advice from a lawyer. For more information, see should.
+she, her, hers
+  Don't use a gendered pronoun except for a specific individual of known gender. Use _they_ and _their_ for the general singular pronoun.
+sherpa
+  If possible, use a more precise term. For example, if you mean _guide_ , use that term.
+shift left
+  In general, avoid using this term to mean moving something earlier in time. Instead, use a less figurative phrase, such as _shift earlier_ or _move to an earlier phase_. This figurative term relies on the non-universal assumption that the natural flow is from left to right.
+  It's OK to use _shift left_ and _shift right_ in the context of binary multiplication and division.
+should, should be
+  Generally avoid.
+  Because _should_ is ambiguous by definition, it can be problematic. For more information and alternatives, see Word choice for recommendations and requirements.
+  See also can, could, may, might, must, and would.
+sign-in (noun or adjective), sign in (verb)
+  Not _log in_ or _signin_.
+sign into
+  Don't use. Instead, use _sign in to_.
+sign-on, sign on
+  Don't use either form on its own. Use the hyphenated version as part of _single sign-on_.
+sign-out (noun or adjective), sign out (verb)
+  Not _log out_ or _signout_.
+simple, simply
+  What might be simple for you might not be simple for others. Try eliminating this word from the sentence because usually the same meaning can be conveyed without it.
+since
+  If you mean _because_ , then use _because_ instead of _since_. _Since_ is ambiguous; it can refer to the passage of time. _Because_ refers to causation or the reason for something.
+single most
+  Not _singlemost_.
+single pane of glass
+  Avoid. This term is used to favorably compare a centralized control and monitoring interface against the alternative of several disparate interfaces. It can almost always be replaced by _single interface_ or _unified interface_.
+single sign-on (noun or adjective)
+slave
+  Don't use. Instead, use alternative terms appropriate to your domain, such as _worker_ or _replica_.
+  If you're replacing the terms _master_ and _slave_ together, then consider such combinations as _primary_ /_secondary_ , _primary_ /_replica_ , _original_ /_replica_ , _controller_ /_worker_ , _initiator_ /_responder_ , _mixer_ /_leaf_ , _aggregator_ /_collector_ , _publisher_ /_subscriber_ , _leader_ /_follower_ , and _active_ /_standby_.
+  If the command or code that you're documenting uses the literal word _slave_ , then use this word only in direct reference to the code item (formatted as code), make it clear what you're referring to, and use the new term thereafter. For example, "Invoke the secondary (`slave`) process directly when debugging issues between the primary and secondary processes."
+  See also master.
+slice and dice
+  Don't use the phrase _slice and dice_. Instead, use specific terms appropriate to the task that you're describing. Some possible options include: _segment data for analysis_ or _break information into smaller parts_.
+smartphone, smart phone
+  Don't use. Instead, use _mobile phone_ or _phone_. If you're talking about more than phones, then use _mobile device_. It's OK to use _phone_ (without _mobile_) when the context is clear.
+soon
+  Avoid in timeless documentation because this word can become outdated. The word can also prematurely disclose product or feature strategy or inappropriately imply that a product or feature might change.
+  See also eventually and future.
+  Recommended: This setting is optional.
+  Not recommended: This setting is optional for existing applications but will soon be required for all applications.
+  For more information, see Timeless documentation.
+spin up
+  As in _spin up an instance_. Avoid using _spin up_ unless you're referring to a hard disk; instead, use a less colloquial term like _create_ or _start_.
+SQL
+  Refer to _a SQL_ (pronounced "a sequel"), not _an SQL_. For more information, see Indefinite articles before abbreviations.
+ssh and SSH
+  Don't use `ssh` or SSH as a verb. SSH is a secure communications protocol; `ssh` is a utility.
+  Recommended: To establish an SSH connection, use the `ssh` command.
+  Recommended: Connect to the instance by using SSH.      Not recommended: `ssh` into your remote shell.
+ssh'ing
+  Don't use. See also ssh and SSH.
+  Recommended: When you use `ssh` to log in ...
+startup (noun or adjective), start up (verb)
+static external IP address
+  Don't use _static IP address_ or _external IP address_ to refer to static external IP addresses.
+status bar
+  Not _statusbar_ or _status-bar_.
+  Lowercase except at the beginning of a sentence, heading, or list item.
+STONITH, STOMITH
+  Avoid using graphic or metaphorical language. Instead, explain the relevant feature, such as _fence failed nodes_.
+style sheet
+  _Style sheet_ and _stylesheet_ are both acceptable spellings. However, be consistent with your choice throughout a given document.
+sub-command
+  Not _subcommand_.
+subnet
+  OK to use as a shortening of _subnetwork_. Use the same term consistently throughout your document. For more information, see  Subnets vs. subnetworks.
+subtree
+  Not _sub-tree_.
+subzone
+  Not _sub-zone_ or _sub zone_.
+such as
+  Use _such as_ to introduce examples or draw comparisons. Note that _such as_ , _like_ , and _include_ introduce non-exhaustive lists, so it's redundant to combine them with _etc._ , _so forth_ , or _and more_. See also etc., like. For more information, see Format examples.
+surface
+  Avoid as a transitive verb; instead, use a more specific term, such as _make people aware of_ or _expose_.
+  Recommended: To make the audit logs available, you must configure the monitoring system.
+  Not recommended: To surface audit logs, you must configure the monitoring system.
+
+### T
+
+tab
+  When referring to the sub-pages of a console, use _page_ instead of _tab_.
+table name
+  Two words. Set specific table names in code font.
+tablet
+  _Tablet_ is OK. If you don't know whether it's a tablet or a phone, use _device_.
+tag
+  See element.
+tap
+  In Android documentation, use for on-screen and soft (capacitive) buttons.      Use instead of _click_ when the environment is definitely a touch device.
+  Use instead of _touch_. However, _touch & hold_ (not _touch and hold_) is OK to use.
+  For mechanical buttons, use _press_.
+tap & hold, tap and hold
+  In Android documentation, don't use. Instead, use _touch & hold_. (Not _touch and hold_.)
+tarball
+  Don't use. Instead, use _tar file_.
+target
+  Avoid using as a verb when possible, especially in reference to people. For some readers, _target_ has aggressive connotations. Instead of "targeting" audiences, we try to attract them or appeal to them or make their lives easier.
+  It's OK to use _target_ as an adjective, as in _target audience_ , but consider rephrasing for clarity. Alternatives include phrases such as _intended for_ , _looking for_ , _focused on_ , and _interacting with_.
+terminate
+  Avoid using as a synonym for _stop_. Instead, use words like _stop_ , _exit_ , _cancel_ , or _end_.
+  For a specific context where you can use _terminate_ as a synonym for _stop_ , see Documenting command-line syntax.           In some contexts, such as telephony and networking, _terminate_ has specific technical meanings that aren't synonyms for _stop_ ; in those contexts, you can use _terminate_.
+text box, textbox
+  Don't use. Instead, use _box_. For more information, see Text box.
+  In Google Cloud documentation, use _field_ instead of _box_. For example, "In the **Instance** field, specify a value less than 64 characters long."
+  In Google Workspace documentation, use _field_ instead of _box_. For example, "In the **Instance** field, specify a value less than 64 characters long."
+their (singular)
+  See _they_.
+then
+  Although it is common in casual usage to omit the word _then_ in _if...then_ statements, you should include helper words like _then_ in technical documentation. For more information, see Use clear, precise, and unambiguous language.
+they (singular)
+  This is our preferred gender-neutral pronoun. Whether used as singular or plural, it always takes the plural verb.
+  Recommended: A user enters their password, and then they insert their security key.
+  See also gender-neutral he.
+third party (noun), third-party (adjective)
+  Spell as _third party_ when used as a noun and as _third-party_ when used as an adjective.
+  Avoid abbreviating to _3rd party_ or _3rd-party_. For more information, see Ordinal numbers.
+this, that
+  Where possible, put a noun after _this_ or _that_ for clarity. If doing so results in clunky prose, then don't do it; but even then, try thinking about what the noun would be. If you aren't sure what noun _this_ or _that_ refers to, then consider rephrasing – otherwise, your reader probably won't know what noun you're referring to, either.
+timeframe
+  Not _time frame_. Avoid where possible, or use an alternative such as _period_ , _schedule_ , _deadline_ , or _when_. But if you do use it, then write it as one word.
+timeout (noun), time out (verb)
+timestamp
+  Not _time stamp_.
+time to live
+  Not _time-to-live_. Abbreviate as _TTL_ after first use.
+time zone (noun), time-zone (adjective)
+  Spell as _time zone_ when used as a noun and as _time-zone_ when used as an adjective. See also wake lock (noun), wake-lock (adjective).
+tl;dr
+  Don't use. Instead, use something like _To summarize_ , or revise the sentence.
+toolkit
+  Not _tool-kit_ or _tool kit_.
+touch
+  In Android documentation, don't use. Instead, use _tap_. However, _touch & hold_ is OK to use.
+"touch & hold"
+  Not _touch and hold_.
+touchscreen
+  Not _touch screen_
+traditional
+  If possible, use a more precise term.
+  Recommended: Conventionally, Python function names are lowercase, with words separated by underscores.
+  Not recommended: Traditionally, Python function names are lowercase, with words separated by underscores.
+  Recommended: This tutorial explains how to migrate from an on-premises data warehouse to BigQuery.
+  Not recommended: This tutorial explains how to migrate from a traditional data warehouse to BigQuery.
+transpile
+  Not _transcompile_.
+tribal knowledge, tribal wisdom
+  Don't use. Instead, use a less figurative term to indicate knowledge held by a group of people.
+trojan
+  Lowercase when referring to malware.
+turn on
+  In procedures, use the appropriate label and action for the UI element that the user interacts with.
+  For turning on or activating an option or feature, use _turn on_ or enable consistently. Use the same term consistently throughout your document.
+  Recommended: To turn on Magic Mode, follow these steps.
+  Recommended: In **Settings** , click the **Magic mode** toggle to the on position.
+tutorial
+  OK to use. See documentation.
+type
+  In general, use enter instead of _type_ because there is typically more than one way to enter text than typing (such as pasting text or speaking).
+typically
+  Use to describe what is usual or expected under normal circumstances.
+  Don't use as the first word in a sentence, as doing so can leave the meaning open to misinterpretation.
+
+### U
+
+UI
+  Don't use generically to refer to a page or dashboard. Use a more specific term like _page_ or _console_. If a specific term is unavailable, use _web interface_.
+  Recommended: In the Google Cloud console
+  Recommended: On the **Cloud Tasks** page
+  Recommended: In the Secure Source Manager web interface
+  Not recommended: In the **Cloud Tasks** UI
+unarchive
+  Don't use. Instead, use _extract_.
+uncheck
+  Don't use to refer to clearing a check mark from a checkbox. Instead, use _clear_.
+  Recommended: Clear **Automatically check for updates**.
+  Not recommended: Uncheck **Automatically check for updates**.
+  Not recommended: Deselect **Automatically check for updates**.
+uncompress
+  Don't use. Instead, use _extract_.
+under
+  Don't use for a range of version numbers. Instead, use _earlier_.
+  Don't use to refer to a position in the UI.
+  Recommended: In the **Service account ID** field, enter a name.
+  Recommended: For **Service account ID** , enter a name.
+  Not recommended: Under **Service account ID** , enter a name.
+Unicode
+  Not _UNICODE_.
+Unix-like
+  Not _Unixlike_ or _Unix like_.
+Unix epoch time
+  Use instead of _Unix time_ or _epoch time_ to refer to a point in time represented as a number of seconds since the Unix epoch (00:00:00 UTC on January 1, 1970), ignoring leap seconds.
+unselect
+  Don't use. Instead, use _clear_ for checkboxes, and _deselect_ for other UI elements.      unsighted
+  Don't use. See blind.
+untar
+  Don't use. Instead, use _extract_.
+unzip
+  Don't use. Instead, use _extract_.
+US
+  OK to use as an abbreviation for _United States_. Don't use _U.S._ or _U.S.A._ For more information, see Periods with abbreviations.
+user
+  Use the word _user_ only to refer to the user of the software that your reader is developing. Otherwise, address the reader as _you_ and assume that they will complete the tasks that you're documenting. For more information, see Second person and first person.
+user base
+  Not _userbase_.
+using
+  Where _using_ might have more than one interpretation, use _by using_ to help clarify the logic of the sentence.
+  Recommended: You can filter for data with specific attributes by using custom filters.
+  Not recommended: You can filter for data with specific attributes using custom filters.
+UTF
+  Include the hyphen in the names of Unicode encodings, such as _UTF-8_ , _UTF-16_ , and _UTF-32_.      utilize, utilization
+  Use with caution. Don't use _utilize_ when you mean _use_. It's OK to use _utilize_ or _utilization_ when referring to the quantity of a resource being used.
+  Recommended: When CPU utilization exceeds 75%, the autoscaler adds more CPU resources.
+  Recommended: To distribute network traffic, use a load balancer.
+  Not recommended: To distribute network traffic, utilize a load balancer.
+
+### V
+
+v (abbreviating _version_)
+  Use lowercase.
+via
+  Don't use.
+vice versa
+  Don't use. Write out the relationship explicitly. To emphasize the reciprocal or contrasting relationship, you can use a more precise term like _conversely_.
+  Not recommended: You can copy local files to the cloud and vice versa.
+  Recommended: You can upload local files to the cloud or download cloud files to your local environment.
+  Recommended: You can upload local files to the cloud. Conversely, you can download cloud files to your local environment.
+virtual machine (VM) instance
+  Use when first introducing virtual machines on a given page. For subsequent mentions, you can use _VM instance_ or _VM_.
+  For Google Cloud: on first mention of a Compute Engine VM, use _Compute Engine instance_ and then use _compute instance_ throughout the rest of the document. If you need to indicate other types of VMs, use _VM_ , _VM instance_ , or _bare metal instance_.
+  See also GKE node.
+visually challenged
+  See blind.
+VLAN attachment
+  Don't use the following: _interconnect attachment (VLAN)_ , _Interconnect attachment_ , _Cloud Interconnect attachment_ , or any variation thereof. See also interconnectAttachment.
+voila
+  Don't use.
+voodoo
+  Don't use. Instead, use a term like _mysterious_ , _complicated_ , or _nondeterministic_.
+vs.
+  Don't use _vs._ as an abbreviation for _versus_ ; instead, use the unabbreviated _versus_.
+
+### W
+
+wake lock (noun), wake-lock (adjective)
+  Spell as _wake lock_ when used as a noun and as _wake-lock_ when used as an adjective. See also time zone (noun), time-zone (adjective).
+walkthrough
+  Not _walk-through_.
+war room, warroom, war-room
+  Don't use. Instead, use a more precise term to describe the activity or team. Depending on context, possible alternatives include _rapid response team_ , _situation response team_ , _situation room_ , _incident-management team_ , or _media monitoring room_.
+warm
+  When possible, avoid jargon like _warm failover_ , _warm standby_ , and _warm spare_. If you use one of these phrases, define it on first use and use it consistently throughout the document.
+we
+  Don't use _we_ (or other first-person plural pronouns such as _our_ or _us_) to address the reader who is performing the tasks that you're documenting. Instead, use _you_.
+  It's OK to use _we_ to refer to the organization that's represented as the author of the document as long as the antecedent is clear. For more information, see Second person and first person.
+web (lowercase)
+WebAssembly, Wasm
+  Use the capitalization established in the WebAssembly specification.
+web application firewall (lowercase)
+webmaster, web master
+  Don't use. Instead, use a more precise term to describe the specific role, such as _website owner_ , _website administrator_ , _web content manager_ , _owner of a site_.
+web server
+  Not _webserver_.
+whether
+  * To decide whether it's more appropriate to use _if_ or _whether_ , see Grammar Girl's discussion of _if_ and _whether_.
+  * To decide whether you need to add _or not_ when using _whether_ , see the New York Times's blog post about whether (or not).
+
+while
+  Don't use to indicate a contrast. Instead, use a more precise term, such as _although_.
+  OK to use to refer to a period of time.
+white-box
+  Avoid using _white-box_ , _whitebox_ , or _white box_ to describe monitoring and testing. Consider using a more precise term for clarity.
+
+  * For monitoring, use _introspective monitoring_.
+  * For testing, use _clear-box testing_.
+
+white glove, white-glove, whiteglove
+  Avoid using. Instead use terms like _high-touch_ , _premium_ , or _platinum-level_.
+whitehat, white hat, white-hat
+  Don't use. Instead, use precise terms for the kind of compliance, such as _legal_ , _ethical_ , or _following the rules_.
+white label, whitelabel, white-label
+  Don't use. Instead, use a more precise term for your context, such as _unbranded_ , _unlabeled_ , or _blank label_.
+whitelist, white list, white-list
+  Don't use. See blacklist.
+whitelisted, white listed, white-listed
+  Don't use. See blacklist.
+whitelisting, white listing, white-listing
+  Don't use. See blacklist.
+whitepaper
+  Not _white paper_.
+  When possible, use a more precise term. The term _whitepaper_ has a variety of meanings in various contexts. If you must use the term _whitepaper_ , also use descriptive terms to provide context.
+whitespace
+  Not _white space_.
+wildcard
+  Not _wild card_.
+will
+  Avoid. Applies equally to its past tense, _would_. See also Present tense and Documenting future features.
+wish
+  Don't use. Instead, use a word like _want_ or _need_.
+with
+  Don't use _with_ when expressing ownership:      Recommended: A handset that has 2 GB of RAM.
+  Not recommended: A handset with 2 GB of RAM.
+  Don't use _with_ when expressing use:      Recommended: Use the debugging tool to debug.
+  Not recommended: Debug this tool with the debugging tool.
+workload
+  The term _workload_ might refer to software, like an app or a service; to app resources, like data and infrastructure; or to physical components that work together.
+  Where possible, use a more precise term to describe what you mean. If you use the term _workload_ , define your meaning on first use as you normally would with jargon and other ambiguous terms.
+World Wide Web
+  Don't use. Instead, use _web_.
+would
+  Avoid using. Instead, use _can_ where possible.
+  See also can, could, may, might, must, and should.
+  For information about clarifying who's performing an action, see Active voice.
+  For information about tenses, see Present tense.
+
+### Y
+
+ymmv
+  Don't use. Instead, use something like _Your results might vary_.
+you
+  Use _you_ instead of _user_ to address the reader of your document. For more information, see Second person and first person.
+
+### Z
+
+zippy
+  Don't use to refer to expander arrows, unless you're specifically referring to the Zippy widget in Closure.

--- a/.claude/skills/arcjet-writing-style/scripts/code_font.py
+++ b/.claude/skills/arcjet-writing-style/scripts/code_font.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Language-aware code font consistency checking.
+
+Two findings, both under the `code-font` category:
+
+1. **Inconsistent** – an identifier appears in code font somewhere in the document and
+   bare somewhere else. High confidence: the document has already decided the term is
+   code, so every other occurrence should match.
+2. **Unmarked** – an identifier-shaped token appears only in prose, never in code font.
+   Lower confidence, reported as `code-font?`.
+
+Language awareness matters because identifier conventions and reserved words differ.
+`class`, `type`, `range`, `set`, `map`, `input`, `filter`, `object`, `string`, and `from`
+are all keywords in some language and ordinary English in prose. Harvesting them as
+identifiers would bury the real findings, so each fenced block's language supplies a
+keyword stoplist, and unlabeled blocks are classified by heuristic.
+"""
+
+import re
+
+# --- Language identification -------------------------------------------------
+
+LANG_ALIASES = {
+    "js": "js", "javascript": "js", "jsx": "js", "node": "js", "mjs": "js", "cjs": "js",
+    "ts": "js", "typescript": "js", "tsx": "js",
+    "py": "python", "python": "python", "python3": "python",
+    "go": "go", "golang": "go",
+    "rs": "rust", "rust": "rust",
+    "java": "java", "kt": "java", "kotlin": "java",
+    "rb": "ruby", "ruby": "ruby",
+    "php": "php",
+    "sh": "shell", "bash": "shell", "zsh": "shell", "shell": "shell",
+    "console": "shell", "terminal": "shell", "shell-session": "shell",
+    "sql": "sql",
+    "json": "data", "yaml": "data", "yml": "data", "toml": "data", "hcl": "data",
+    "html": "markup", "xml": "markup", "css": "markup", "scss": "markup",
+    "c": "c", "cpp": "c", "c++": "c", "cs": "c", "csharp": "c",
+}
+
+KEYWORDS = {
+    "js": """abstract async await break case catch class const constructor continue debugger
+        default delete do else enum export extends false finally for from function get
+        if implements import in instanceof interface let new null of package private
+        protected public readonly return set static super switch this throw true try type
+        typeof var void while with yield any boolean number string object symbol unknown
+        never undefined require module exports console""",
+    "python": """and as assert async await break class continue def del elif else except
+        False finally for from global if import in is lambda None nonlocal not or pass
+        raise return True try while with yield self cls print len range list dict set
+        tuple str int float bool bytes type object input open filter map sum min max
+        format id next iter super property staticmethod classmethod""",
+    "go": """break case chan const continue default defer else fallthrough for func go goto
+        if import interface map package range return select struct switch type var nil
+        true false make new len cap append copy delete panic recover print string error
+        int int64 float64 bool byte rune""",
+    "rust": """as async await break const continue crate dyn else enum extern false fn for
+        if impl in let loop match mod move mut pub ref return self Self static struct
+        super trait true type unsafe use where while String Vec Option Some None Result
+        Ok Err Box str usize isize u8 u32 u64 i32 i64 f64 bool char""",
+    "java": """abstract assert boolean break byte case catch char class const continue
+        default do double else enum extends final finally float for goto if implements
+        import instanceof int interface long native new package private protected public
+        return short static strictfp super switch synchronized this throw throws
+        transient try void volatile while var record sealed String List Map Set
+        Integer Object System""",
+    "ruby": """alias and begin break case class def defined do else elsif end ensure false
+        for if in module next nil not or redo rescue retry return self super then true
+        undef unless until when while yield puts require attr_accessor""",
+    "php": """abstract and array as break callable case catch class clone const continue
+        declare default do echo else elseif empty enddeclare endfor endforeach endif
+        endswitch endwhile enum extends final finally fn for foreach function global
+        goto if implements include instanceof insteadof interface isset list match
+        namespace new or print private protected public readonly require return static
+        switch throw trait try unset use var while xor yield""",
+    "shell": """alias awk bash cat cd chmod chown cp curl cut date dirname do done echo
+        elif else esac eval exec exit export false fi find for function grep head if
+        in kill less local ls mkdir mv printf pwd read return rm sed set sh sleep sort
+        source sudo tail tar test then time touch tr true umask unset until wc while
+        xargs cmd run""",
+    "sql": """add all alter and any as asc between by case cast check column commit
+        constraint create cross database default delete desc distinct drop else end
+        exists foreign from full group having in index inner insert into is join key
+        left like limit not null offset on or order outer primary references right
+        rollback select set table then union unique update values view when where with""",
+    "data": """true false null nil yes no on off name type kind value key id items
+        version spec metadata apiVersion""",
+    "markup": """a b body br class code div em h1 h2 h3 h4 h5 h6 head href html i id img
+        input label li link meta name ol p pre script span src strong style table tbody
+        td th thead title tr type ul var""",
+    "c": """auto bool break case catch char class const continue default delete do double
+        else enum explicit extern false float for friend goto if inline int long
+        namespace new nullptr operator private protected public register return short
+        signed sizeof static struct switch template this throw true try typedef typename
+        union unsigned using virtual void volatile while string vector""",
+}
+KEYWORDS = {k: set(v.split()) for k, v in KEYWORDS.items()}
+
+# Signatures for classifying a fenced block with no language label.
+HEURISTICS = [
+    ("python", re.compile(r"^\s*(?:def |class \w+[:(]|from \w+ import |import \w+$)", re.M)),
+    ("js", re.compile(r"\b(?:const|let|var|=>|function|import .* from |require\()")),
+    ("go", re.compile(r"^\s*(?:func |package |type \w+ struct)", re.M)),
+    ("rust", re.compile(r"^\s*(?:fn |impl |let mut |use \w+::)", re.M)),
+    ("java", re.compile(r"\b(?:public|private)\s+(?:static\s+)?(?:class|void|final)\b")),
+    ("shell", re.compile(r"^\s*[$#>]\s|\b(?:sudo|npm|pip|curl|git|docker|kubectl)\b", re.M)),
+    ("data", re.compile(r'^\s*[\w"-]+\s*:\s|^\s*\{\s*$', re.M)),
+    ("sql", re.compile(r"\b(?:SELECT|INSERT INTO|CREATE TABLE|UPDATE)\b")),
+    ("markup", re.compile(r"</?\w+[\s/>]")),
+]
+
+# Never demand code font for these, however they are shaped.
+ALLOWLIST = {
+    "javascript", "typescript", "coffeescript", "actionscript", "postscript",
+    "github", "gitlab", "bitbucket", "sourceforge", "stackoverflow", "npmjs",
+    "postgresql", "mysql", "mongodb", "sqlite", "mariadb", "clickhouse", "dynamodb",
+    "graphql", "restful", "oauth", "openid", "jsonwebtoken", "webassembly", "websocket",
+    "kubernetes", "openshift", "cloudflare", "powershell", "wordpress", "salesforce",
+    "hubspot", "posthog", "sharepoint", "quickbooks", "mailchimp", "sendgrid",
+    "macos", "ios", "ipados", "watchos", "tvos", "chromeos", "freebsd", "openbsd",
+    "openai", "anthropic", "arcjet", "vercel", "netlify", "supabase", "planetscale",
+    "nodejs", "denojs", "nextjs", "nuxtjs", "sveltekit", "fastapi", "sqlalchemy",
+    "devops", "devsecops", "mlops", "finops", "gitops", "noops",
+    "youtube", "linkedin", "paypal", "ebay", "airbnb", "shopify", "wordpad",
+}
+
+# Extensions and TLDs that make a dotted token a filename or domain, not an identifier.
+NOT_IDENTIFIER_TAILS = {
+    "com", "org", "net", "io", "dev", "app", "ai", "co", "gov", "edu", "sh", "so",
+    "js", "ts", "jsx", "tsx", "py", "go", "rs", "rb", "php", "java", "kt", "c", "cpp",
+    "html", "css", "scss", "json", "yaml", "yml", "toml", "md", "txt", "csv", "xml",
+    "png", "jpg", "svg", "gif", "pdf", "zip", "tar", "gz", "log", "env", "lock", "sql",
+}
+
+FENCE = re.compile(r"^(\s*)(```+|~~~+)\s*([\w+#-]*)")
+INLINE = re.compile(r"(`+)([^`]+?)\1")
+HTML_CODE = re.compile(r"<(code|pre|kbd|var|samp)\b[^>]*>(.*?)</\1>", re.S | re.I)
+LINK_URL = re.compile(r"\]\([^)]*\)|https?://\S+")
+TOKEN = re.compile(r"[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*")
+
+
+def classify(label, body):
+    """Map a fence label to a canonical language, falling back to content heuristics."""
+    canonical = LANG_ALIASES.get(label.strip().lower().lstrip("."))
+    if canonical:
+        return canonical
+    for name, pattern in HEURISTICS:
+        if pattern.search(body):
+            return name
+    return None
+
+
+def is_identifier_shaped(token, seen_as_call=False):
+    """True if the token's shape marks it as code rather than an English word.
+
+    Requires a structural signal, so ordinary prose words never qualify no matter how
+    often they appear inside code blocks.
+    """
+    if token.lower() in ALLOWLIST or len(token) < 3:
+        return False
+    if "." in token:
+        head, _, tail = token.rpartition(".")
+        if tail.lower() in NOT_IDENTIFIER_TAILS or not head:
+            return False
+        return True
+    if "_" in token.strip("_"):
+        return True
+    if re.search(r"[a-z][A-Z]", token):                       # camelCase
+        return True
+    if re.match(r"^[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)+$", token):  # PascalCase, 2+ humps
+        return True
+    return bool(seen_as_call)
+
+
+def split_document(text):
+    """Return (code_segments, prose_lines).
+
+    code_segments is a list of (language, body). prose_lines is a list of
+    (line_number, text) with inline code, HTML code elements, and link URLs blanked out.
+    """
+    html_code_spans = []
+
+    def mask_html(m):
+        html_code_spans.append(m.group(2))
+        return " " * (m.end() - m.start())
+
+    text = HTML_CODE.sub(mask_html, text)
+    lines = text.split("\n")
+
+    code_segments = [(None, span) for span in html_code_spans]
+    prose_lines = []
+    fence_marker = None
+    fence_label = ""
+    buffer = []
+
+    for number, raw in enumerate(lines, start=1):
+        fence = FENCE.match(raw)
+        if fence and fence_marker is None:
+            fence_marker, fence_label, buffer = fence.group(2), fence.group(3), []
+            continue
+        if fence_marker is not None:
+            if (fence and fence.group(2)[0] == fence_marker[0]
+                    and len(fence.group(2)) >= len(fence_marker)
+                    and not fence.group(3)):
+                body = "\n".join(buffer)
+                code_segments.append((classify(fence_label, body), body))
+                fence_marker, fence_label, buffer = None, "", []
+            else:
+                buffer.append(raw)
+            continue
+        if re.match(r"^(?: {4,}|\t)\S", raw):        # indented code block
+            code_segments.append((None, raw))
+            continue
+
+        inline = []
+        stripped = INLINE.sub(
+            lambda m: (inline.append(m.group(2)), " " * (m.end() - m.start()))[1], raw)
+        for span in inline:
+            code_segments.append((None, span))
+        prose_lines.append((number, LINK_URL.sub(" ", stripped)))
+
+    if buffer:                                        # unterminated fence
+        code_segments.append((classify(fence_label, "\n".join(buffer)), "\n".join(buffer)))
+    return code_segments, prose_lines
+
+
+def harvest(code_segments):
+    """Collect identifiers that the document itself has already marked as code."""
+    vocabulary = {}
+    languages = set()
+    for language, body in code_segments:
+        if language:
+            languages.add(language)
+        stop = KEYWORDS.get(language, set())
+        for match in TOKEN.finditer(body):
+            token = match.group(0)
+            if token in stop or token.lower() in stop:
+                continue
+            called = body[match.end():match.end() + 1] == "("
+            if "." in token:
+                # Register the final segment too: prose usually writes protect(), not
+                # aj.protect(), so the qualified form alone would miss it.
+                tail = token.rpartition(".")[2]
+                if is_identifier_shaped(tail):
+                    vocabulary[tail] = False
+                elif called and tail not in vocabulary:
+                    vocabulary[tail] = True
+            if is_identifier_shaped(token):
+                vocabulary[token] = False        # shape alone marks it as code
+            elif called and token not in vocabulary:
+                # Qualifies only because the code calls it. A bare word like "tool" is
+                # ordinary English in prose, so only flag it when written as "tool()".
+                vocabulary[token] = True
+    return vocabulary, languages
+
+
+def check_code_font(text, include_unmarked=True):
+    """Return findings as (line, column, category, message, match) tuples."""
+    code_segments, prose_lines = split_document(text)
+    vocabulary, languages = harvest(code_segments)
+    all_stopwords = set().union(*KEYWORDS.values()) if KEYWORDS else set()
+
+    findings = []
+    for number, line in prose_lines:
+        for match in TOKEN.finditer(line):
+            token = match.group(0)
+            called = line[match.end():match.end() + 1] == "("
+            if token in vocabulary:
+                if vocabulary[token] and not called:
+                    continue
+                findings.append((
+                    number, match.start() + 1, "code-font",
+                    f"'{token}' is in code font elsewhere in this document. "
+                    "Use code font here too.", token))
+            elif include_unmarked and is_identifier_shaped(token, seen_as_call=called):
+                if token in all_stopwords or token.lower() in all_stopwords:
+                    continue
+                findings.append((
+                    number, match.start() + 1, "code-font?",
+                    f"'{token}' looks like a code identifier but never appears in code "
+                    "font. Add backticks, or ignore if it's a product name.", token))
+    return findings, languages

--- a/.claude/skills/arcjet-writing-style/scripts/style_check.py
+++ b/.claude/skills/arcjet-writing-style/scripts/style_check.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Flag mechanical Google-style violations in Markdown or HTML documentation.
+
+Usage:
+    python3 style_check.py FILE [FILE ...] [--json] [--only CATEGORY]
+
+This is a regex pass over prose. It catches a narrow, high-confidence class of
+errors and says nothing about voice, structure, or accuracy – read the text too.
+Code blocks and inline code are skipped, because most rules don't apply there.
+
+Exit code is 1 if anything is flagged, 0 otherwise.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from code_font import check_code_font  # noqa: E402
+
+# (category, pattern, message). Patterns run against prose with code masked out.
+RULES = [
+    # --- Tone ---
+    ("tone", r"\bplease\b",
+     "Drop 'please' from instructions."),
+    ("tone", r"\b(?:simply|easily|effortlessly|quickly)\b|it[’']?s (?:easy|that simple)",
+     "Don't call the task easy or fast – it isn't, for the reader who is stuck."),
+    ("tone", r"!(?!=)",
+     "Avoid exclamation points outside code and literal strings."),
+    ("tone", r"\b(?:let's|lets)\s+(?:start|begin|take|look|create|dive)\b",
+     "Avoid 'let's' – use second person or the imperative."),
+    ("tone", r"\b(?:tl;dr|ymmv|rtfm|imho|fyi)\b",
+     "No internet-slang abbreviations."),
+    ("tone", r"\bnote that\b",
+     "'Note that' is filler – state the fact, or use a Note notice."),
+
+    # --- Word choice ---
+    ("wording", r"\b(?:utilize|utilizes|utilizing|leverage|leverages|leveraging)\b",
+     "Use 'use'."),
+    ("wording", r"\b(?:commence|commences|endeavor|endeavour)\b",
+     "Use the simple word: 'start', 'try'."),
+    ("wording", r"\bin order to\b",
+     "'to' is enough."),
+    ("wording", r"\b(?:allows you to|enables you to|permits you to)\b",
+     "Use 'lets you'."),
+    ("wording", r"\b(?:e\.g\.|i\.e\.)",
+     "Write 'for example' or 'that is'."),
+    ("wording", r"\betc\.",
+     "Introduce the list so it's clearly not exhaustive instead of trailing 'etc.'"),
+    ("wording", r"\band/or\b",
+     "Spell out the options: 'A, B, or both'."),
+    ("wording", r"\bshould\b",
+     "'should' is ambiguous. Use 'must', 'can', 'might', or 'We recommend'."),
+    ("wording", r"\bhover(?:s|ing)? over\b",
+     "Use 'hold the pointer over'."),
+    ("wording", r"\brun the following command\b",
+     "Say what the command does instead."),
+    ("wording", r"\bfor more information on\b",
+     "Use 'for more information about'."),
+    ("wording", r"\bmake use of\b",
+     "Use 'use'."),
+
+    # --- Timeless documentation ---
+    ("timeless", r"\b(?:currently|presently|at present|as of this writing|for the time being)\b",
+     "Time-anchored: the documentation is assumed current."),
+    ("timeless", r"\b(?:soon|eventually|in the future|does not yet|doesn't yet)\b",
+     "Don't anchor to a timeline or pre-announce."),
+    ("timeless", r"\bthe latest\b",
+     "'latest' goes stale – name the version."),
+
+    # --- Excessive claims ---
+    ("claims", r"\b(?:the best|the fastest|the simplest|the easiest|world-class|blazing[- ]fast)\b",
+     "Superlative claim – state something verifiable instead."),
+    ("claims", r"\b(?:guarantees|guaranteed|ensures)\b",
+     "Only claim a guarantee where one truly exists."),
+
+    # --- Inclusive language ---
+    ("inclusive", r"\b(?:whitelist|blacklist|whitelisted|blacklisted)\b",
+     "Use 'allowlist' / 'denylist', or rewrite around it."),
+    ("inclusive", r"\b(?:sanity[- ]check|crazy|insane|dummy|cripples?|lame)\b",
+     "Ableist. Choose a precise, neutral word."),
+    ("inclusive", r"\bman-hours\b",
+     "Use 'person-hours'."),
+    ("inclusive", r"\b(?:mankind|manpower|manned)\b",
+     "Use a gender-neutral term."),
+    ("inclusive", r"\b(?:he/she|\(s\)he|s/he)\b",
+     "Use singular 'they'."),
+    ("inclusive", r"\b(?:master|slave)\b",
+     "Prefer 'primary'/'replica' or 'parent'/'worker' unless it's a code keyword in code font."),
+
+    # --- Accessibility ---
+    ("a11y", r"\b(?:diagram|table|figure|image|screenshot|section|example|command|list|steps?)\s+(?:above|below)\b",
+     "Directional language. Use 'preceding' or 'following'."),
+    ("a11y", r"\b(?:above|below)\s+(?:diagram|table|figure|image|screenshot|section|example)\b",
+     "Directional language. Use 'preceding' or 'following'."),
+    ("a11y", r"\b(?:left|right)[- ]hand side\b|\b(?:on the|in the) (?:left|right)\b",
+     "Directional language doesn't survive translation or screen readers."),
+    ("a11y", r"\[(?:click here|here|this document|this page|this link|read more|learn more|more)\]",
+     "Link text must make sense out of context."),
+    ("a11y", r"\bclick here\b",
+     "Link text must make sense out of context."),
+    ("a11y", r"!\[\s*\]\(",
+     "Image has empty alt text – confirm the image is purely decorative."),
+
+    # --- Punctuation and mechanics ---
+    ("mechanics", r"[\u2018\u2019\u201c\u201d]",
+     "Use straight quotation marks and apostrophes."),
+    ("mechanics", r"\u2014",
+     "Project rule: no em dashes. Use a spaced en dash (–)."),
+    ("mechanics", r"(?<!-)--(?!-)",
+     "Double hyphen used as a dash. Use a spaced en dash (–)."),
+    ("mechanics", r"\d\u2013\d",
+     "Ranges take a hyphen, not an en dash."),
+    ("mechanics", r"[^\s\d]\u2013|\u2013[^\s\d]",
+     "Put a space on each side of an en dash used as a sentence break."),
+    ("mechanics", r"\s+&\s+",
+     "Use 'and', not an ampersand."),
+    ("mechanics", r"\b\d{1,2}/\d{1,2}/\d{2,4}\b",
+     "Ambiguous numeric date. Write 'January 19, 2017' or ISO 8601."),
+    ("mechanics", r"\b\d+(?:st|nd|rd|th)\b",
+     "Spell out ordinals: 'first', 'fifth'."),
+    ("mechanics", r"\b\d+x\b(?!\d)",
+     "Write '10 times', not '10x'. (Dimensions like 192x192 are fine.)"),
+    ("mechanics", r"\b\w+\(s\)",
+     "No parenthetical plurals. Pick singular or plural, or use 'one or more'."),
+    ("mechanics", r"\b\d+(?:GB|MB|KB|TB|GiB|MiB|KiB|ms|kg|mm|Mbps)\b",
+     "Put a nonbreaking space between the number and the unit."),
+    ("mechanics", r"\b(?:GBs|MBs|KBs|TBs)\b",
+     "Don't pluralize a unit abbreviation."),
+    ("mechanics", r"\bclick the \"",
+     "Refer to a button by its bold label, not a quoted label plus 'button'."),
+
+    # --- Lower-confidence heuristics ---
+    ("maybe", r"\b(?:is|are|was|were|be|been|being)\s+\w+(?:ed|wn|en)\s+by\b",
+     "Possible passive voice – name the actor."),
+    ("maybe", r"\b\w+,\s+\w+\s+and\s+\w+\b",
+     "Possible missing serial comma."),
+]
+
+CODE_FENCE = re.compile(r"^(\s*)(```|~~~)")
+INLINE_CODE = re.compile(r"`[^`]*`")
+HTML_CODE = re.compile(r"<(code|pre|kbd|var)\b.*?</\1>", re.S | re.I)
+MD_LINK_URL = re.compile(r"\]\([^)]*\)")
+HEADING = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
+GERUND_OK = {"billing", "pricing", "licensing", "networking", "logging", "monitoring",
+             "formatting", "processing", "reporting", "onboarding", "troubleshooting"}
+
+
+def mask(text):
+    """Replace code spans with same-length filler so offsets stay accurate."""
+    def blank(m):
+        return " " * (m.end() - m.start())
+    text = HTML_CODE.sub(blank, text)
+    text = INLINE_CODE.sub(blank, text)
+    text = MD_LINK_URL.sub(blank, text)
+    return text
+
+
+def check_heading(line_no, hashes, text, findings):
+    if text.endswith("."):
+        findings.append((line_no, 1, "heading", "No period at the end of a heading.", text))
+    first = re.sub(r"[^\w-]", "", text.split()[0]).lower().split("-")[-1] if text.split() else ""
+    if first.endswith("ing") and first not in GERUND_OK:
+        findings.append((line_no, 1, "heading",
+                         "Task headings take a bare infinitive: 'Create an instance'.", text))
+    if re.match(r"^(?:step\s*)?\d+[.):]", text.strip(), re.I):
+        findings.append((line_no, 1, "heading",
+                         "Don't number headings – hierarchy conveys sequence.", text))
+    if re.search(r"\[[^\]]+\]\(", text):
+        findings.append((line_no, 1, "heading", "Don't put links in headings.", text))
+    words = [w for w in re.findall(r"[A-Za-z][\w'-]*", text)][1:]
+    capped = [w for w in words if w[:1].isupper() and not w.isupper()]
+    if len(words) >= 3 and len(capped) >= max(2, len(words) - 1):
+        findings.append((line_no, 1, "heading",
+                         "Looks like title case. Use sentence case.", text))
+
+
+def check_file(path, only=None, code_font=True, unmarked=True):
+    findings = []
+    languages = set()
+    try:
+        text = open(path, encoding="utf-8").read()
+    except OSError as err:
+        print(f"{path}: {err}", file=sys.stderr)
+        return findings, languages
+    lines = text.split("\n")
+
+    if code_font:
+        found, languages = check_code_font(text, include_unmarked=unmarked)
+        findings.extend(found)
+
+    in_fence = False
+    fence_marker = None
+    for i, raw in enumerate(lines, start=1):
+        fence = CODE_FENCE.match(raw)
+        if fence:
+            marker = fence.group(2)
+            if not in_fence:
+                in_fence, fence_marker = True, marker
+            elif marker == fence_marker:
+                in_fence, fence_marker = False, None
+            continue
+        if in_fence or re.match(r"^(?: {4,}|\t)\S", raw):
+            continue
+
+        heading = HEADING.match(raw)
+        if heading:
+            check_heading(i, heading.group(1), heading.group(2), findings)
+
+        line = mask(raw)
+        for category, pattern, message in RULES:
+            if only and category != only:
+                continue
+            for m in re.finditer(pattern, line, re.I):
+                findings.append((i, m.start() + 1, category, message, m.group(0).strip()))
+
+    if only:
+        findings = [f for f in findings if f[2].rstrip("?") == only.rstrip("?")]
+    return sorted(findings), languages
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("files", nargs="+")
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    parser.add_argument("--only", help="restrict to one category")
+    parser.add_argument("--no-code-font", action="store_true",
+                        help="skip the code font consistency pass")
+    parser.add_argument("--strict-code-font", action="store_true",
+                        help="also report identifiers that never appear in code font")
+    args = parser.parse_args()
+
+    checked = {p: check_file(p, args.only, code_font=not args.no_code_font,
+                             unmarked=args.strict_code_font) for p in args.files}
+    results = {p: v[0] for p, v in checked.items()}
+    langs = {p: v[1] for p, v in checked.items()}
+    total = sum(len(v) for v in results.values())
+
+    if args.json:
+        print(json.dumps(
+            {p: [{"line": l, "col": c, "category": cat, "message": msg, "match": mt}
+                 for l, c, cat, msg, mt in v] for p, v in results.items()},
+            indent=2))
+        return 1 if total else 0
+
+    for path, found in results.items():
+        detected = ", ".join(sorted(langs[path])) or "none detected"
+        if not found:
+            print(f"{path}: clean (code languages: {detected})")
+            continue
+        print(f"\n{path}: {len(found)} finding{'s' if len(found) != 1 else ''} "
+              f"(code languages: {detected})")
+        for line, col, category, message, match in found:
+            print(f"  {line}:{col} [{category}] {message}")
+            print(f"      -> {match!r}")
+
+    if total:
+        print(f"\n{total} total. 'maybe' and 'code-font?' findings are heuristics \u2013 "
+              "verify before changing.")
+    return 1 if total else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ pnpm-debug.log*
 # Visual Studio Code specific files
 .vscode
 .idea
+
+# Python bytecode cache
+__pycache__/
+*.pyc

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -44,6 +44,10 @@ lint:
       paths:
         # Ignore playwright snapshots
         - "**/*-snapshots/**"
+        # Vendored skill. Kept byte-identical to its upstream copy so that the
+        # skills-lock.json hash stays meaningful and re-syncs diff cleanly;
+        # formatting it here would rewrite every line on the next sync.
+        - ".claude/skills/**"
 actions:
   enabled:
     - trunk-announce

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "arcjet-writing-style": {
+      "source": "arcjet/skills-internal",
+      "sourceType": "github",
+      "skillPath": "skills/arcjet-writing-style/SKILL.md",
+      "computedHash": "af504b58af0e7378bda430022cd87c698f2892ae486273959724ec676c022e05"
+    }
+  }
+}


### PR DESCRIPTION
Vendors the `arcjet-writing-style` skill into the repo so docs work here picks it up automatically, instead of depending on whatever each contributor happens to have installed locally. The style audit in #868 was done against this guide, so keeping it next to the docs it governs makes the rules that audit applied reviewable in the same place.

## What's here

- `.claude/skills/arcjet-writing-style/SKILL.md` – the rules that carry most of the weight, plus the review checklist
- `references/` – six files: A-Z word list (600+ term decisions), language and grammar, punctuation, formatting, code and UI, global and inclusive
- `scripts/style_check.py` – regex pass for mechanical violations: `please`, `simply`, click-here links, curly quotes, directional language, title-case headings, em dashes, exclamation points. Also runs a code font consistency pass that harvests identifiers from a document's own code blocks and reports any that appear bare in prose
- `skills-lock.json` – upstream source and content hash, so the vendored copy can be diffed against upstream later

## Two things worth a reviewer's attention

**The vendored files are committed byte-identical to upstream, and Trunk has to leave them that way.** Prettier reflows every paragraph and rewrites `_em_` to `*em*`; on the first commit attempt that produced a 1,531-line reformat, which would turn every future upstream sync into a whole-file conflict. Hence the `.claude/skills/**` entry in the ALL-linters ignore list in `.trunk/trunk.yaml`. If you'd rather have the files formatted to house style, that's fine, but then `skills-lock.json` should go – the hash stops meaning anything.

**Provenance is an internal repo.** `skills-lock.json` records the source as `arcjet/skills-internal`, which is an INTERNAL repo, and this one is PUBLIC. I read all nine files before committing: the content is editorial guidance adapted from the [Google developer documentation style guide](https://developers.google.com/style) and carries its CC BY 4.0 attribution, with no secrets, internal URLs, or unreleased product detail. So publishing it looks fine to me – but the call to move content across that boundary is yours, not mine, and the internal repo name does become public in the lockfile.

## Also

- `.gitignore` now covers `__pycache__/` and `*.pyc`, which the checker scripts generate on first run

## Test plan

- [x] `python3 .claude/skills/arcjet-writing-style/scripts/style_check.py` runs clean on a real page
- [x] Committed bytes verified identical to upstream (sha256 match on `SKILL.md`, and `scripts/*.py` diff empty)
- [x] Re-commit with the Trunk ignore in place leaves the vendored files untouched
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)