### PR TITLE
docs: OpenAI Agents Guard adapter page

### DIFF
--- a/src/content/docs/guards/framework-integrations.mdx
+++ b/src/content/docs/guards/framework-integrations.mdx
@@ -128,9 +128,10 @@ for inbound screening, authored tools, and ToolNode denials.
 OpenAI Agents text `Agent` workflows (`run()` + authored `tool()`) have no
 `guardInbound`. Screen user text with a direct `guard()` call before
 `run()`. `needsApproval` and hosted `requireApproval` are human HITL, not
-policy. There is no `guardApproval` and no `guardToolNode`. Use
-`guardTool()` for authored `tool({ execute })` handlers. Hosted tools,
-handoffs, and Runner `agent_tool_start` are not deny points.
+policy. There is no `guardApproval`, no `guardToolNode`, and no
+`guardHooks`. Use `guardTool()` to wrap `FunctionTool.invoke` after
+`tool({ execute })`. Hosted tools, handoffs, and Runner `agent_tool_start`
+are not deny points.
 
 This is not Realtime, Sandbox, hosted tools, MCP, `agent.asTool()`, or
 computer/shell.
@@ -190,8 +191,11 @@ The wrappers default to fail closed when Guard is unavailable:
 - LangGraph helpers default to `onGuardError: "deny"`. On the inbound `guard()`
   before `invoke`, `"allow"` is a legitimate choice because failing closed
   stops the graph running.
-- OpenAI Agents `guardTool` returns a plain `ArcjetDenialResult` and does
-  not throw. Screen inbound with a direct `guard()` before `run()`.
+- OpenAI Agents helpers default to `onGuardError: "deny"`. `guardTool`
+  returns a plain `ArcjetDenialResult` and does not throw. The runner
+  stringifies it onto a `function_call_result` with `status: "completed"`.
+  On the inbound `guard()` before `run()`, `"allow"` is a legitimate
+  choice because failing closed stops the agent running.
 
 Set `onGuardError: "allow"` in JavaScript or `on_guard_error="allow"` in Python
 only when executing without a complete security decision is acceptable.

--- a/src/content/docs/guards/framework-integrations.mdx
+++ b/src/content/docs/guards/framework-integrations.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent guard framework integrations"
-description: "Guard Vercel AI SDK, LangChain, LangGraph, Vercel Eve, Mastra, and Claude Agent SDK tools, processors, and inbound messages."
+description: "Guard Vercel AI SDK, LangChain, LangGraph, OpenAI Agents, Vercel Eve, Mastra, and Claude Agent SDK tools, processors, and inbound messages."
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -123,6 +123,21 @@ not LangChain `createAgent` / `wrapToolCall`.
 See the <Link.Page href="/guards/langgraph">LangGraph agent guard</Link.Page>
 for inbound screening, authored tools, and ToolNode denials.
 
+## OpenAI Agents
+
+OpenAI Agents text `Agent` workflows (`run()` + authored `tool()`) have no
+`guardInbound`. Screen user text with a direct `guard()` call before
+`run()`. `needsApproval` and hosted `requireApproval` are human HITL, not
+policy. There is no `guardApproval` and no `guardToolNode`. Use
+`guardTool()` for authored `tool({ execute })` handlers. Hosted tools,
+handoffs, and Runner `agent_tool_start` are not deny points.
+
+This is not Realtime, Sandbox, hosted tools, MCP, `agent.asTool()`, or
+computer/shell.
+
+See the <Link.Page href="/guards/openai-agents">OpenAI Agents agent guard</Link.Page>
+for inbound screening, authored tools, and execute denials.
+
 ## Vercel Eve
 
 Eve agents can have zero authored tools. OpenAPI and MCP connections have no
@@ -175,6 +190,8 @@ The wrappers default to fail closed when Guard is unavailable:
 - LangGraph helpers default to `onGuardError: "deny"`. On the inbound `guard()`
   before `invoke`, `"allow"` is a legitimate choice because failing closed
   stops the graph running.
+- OpenAI Agents `guardTool` returns a plain `ArcjetDenialResult` and does
+  not throw. Screen inbound with a direct `guard()` before `run()`.
 
 Set `onGuardError: "allow"` in JavaScript or `on_guard_error="allow"` in Python
 only when executing without a complete security decision is acceptable.

--- a/src/content/docs/guards/openai-agents.mdx
+++ b/src/content/docs/guards/openai-agents.mdx
@@ -54,7 +54,13 @@ The integration exposes two surfaces:
   (`{ arcjetDenied, reason, message, retryable, retryAfterSeconds? }`).
   It does not throw. The runner stringifies that object onto a
   `function_call_result` with `status: "completed"`. The denial rides in
-  the payload (`arcjetDenied: true`), not the envelope.
+  the payload (`arcjetDenied: true`), not the envelope. Because the
+  runner treats that return as the tool's output, `timeoutMs` races the
+  guard round trip as well as `execute`, and `outputGuardrails` /
+  `customDataExtractor` receive the denial object. Keep `timeoutMs` wide
+  enough for a guard call. `guardTool` warns if `invoke` is handed
+  neither a string nor an object: the runner passes a JSON string, so
+  another shape means no arguments were scanned.
 - `openaiAgentsContext()` reads a field you put on
   `runContext.context`: `correlationId`, then `sessionId`, then
   `conversationId`, then `groupId`. Then it reads envelope copies
@@ -99,13 +105,11 @@ prompt-injection (and other inbound rules) in the application before
 `callModelInputFilter` are OpenAI SDK surfaces. They are not Arcjet.
 
 Direct `client.guard({ label, rules, ...openaiAgentsContext(...) })` is the
-inbound pattern.
+inbound pattern. Act on that decision. Direct `guard()` fails open, so an
+`ALLOW` is not proof the rules ran. Gate on `decision.hasFailedOpen()` if
+this call site must fail closed. `guardTool` already defaults to that.
 
 On `DENY`, do not call `run()`.
-
-Helpers default to `onGuardError: "deny"`. `"allow"` is a legitimate choice
-on the inbound `guard()` before `run()`, because failing closed there stops
-the agent running during an outage.
 
 ```ts
 import { detectPromptInjection } from "@arcjet/guard";
@@ -122,7 +126,7 @@ const decision = await arcjet.guard({
   ...openaiAgentsContext({ context: appContext, conversationId }),
 });
 
-if (decision.conclusion === "DENY") {
+if (decision.conclusion === "DENY" || decision.hasFailedOpen()) {
   throw new Error("message blocked");
 }
 
@@ -146,7 +150,9 @@ It does not throw. The runner stringifies that object onto a
 `function_call_result` with `status: "completed"`. Do not throw from
 `execute` to signal a denial: the SDK `errorFunction` would turn a throw
 into a model-visible string (or `ToolCallError` when `outputSchema` is
-set). Scan free-text args (a note, reason, or body). An opaque
+set). `timeoutMs` races the guard round trip, and
+`outputGuardrails` / `customDataExtractor` receive the denial object.
+Scan free-text args (a note, reason, or body). An opaque
 `orderNumber` or tool-call id will not trip email / phone / card / IP, so
 do not pass it to `localDetectSensitiveInfo`. That helper runs on a local
 ML model backend.

--- a/src/content/docs/guards/openai-agents.mdx
+++ b/src/content/docs/guards/openai-agents.mdx
@@ -1,0 +1,226 @@
+---
+title: "OpenAI Agents agent guard"
+description: "Screen user text before the agent run, wrap authored function-tool execute, and treat approval pauses as HITL, not policy."
+---
+
+import { Link } from "@/components/link";
+
+{/* TODO: Sync examples to Runtime's final DENY / context shape once the adapter SHA lands. */}
+
+[OpenAI Agents](https://openai.github.io/openai-agents-js/) text `Agent`
+workflows call authored `tool()` handlers from `run()`. Arcjet Guard sits at
+those boundaries so a remote policy can allow or deny the action before a
+side effect runs.
+
+Use <Link.Page href="/get-started">`protect()`</Link.Page> for HTTP routes. Use the OpenAI Agents helpers on this page for
+authored tools and inbound screening. Vercel AI SDK, Python LangChain, Eve,
+Mastra, LangGraph, and Claude wrappers are on
+<Link.Page href="/guards/framework-integrations">Framework integrations</Link.Page>.
+
+This adapter is a text `Agent` plus `run()` plus authored `tool()`. It is not
+Realtime, Sandbox, hosted tools, MCP, `agent.asTool()`, or computer/shell.
+
+## Install
+
+Install the Guard SDK and the OpenAI Agents SDK:
+
+```bash
+npm install @arcjet/guard @openai/agents
+```
+
+Import helpers from `@arcjet/guard/openai-agents/v0`. That export is
+unpublished. It is not an npm package you can install by that path. There is
+no unversioned alias. `@openai/agents` (`>=0.17.0 <1`) is a peer. The SDK is
+pre-1.0, so the segment is `v0`. The integration requires Node.js 22 or later.
+
+Launch one client at module scope:
+
+```ts
+import { launchArcjet } from "@arcjet/guard";
+
+export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
+```
+
+## Helpers
+
+The integration exposes two surfaces:
+
+- `guardTool()` wraps an authored `tool({ execute })`. On `DENY` the tool's
+  `execute` never runs a side effect. It returns a plain
+  `ArcjetDenialResult` (`arcjetDenied: true`, plus reason / message /
+  retryable). It does not throw. If `execute` throws and the tool has no
+  `outputSchema`, the SDK's default `errorFunction` turns the throw into a
+  model-visible string. Return the denial object instead.
+- `openaiAgentsContext()` reads an app field on `runContext.context`. It
+  never mints an id. It never calls `createAgentContext`. `RunContext` has
+  no conversation or session id. Copy `session.getSessionId()`, the
+  `conversationId` you already pass to `run()`, or both onto that app
+  context. Do not write `runContext.conversationId`.
+
+There is no `guardInbound`. There is no inbound hook. Screen user text with a
+direct `guard()` call before `run()`. There is no `guardApproval` and no
+`guardToolNode`.
+
+OpenAI's `inputGuardrails`, `outputGuardrails`, and
+`defineToolInputGuardrail` / `defineToolOutputGuardrail` are the SDK's own
+tripwires (`tripwireTriggered`, `rejectContent`). They are not Arcjet.
+
+Never call `createAgentContext` inside an OpenAI Agents callback. Do not also
+wrap these tools with `@arcjet/guard/vercel-ai/v7`.
+
+## Screen user text before `run()` — there is no inbound hook. `inputGuardrails` / `callModelInputFilter` are not Guard.
+
+There is no first-class inbound hook, so there is no `guardInbound`. Put
+prompt-injection (and other inbound rules) in the application before
+`run(agent, input)`.
+
+`inputGuardrails` on the `Agent` or on `tool()`, `outputGuardrails`,
+`defineToolInputGuardrail` / `defineToolOutputGuardrail`, and
+`callModelInputFilter` are OpenAI SDK surfaces. They are not Arcjet.
+
+Direct `client.guard({ label, rules, ...openaiAgentsContext(...) })` is the
+inbound pattern.
+
+On `DENY`, do not call `run()`.
+
+```ts
+import { detectPromptInjection } from "@arcjet/guard";
+import { openaiAgentsContext } from "@arcjet/guard/openai-agents/v0";
+import { run } from "@openai/agents";
+import { arcjet } from "./arcjet.js";
+
+const inbound = detectPromptInjection();
+const sessionId = await session.getSessionId();
+const appContext = { sessionId };
+
+const decision = await arcjet.guard({
+  label: "message.received",
+  rules: [inbound(userText)],
+  ...openaiAgentsContext(appContext),
+});
+
+if (decision.conclusion === "DENY") {
+  throw new Error("message blocked");
+}
+
+await run(agent, userText, { session, context: appContext });
+```
+
+## `needsApproval` is HITL, not a policy gate (same trap as hosted `requireApproval`).
+
+`needsApproval` pauses the run and returns `interruptions` for
+human-in-the-loop (`state.approve` / `state.reject`). Hosted MCP
+`requireApproval` is the same class of control. Neither is a remote policy.
+Same trap as Mastra `requireApproval`, Claude `canUseTool`, and LangGraph
+`interrupt()`. There is no `guardApproval`. Do not wrap them as Guard.
+
+Use `guardTool` for authored `tool({ execute })` handlers you own.
+
+On `DENY` the tool's `execute` never runs a side effect. `guardTool` returns
+a plain `ArcjetDenialResult`
+(`{ arcjetDenied: true, reason, message, retryable }`). It does not throw.
+Do not throw from `execute` to signal a denial. Scan free-text args (a note,
+reason, or body). An opaque `orderNumber` or tool-call id will not trip
+email / phone / card / IP, so do not pass it to
+`localDetectSensitiveInfo`. That helper runs on a local ML model backend.
+
+```ts
+import { tool } from "@openai/agents";
+import { z } from "zod";
+import { guardTool } from "@arcjet/guard/openai-agents/v0";
+import { tokenBucket, localDetectSensitiveInfo } from "@arcjet/guard";
+import { arcjet } from "./arcjet.js";
+
+const lookupLimit = tokenBucket({
+  bucket: "lookups",
+  refillRate: 10,
+  intervalSeconds: 60,
+  maxTokens: 10,
+});
+// Factory then text. Same shape as `detectPromptInjection()(text)`.
+const detectPii = localDetectSensitiveInfo();
+
+export const lookupOrder = guardTool(
+  arcjet,
+  tool({
+    name: "lookup_order",
+    description: "Look up an order by number",
+    parameters: z.object({
+      orderNumber: z.string(),
+      note: z.string(),
+    }),
+    execute: async ({ orderNumber, note }) => ({
+      orderNumber,
+      note,
+      status: "shipped",
+    }),
+  }),
+  {
+    action: "order.looked-up",
+    rules: (input) => [
+      lookupLimit({ key: input.orderNumber, requested: 1 }),
+      detectPii(input.note),
+    ],
+  },
+);
+```
+
+## Deny inside `tool({ execute })` — the only local side-effect you can stop. Hosted tools, handoffs, and Runner `agent_tool_start` are not deny points.
+
+`guardTool` wraps authored `tool({ execute })` only. That `execute` is the
+only local side effect this adapter can stop.
+
+Hosted tools (`webSearchTool`, `fileSearchTool`, `codeInterpreterTool`, and
+the other hosted helpers), `handoff`, `agent.asTool()`, MCP servers
+(`mcpServers`), and computer/shell tools do not go through that local
+`execute` path. Runner `agent_tool_start` is not a deny point. There is no
+`guardToolNode` and no hook wrapper for those paths.
+
+Pass wrapped tools on the `Agent` `tools` array, then call `run()`.
+
+## Correlation
+
+`RunContext` has no conversation or session id. Copy the identity the SDK
+already has onto your app context, then pass that object as
+`run(..., { context })`.
+
+Use `await session.getSessionId()` when you have a `session`. Use the same
+`conversationId` string you pass to `run()` when you use the Conversations
+API. `openaiAgentsContext` reads that app field on `runContext.context`. It
+never mints an id. It never calls `createAgentContext`. If the app field is
+not a valid 1-256 printable-ASCII string, the call is uncorrelated rather
+than joined to a generated id.
+
+```ts
+const sessionId = await session.getSessionId();
+const appContext = { sessionId };
+
+await run(agent, userText, { session, context: appContext });
+```
+
+## What not to use
+
+- There is no `guardInbound`. Screen prompt injection before `run()`.
+- There is no `guardApproval`. `needsApproval` and hosted `requireApproval`
+  are human HITL, not policy.
+- There is no `guardToolNode`.
+- Do not treat `inputGuardrails`, `outputGuardrails`,
+  `defineToolInputGuardrail` / `defineToolOutputGuardrail`, or
+  `callModelInputFilter` as Arcjet.
+- Do not deny from Runner `agent_tool_start`.
+- Do not use this adapter with Realtime, Sandbox, hosted tools, MCP,
+  `agent.asTool()`, or computer/shell.
+- Do not call `createAgentContext` inside an OpenAI Agents callback.
+- Do not also wrap these tools with `@arcjet/guard/vercel-ai/v7`.
+- Do not import `@arcjet/guard/openai-agents`. The path is
+  `@arcjet/guard/openai-agents/v0`.
+
+## Related
+
+- <Link.Page href="/guards/framework-integrations">Framework integrations</Link.Page>
+- <Link.Page href="/guards/langgraph">LangGraph agent guard</Link.Page>
+- <Link.Page href="/guards/langchain">LangChain agent guard</Link.Page>
+- <Link.Page href="/guards/vercel-eve">Vercel Eve agent guard</Link.Page>
+- <Link.Page href="/guards/mastra">Mastra agent guard</Link.Page>
+- <Link.Page href="/guards/claude-agent-sdk">Claude Agent SDK agent guard</Link.Page>
+- <Link.Page href="/guards">Agent guards</Link.Page>

--- a/src/content/docs/guards/openai-agents.mdx
+++ b/src/content/docs/guards/openai-agents.mdx
@@ -1,11 +1,9 @@
 ---
 title: "OpenAI Agents agent guard"
-description: "Screen user text before the agent run, wrap authored function-tool execute, and treat approval pauses as HITL, not policy."
+description: "Screen user text before the agent run, wrap authored function-tool invoke, and treat approval pauses as HITL, not policy."
 ---
 
 import { Link } from "@/components/link";
-
-{/* TODO: Sync examples to Runtime's final DENY / context shape once the adapter SHA lands. */}
 
 [OpenAI Agents](https://openai.github.io/openai-agents-js/) text `Agent`
 workflows call authored `tool()` handlers from `run()`. Arcjet Guard sits at
@@ -45,21 +43,27 @@ export const arcjet = launchArcjet({ key: process.env.ARCJET_KEY! });
 
 The integration exposes two surfaces:
 
-- `guardTool()` wraps an authored `tool({ execute })`. On `DENY` the tool's
-  `execute` never runs a side effect. It returns a plain
-  `ArcjetDenialResult` (`arcjetDenied: true`, plus reason / message /
-  retryable). It does not throw. If `execute` throws and the tool has no
-  `outputSchema`, the SDK's default `errorFunction` turns the throw into a
-  model-visible string. Return the denial object instead.
-- `openaiAgentsContext()` reads an app field on `runContext.context`. It
-  never mints an id. It never calls `createAgentContext`. `RunContext` has
-  no conversation or session id. Copy `session.getSessionId()`, the
-  `conversationId` you already pass to `run()`, or both onto that app
-  context. Do not write `runContext.conversationId`.
+- `guardTool()` wraps a `FunctionTool` from `tool({ execute })`. After
+  `tool()` the authored `execute` is closed over. The runner calls
+  `invoke`, so this helper wraps `invoke`. On `DENY` the original `invoke`
+  never runs, so `execute` never runs a side effect. It returns a plain
+  `ArcjetDenialResult`
+  (`{ arcjetDenied, reason, message, retryable, retryAfterSeconds? }`).
+  It does not throw. The runner stringifies that object onto a
+  `function_call_result` with `status: "completed"`. The denial rides in
+  the payload (`arcjetDenied: true`), not the envelope.
+- `openaiAgentsContext()` reads a field you put on
+  `runContext.context`: `correlationId`, then `sessionId`, then
+  `conversationId`, then `groupId`. Then it reads envelope copies
+  (`conversationId`, `groupId`, already-resolved `sessionId`). It also
+  accepts a bare app object (`{ sessionId }`) or
+  `{ context: appContext, conversationId }`. It never mints an id. It
+  never reads `traceId`. It never calls `session.getSessionId()`. It
+  never calls `createAgentContext`.
 
 There is no `guardInbound`. There is no inbound hook. Screen user text with a
-direct `guard()` call before `run()`. There is no `guardApproval` and no
-`guardToolNode`.
+direct `guard()` call before `run()`. There is no `guardApproval`, no
+`guardToolNode`, and no `guardHooks`.
 
 OpenAI's `inputGuardrails`, `outputGuardrails`, and
 `defineToolInputGuardrail` / `defineToolOutputGuardrail` are the SDK's own
@@ -67,6 +71,19 @@ tripwires (`tripwireTriggered`, `rejectContent`). They are not Arcjet.
 
 Never call `createAgentContext` inside an OpenAI Agents callback. Do not also
 wrap these tools with `@arcjet/guard/vercel-ai/v7`.
+
+The OpenAI Agents integration skill ships with `@arcjet/guard`. After
+`npm install`, copy or symlink it into your coding agent's skills directory:
+
+```bash
+mkdir -p ~/.claude/skills
+cp -r node_modules/@arcjet/guard/skills/integrate-arcjet-guard-openai-agents ~/.claude/skills/
+```
+
+Then ask the agent to add Arcjet Guard to this OpenAI Agents project. In
+Claude Code, run `/integrate-arcjet-guard-openai-agents`. Until
+`@arcjet/guard/openai-agents/v0` is published, the skill source is
+[integrate-arcjet-guard-openai-agents](https://github.com/arcjet/arcjet-js/blob/891bc92eb9b028b1ae54370987dafe7140940ee1/arcjet-guard/skills/integrate-arcjet-guard-openai-agents/SKILL.md).
 
 ## Screen user text before `run()` — there is no inbound hook. `inputGuardrails` / `callModelInputFilter` are not Guard.
 
@@ -83,6 +100,10 @@ inbound pattern.
 
 On `DENY`, do not call `run()`.
 
+Helpers default to `onGuardError: "deny"`. `"allow"` is a legitimate choice
+on the inbound `guard()` before `run()`, because failing closed there stops
+the agent running during an outage.
+
 ```ts
 import { detectPromptInjection } from "@arcjet/guard";
 import { openaiAgentsContext } from "@arcjet/guard/openai-agents/v0";
@@ -90,20 +111,19 @@ import { run } from "@openai/agents";
 import { arcjet } from "./arcjet.js";
 
 const inbound = detectPromptInjection();
-const sessionId = await session.getSessionId();
-const appContext = { sessionId };
+const appContext = { sessionId: conversationId };
 
 const decision = await arcjet.guard({
   label: "message.received",
   rules: [inbound(userText)],
-  ...openaiAgentsContext(appContext),
+  ...openaiAgentsContext({ context: appContext, conversationId }),
 });
 
 if (decision.conclusion === "DENY") {
   throw new Error("message blocked");
 }
 
-await run(agent, userText, { session, context: appContext });
+await run(agent, userText, { context: appContext });
 ```
 
 ## `needsApproval` is HITL, not a policy gate (same trap as hosted `requireApproval`).
@@ -116,13 +136,17 @@ Same trap as Mastra `requireApproval`, Claude `canUseTool`, and LangGraph
 
 Use `guardTool` for authored `tool({ execute })` handlers you own.
 
-On `DENY` the tool's `execute` never runs a side effect. `guardTool` returns
-a plain `ArcjetDenialResult`
-(`{ arcjetDenied: true, reason, message, retryable }`). It does not throw.
-Do not throw from `execute` to signal a denial. Scan free-text args (a note,
-reason, or body). An opaque `orderNumber` or tool-call id will not trip
-email / phone / card / IP, so do not pass it to
-`localDetectSensitiveInfo`. That helper runs on a local ML model backend.
+On `DENY` the original `invoke` never runs, so `execute` never runs a side
+effect. `guardTool` returns a plain `ArcjetDenialResult`
+(`{ arcjetDenied: true, reason, message, retryable, retryAfterSeconds? }`).
+It does not throw. The runner stringifies that object onto a
+`function_call_result` with `status: "completed"`. Do not throw from
+`execute` to signal a denial: the SDK `errorFunction` would turn a throw
+into a model-visible string (or `ToolCallError` when `outputSchema` is
+set). Scan free-text args (a note, reason, or body). An opaque
+`orderNumber` or tool-call id will not trip email / phone / card / IP, so
+do not pass it to `localDetectSensitiveInfo`. That helper runs on a local
+ML model backend.
 
 ```ts
 import { tool } from "@openai/agents";
@@ -167,35 +191,38 @@ export const lookupOrder = guardTool(
 
 ## Deny inside `tool({ execute })` — the only local side-effect you can stop. Hosted tools, handoffs, and Runner `agent_tool_start` are not deny points.
 
-`guardTool` wraps authored `tool({ execute })` only. That `execute` is the
-only local side effect this adapter can stop.
+`guardTool` wraps `FunctionTool.invoke` after `tool({ execute })`. That
+closed-over `execute` is the only local side effect this adapter can stop.
 
 Hosted tools (`webSearchTool`, `fileSearchTool`, `codeInterpreterTool`, and
 the other hosted helpers), `handoff`, `agent.asTool()`, MCP servers
-(`mcpServers`), and computer/shell tools do not go through that local
-`execute` path. Runner `agent_tool_start` is not a deny point. There is no
-`guardToolNode` and no hook wrapper for those paths.
+(`mcpServers`), and computer/shell tools do not go through that authored
+`invoke` path. Runner `agent_tool_start` and `agent_tool_end` are
+observe-only. They are not a deny point. There is no `guardToolNode` and
+no `guardHooks` for those paths.
 
 Pass wrapped tools on the `Agent` `tools` array, then call `run()`.
 
 ## Correlation
 
-`RunContext` has no conversation or session id. Copy the identity the SDK
-already has onto your app context, then pass that object as
-`run(..., { context })`.
+`RunContext` has no conversation or session id. Put the id you already have
+on the app object you pass as `run(..., { context })`. Do not write
+`runContext.conversationId`. Do not pass a `Session` and expect
+`getSessionId()` to run: `openaiAgentsContext` never calls it, and
+`MemorySession` mints a UUID when constructed without `sessionId`.
 
-Use `await session.getSessionId()` when you have a `session`. Use the same
-`conversationId` string you pass to `run()` when you use the Conversations
-API. `openaiAgentsContext` reads that app field on `runContext.context`. It
-never mints an id. It never calls `createAgentContext`. If the app field is
-not a valid 1-256 printable-ASCII string, the call is uncorrelated rather
-than joined to a generated id.
+Preference order is `context.correlationId`, then `context.sessionId`,
+then `context.conversationId`, then `context.groupId`. Then envelope
+copies: `conversationId`, `groupId`, already-resolved `sessionId`. A bare
+app object (`{ sessionId }`) and `{ context: appContext, conversationId }`
+are both valid sources. `traceId` is never read. If nothing is a valid
+1-256 printable-ASCII string, the call is uncorrelated rather than joined
+to a generated id.
 
 ```ts
-const sessionId = await session.getSessionId();
-const appContext = { sessionId };
+const appContext = { sessionId: conversationId };
 
-await run(agent, userText, { session, context: appContext });
+await run(agent, userText, { context: appContext });
 ```
 
 ## What not to use
@@ -203,11 +230,14 @@ await run(agent, userText, { session, context: appContext });
 - There is no `guardInbound`. Screen prompt injection before `run()`.
 - There is no `guardApproval`. `needsApproval` and hosted `requireApproval`
   are human HITL, not policy.
-- There is no `guardToolNode`.
+- There is no `guardToolNode` and no `guardHooks`.
 - Do not treat `inputGuardrails`, `outputGuardrails`,
   `defineToolInputGuardrail` / `defineToolOutputGuardrail`, or
   `callModelInputFilter` as Arcjet.
 - Do not deny from Runner `agent_tool_start`.
+- Do not call `session.getSessionId()` from this helper. Put the id you
+  already have on `context`.
+- Do not read `traceId` for correlation. The SDK mints one when omitted.
 - Do not use this adapter with Realtime, Sandbox, hosted tools, MCP,
   `agent.asTool()`, or computer/shell.
 - Do not call `createAgentContext` inside an OpenAI Agents callback.
@@ -224,3 +254,4 @@ await run(agent, userText, { session, context: appContext });
 - <Link.Page href="/guards/mastra">Mastra agent guard</Link.Page>
 - <Link.Page href="/guards/claude-agent-sdk">Claude Agent SDK agent guard</Link.Page>
 - <Link.Page href="/guards">Agent guards</Link.Page>
+- Adapter: [arcjet/arcjet-js@891bc92](https://github.com/arcjet/arcjet-js/commit/891bc92eb9b028b1ae54370987dafe7140940ee1)

--- a/src/content/docs/guards/openai-agents.mdx
+++ b/src/content/docs/guards/openai-agents.mdx
@@ -26,10 +26,13 @@ Install the Guard SDK and the OpenAI Agents SDK:
 npm install @arcjet/guard @openai/agents
 ```
 
-Import helpers from `@arcjet/guard/openai-agents/v0`. That export is
-unpublished. It is not an npm package you can install by that path. There is
-no unversioned alias. `@openai/agents` (`>=0.17.0 <1`) is a peer. The SDK is
-pre-1.0, so the segment is `v0`. The integration requires Node.js 22 or later.
+Import helpers from the versioned path `@arcjet/guard/openai-agents/v0`.
+There is no unversioned alias. `@arcjet/guard/openai-agents` does not
+resolve. The SDK is pre-1.0, so the segment is `v0`. `@openai/agents`
+(`>=0.17.0 <1`) is an optional peer. The integration requires Node.js 22
+or later. Until `@arcjet/guard/openai-agents/v0` is published, the import
+is on [arcjet-js main](https://github.com/arcjet/arcjet-js/pull/6233), not
+on npm.
 
 Launch one client at module scope:
 
@@ -83,7 +86,7 @@ cp -r node_modules/@arcjet/guard/skills/integrate-arcjet-guard-openai-agents ~/.
 Then ask the agent to add Arcjet Guard to this OpenAI Agents project. In
 Claude Code, run `/integrate-arcjet-guard-openai-agents`. Until
 `@arcjet/guard/openai-agents/v0` is published, the skill source is
-[integrate-arcjet-guard-openai-agents](https://github.com/arcjet/arcjet-js/blob/891bc92eb9b028b1ae54370987dafe7140940ee1/arcjet-guard/skills/integrate-arcjet-guard-openai-agents/SKILL.md).
+[integrate-arcjet-guard-openai-agents](https://github.com/arcjet/arcjet-js/pull/6233).
 
 ## Screen user text before `run()` — there is no inbound hook. `inputGuardrails` / `callModelInputFilter` are not Guard.
 
@@ -254,4 +257,4 @@ await run(agent, userText, { context: appContext });
 - <Link.Page href="/guards/mastra">Mastra agent guard</Link.Page>
 - <Link.Page href="/guards/claude-agent-sdk">Claude Agent SDK agent guard</Link.Page>
 - <Link.Page href="/guards">Agent guards</Link.Page>
-- Adapter: [arcjet/arcjet-js@891bc92](https://github.com/arcjet/arcjet-js/commit/891bc92eb9b028b1ae54370987dafe7140940ee1)
+- Adapter: [arcjet/arcjet-js#6233](https://github.com/arcjet/arcjet-js/pull/6233)

--- a/src/lib/sidebars.ts
+++ b/src/lib/sidebars.ts
@@ -657,6 +657,10 @@ export const main = [
         link: "/ai-protection/abuse-protection?f=next-js",
       },
       {
+        label: "OpenAI Agents",
+        link: "/guards/openai-agents",
+      },
+      {
         label: "Vercel",
         link: "https://vercel.com/integrations/arcjet",
         attrs: { target: "_blank", class: "external-link" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Drafts `/guards/openai-agents/` for the unpublished-until-release `@arcjet/guard/openai-agents/v0` adapter now on [arcjet-js#6233](https://github.com/arcjet/arcjet-js/pull/6233) (merge `0099fb76`).

The page documents the two shipped helpers (`guardTool`, `openaiAgentsContext`) and the three locked H2s:

- Screen user text before `run()` — there is no inbound hook. SDK `inputGuardrails` / `callModelInputFilter` are not Guard.
- `needsApproval` is HITL, not a policy gate (same trap as hosted `requireApproval`).
- Deny inside `tool({ execute })` — hosted tools, handoffs, and Runner `agent_tool_start` are not deny points.

Pinned to the merge on main:

- `guardTool` wraps `FunctionTool.invoke`. DENY is `ArcjetDenialResult` on a `function_call_result` with `status: "completed"`.
- `timeoutMs` races the guard round trip; `outputGuardrails` / `customDataExtractor` receive the denial object.
- Direct inbound `guard()` fails open — `ALLOW` is not proof the rules ran. The inbound example gates on `hasFailedOpen()`.
- `guardTool` warns if `invoke` is handed neither a string nor an object.
- `openaiAgentsContext` reads app/envelope fields only. It never mints, never reads `traceId`, and never calls `session.getSessionId()`.

Install wording matches LangGraph before publish: the import is on arcjet-js main, not npm until a Guard release. Sidebar entry is under Integrations only. Framework-integrations gets a LangGraph-shaped pointer. No remote-policy teaching (`actor` / `inputs` / `policyInput`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10402d7f-72d2-4083-b63f-f8a187d3ce3e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10402d7f-72d2-4083-b63f-f8a187d3ce3e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

