### PR TITLE
docs(python): mark Alpine/musl as unsupported

### DIFF
--- a/src/content/docs/reference/python.mdx
+++ b/src/content/docs/reference/python.mdx
@@ -17,6 +17,7 @@ import ProtectSync from "/src/snippets/reference/python/ProtectSync.py?raw";
 import IPLocation from "/src/snippets/reference/python/IPLocation.py?raw";
 import ErrorLogging from "/src/snippets/reference/python/ErrorLogging.py?raw";
 import Guard from "/src/snippets/reference/python/Guard.py?raw";
+import Requirements from "@/snippets/shared/python/Requirements.mdx";
 
 [![PyPI](https://img.shields.io/pypi/v/arcjet?style=flat-square&label=%E2%9C%A6Aj&labelColor=ECE6F0&color=ECE6F0)](https://pypi.org/project/arcjet/)
 
@@ -45,14 +46,13 @@ pip install arcjet
 </TabItem>
 </Tabs>
 
+Prefer a glibc Linux container image such as `python:3.10-slim` or
+`astral/uv:python3.10-trixie-slim`. Alpine/musl isn't a supported install
+target.
+
 ### Requirements
 
-- Python 3.10 or later.
-- `libgcc`, needed by the bundled WebAssembly runtime (used for local bot
-  detection, sensitive information detection, and prompt injection
-  detection). Most Linux distributions include this by default, but Alpine
-  Linux does not; run `apk add libgcc` first, otherwise `import arcjet`
-  raises `OSError: Error loading shared library libgcc_s.so.1`.
+<Requirements />
 
 ## Quick start
 
@@ -871,7 +871,8 @@ Use `arcjet.guard.testing.register_test_client()` in tests. See
 
 ## Version support
 
-Arcjet supports Python 3.10 and later.
+Arcjet supports CPython 3.10 and later on macOS, Windows, and glibc Linux.
+Alpine/musl isn't supported.
 
 <Link.Page href="/support">Technical support</Link.Page> is provided for the
 current major version of the Arcjet SDK for all users and for the current and

--- a/src/snippets/get-started/python-fastapi/Requirements.mdx
+++ b/src/snippets/get-started/python-fastapi/Requirements.mdx
@@ -1,4 +1,3 @@
-- Python 3.10 or later
-- `libgcc` – needed by the bundled WebAssembly runtime. Most Linux
-  distributions include this by default, but Alpine Linux does not; run
-  `apk add libgcc` first
+import Requirements from "@/snippets/shared/python/Requirements.mdx";
+
+<Requirements />

--- a/src/snippets/get-started/python-flask/Requirements.mdx
+++ b/src/snippets/get-started/python-flask/Requirements.mdx
@@ -1,4 +1,3 @@
-- Python 3.10 or later
-- `libgcc` – needed by the bundled WebAssembly runtime. Most Linux
-  distributions include this by default, but Alpine Linux does not; run
-  `apk add libgcc` first
+import Requirements from "@/snippets/shared/python/Requirements.mdx";
+
+<Requirements />

--- a/src/snippets/shared/python/Requirements.mdx
+++ b/src/snippets/shared/python/Requirements.mdx
@@ -1,0 +1,15 @@
+- CPython 3.10 or later on macOS, Windows, and glibc Linux (Debian, Ubuntu,
+  RHEL, and `*-slim` / manylinux container images)
+- Alpine Linux and other musl-based systems aren't supported. Prefer a glibc
+  container image such as `python:3.10-slim` or
+  `astral/uv:python3.10-trixie-slim`
+
+Two runtime dependencies ship native code:
+
+- [`wasmtime`](https://pypi.org/project/wasmtime/): local WASM rule evaluation
+- [`pyqwest`](https://pypi.org/project/pyqwest/): HTTP client used by
+  `connect-python`
+
+Those packages publish `musllinux` wheels, so `pip install arcjet` can succeed
+on Alpine without a compiler. Alpine/musl isn't a supported target. A missing
+wheel forces a source build that needs Rust and a C toolchain.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Python SDK README on [arcjet-py#207](https://github.com/arcjet/arcjet-py/pull/207) now documents Alpine/musl as unsupported. Live docs still treated Alpine as supported if you `apk add libgcc`.

This PR makes the docs match that README.

## Changes

- Supported platforms: CPython 3.10+ on macOS, Windows, and glibc Linux (Debian, Ubuntu, RHEL, and `*-slim` / manylinux container images).
- Alpine/musl is not a supported install target. Prefer `python:3.10-slim` or `astral/uv:python3.10-trixie-slim`.
- Native deps (`wasmtime`, `pyqwest`) can publish `musllinux` wheels, so install can succeed on Alpine. That is not support. A missing wheel forces a source build.
- Removed the `apk add libgcc` Alpine workaround. `libgcc` is not documented for glibc distros (they already ship it).
- Shared Requirements snippet used by the Python SDK reference and the FastAPI/Flask get-started pages so the copy cannot drift.

## Scope

Edits stay in the Python Requirements / install / Version support area so they stay additive next to other open docs PRs that touch `python.mdx` (for example #880). No JS page rewrites. No remote-policy teaching.

Source of truth: [arcjet-py README Compatibility](https://github.com/arcjet/arcjet-py/blob/main/README.md) and the install note after `pip install`.

## Verification

- `astro check`: 0 errors
- Production build with the Playwright dummy key: success; internal links valid
- Rendered `/reference/python/`, `/reference/python.md`, and get-started FastAPI/Flask slots: Alpine/musl unsupported, slim images recommended, no `apk add libgcc`
- Get-started Playwright screenshots: unchanged (default framework is not Python)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5ed9cf0-902f-4322-b386-8b333ee09b6c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5ed9cf0-902f-4322-b386-8b333ee09b6c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

