### PR TITLE
docs(python): document 2000 ms Protect `timeout_ms` default

### DIFF
--- a/src/content/docs/environment.mdx
+++ b/src/content/docs/environment.mdx
@@ -51,10 +51,13 @@ Python SDK users: if your config library doesn't propagate `.env` into
 `environment=` kwarg on `arcjet()` / `arcjet_sync()` – see the
 <Link.Page href="/reference/python#pydantic-settings-users">Python SDK reference</Link.Page>.
 
-In development, the timeout for connecting to Cloud API is increased. In
-production, the timeout is quicker. This is because in production your app
+In the JavaScript SDKs, the timeout for connecting to Cloud API is increased in
+development and quicker in production. This is because in production your app
 typically runs close to an Arcjet server, but in development your app may run on
-your local machine, far away from Arcjet servers. For more information, see <Link.Page href="/architecture#api-latency">Architecture: API latency</Link.Page>.
+your local machine, far away from Arcjet servers. The Python SDK uses a 2000 ms
+timeout for `arcjet()` / `arcjet_sync()` in both environments. For more
+information, see <Link.Page href="/architecture#api-latency">Architecture: API latency</Link.Page>
+and the <Link.Page href="/reference/python#configuration">Python SDK reference</Link.Page>.
 
 In production, an error is logged when no client IP is found. In development,
 the local IP `127.0.0.1` is used as a fallback. When the client IP is missing

--- a/src/content/docs/reference/python.mdx
+++ b/src/content/docs/reference/python.mdx
@@ -145,6 +145,9 @@ The following fields are optional:
 - `disable_automatic_ip_detection` (`bool`) – Disable automatic client IP
   detection so the application can provide `ip_src` to every `protect()` call.
   Defaults to `False`. This option cannot be combined with `proxies`.
+- `timeout_ms` (`int`) – Request timeout in milliseconds. Defaults to
+  2000 ms for every rule, in both development and production. An explicit
+  `timeout_ms` overrides the default.
 
 <Tabs>
   <TabItem label="FastAPI (async)">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Python `arcjet()` / `arcjet_sync()` now default to a 2000 ms Decide timeout for every `protect()` rule, matching Guard. The old 500 ms production / 1000 ms development split and the prompt-injection-only floor are gone. An explicit `timeout_ms` still wins.

This updates the docs to match [arcjet-py#204](https://github.com/arcjet/arcjet-py/pull/204), the `arcjet()` / `arcjet_sync()` docstrings on main (`timeout_ms: Request timeout in milliseconds. Defaults to 2000 ms.`), and the live [Python SDK reference](https://docs.arcjet.com/reference/python/).

## Changes

- Add `timeout_ms` to the Python Protect configuration optional fields: default 2000 ms for every rule, same in development and production, explicit value overrides.
- Note on the environment variables page that the Python Protect timeout does not follow the JavaScript 1000 ms / 500 ms split.

Guard (`launch_arcjet` / `launch_arcjet_sync`) was already documented as 2000 ms and is unchanged. JavaScript SDK pages that still correctly say 1000 ms development / 500 ms production are unchanged.

## Test plan

- [ ] Confirm the Protect configuration list on `/reference/python` documents `timeout_ms` as 2000 ms in both environments
- [ ] Confirm `/environment` still describes the JS timeout split and adds the Python caveat
- [ ] Confirm JS SDK reference pages still say 1000 ms development / 500 ms production

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c69b16e8-67e5-49f6-9df4-af95e1900a34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c69b16e8-67e5-49f6-9df4-af95e1900a34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

