### PR TITLE
docs: default JS Decide API timeout to 2000 ms

### DIFF
--- a/snippets/nuxt/server/utils/ClientOverride.js
+++ b/snippets/nuxt/server/utils/ClientOverride.js
@@ -13,11 +13,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 export const arcjet = arcjetNuxt({

--- a/snippets/nuxt/server/utils/ClientOverride.ts
+++ b/snippets/nuxt/server/utils/ClientOverride.ts
@@ -14,11 +14,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 export const arcjet = arcjetNuxt({

--- a/src/content/docs/architecture.mdx
+++ b/src/content/docs/architecture.mdx
@@ -304,21 +304,7 @@ often significantly less.
 There is a timeout in place to prevent waiting for a response indefinitely in
 case of problems.
 This value is configurable in the SDK.
-The default is 500&nbsp;ms in production and 1000&nbsp;ms in development.
-
-The reason for this difference is that in production your app usually runs on a
-server close to the Cloud API.
-In development your app may run on a laptop some distance away from the Cloud
-API.
-That introduces additional latency.
-
-To illustrate,
-a developer in New Zealand may have to connect to the Arcjet Cloud API running
-in the closest cloud region, which might be Australia.
-In contrast,
-a user would connect to your application and then the application would connect
-to the closest Arcjet Cloud API,
-usually within the same region.
+The default is 2000&nbsp;ms in both development and production.
 
 A shorter timeout may result in faster failure responses but could lead to
 increased error rates if the Cloud API needs time to respond.

--- a/src/content/docs/bot-protection/reference.mdx
+++ b/src/content/docs/bot-protection/reference.mdx
@@ -374,10 +374,8 @@ available on the `decision.allowed` and `decision.denied` properties.
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms
-in development (see <Link.Page
-href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>) and 500&nbsp;ms
-otherwise. However, in most cases, the response time is less than 20&nbsp;ms to
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
 30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an

--- a/src/content/docs/email-validation/reference.mdx
+++ b/src/content/docs/email-validation/reference.mdx
@@ -371,10 +371,8 @@ else:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms
-in development (see <Link.Page
-href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>) and 500&nbsp;ms
-otherwise. However, in most cases, the response time is less than 20&nbsp;ms to
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
 30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an

--- a/src/content/docs/environment.mdx
+++ b/src/content/docs/environment.mdx
@@ -51,10 +51,9 @@ Python SDK users: if your config library doesn't propagate `.env` into
 `environment=` kwarg on `arcjet()` / `arcjet_sync()` – see the
 <Link.Page href="/reference/python#pydantic-settings-users">Python SDK reference</Link.Page>.
 
-In development, the timeout for connecting to Cloud API is increased. In
-production, the timeout is quicker. This is because in production your app
-typically runs close to an Arcjet server, but in development your app may run on
-your local machine, far away from Arcjet servers. For more information, see <Link.Page href="/architecture#api-latency">Architecture: API latency</Link.Page>.
+The timeout for connecting to Cloud API defaults to 2000&nbsp;ms in both
+development and production. This applies to the JavaScript and Python SDKs.
+For more information, see <Link.Page href="/architecture#timeout">Architecture: Timeout</Link.Page>.
 
 In production, an error is logged when no client IP is found. In development,
 the local IP `127.0.0.1` is used as a fallback. When the client IP is missing

--- a/src/content/docs/filters/reference.mdx
+++ b/src/content/docs/filters/reference.mdx
@@ -478,10 +478,8 @@ for result in decision.results:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms
-in development (see <Link.Page
-href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>) and 500&nbsp;ms
-otherwise. However, in most cases, the response time is less than 20&nbsp;ms to
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
 30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an

--- a/src/content/docs/rate-limiting/reference.mdx
+++ b/src/content/docs/rate-limiting/reference.mdx
@@ -565,10 +565,8 @@ response headers similar to the following:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms
-in development (see <Link.Page
-href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>) and 500&nbsp;ms
-otherwise. However, in most cases, the response time is less than 20&nbsp;ms to
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
 30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an

--- a/src/content/docs/reference/astro.mdx
+++ b/src/content/docs/reference/astro.mdx
@@ -596,10 +596,8 @@ returns only the fields it has data for:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms
-in development (see <Link.Page
-href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>) and 500&nbsp;ms
-otherwise. However, in most cases, the response time is less than 20&nbsp;ms to
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
 30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an

--- a/src/content/docs/reference/bun.mdx
+++ b/src/content/docs/reference/bun.mdx
@@ -512,10 +512,8 @@ For more information about these properties, see the <Link.ToSdk href="/email-va
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms
-in development (see <Link.Page
-href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>) and 500&nbsp;ms
-otherwise. However, in most cases, the response time is less than 20&nbsp;ms to
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
 30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an

--- a/src/content/docs/reference/nestjs.mdx
+++ b/src/content/docs/reference/nestjs.mdx
@@ -404,10 +404,8 @@ returns only the fields it has data for:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms
-in development (see <Link.Page
-href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>) and 500&nbsp;ms
-otherwise. However, in most cases, the response time is less than 20&nbsp;ms to
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
 30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an

--- a/src/content/docs/reference/nextjs.mdx
+++ b/src/content/docs/reference/nextjs.mdx
@@ -645,10 +645,8 @@ returns only the fields it has data for:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms
-in development (see <Link.Page
-href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>) and 500&nbsp;ms
-otherwise. However, in most cases, the response time is less than 20&nbsp;ms to
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
 30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an

--- a/src/content/docs/reference/nodejs.mdx
+++ b/src/content/docs/reference/nodejs.mdx
@@ -467,10 +467,8 @@ returns only the fields it has data for:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms
-in development (see <Link.Page
-href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>) and 500&nbsp;ms
-otherwise. However, in most cases, the response time is less than 20&nbsp;ms to
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
 30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an

--- a/src/content/docs/reference/nuxt.mdx
+++ b/src/content/docs/reference/nuxt.mdx
@@ -666,10 +666,8 @@ returns only the fields it has data for:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms
-in development (see <Link.Page
-href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>) and 500&nbsp;ms
-otherwise. However, in most cases, the response time is less than 20&nbsp;ms to
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
 30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an

--- a/src/content/docs/reference/remix.mdx
+++ b/src/content/docs/reference/remix.mdx
@@ -470,10 +470,8 @@ returns only the fields it has data for:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms
-in development (see <Link.Page
-href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>) and 500&nbsp;ms
-otherwise. However, in most cases, the response time is less than 20&nbsp;ms to
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
 30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an

--- a/src/content/docs/reference/sveltekit.mdx
+++ b/src/content/docs/reference/sveltekit.mdx
@@ -527,10 +527,8 @@ For more information about these properties, see the <Link.ToSdk href="/email-va
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms
-in development (see <Link.Page
-href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>) and 500&nbsp;ms
-otherwise. However, in most cases, the response time is less than 20&nbsp;ms to
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
 30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an

--- a/src/content/docs/sensitive-info/reference.mdx
+++ b/src/content/docs/sensitive-info/reference.mdx
@@ -658,11 +658,9 @@ than tokens.
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms in
-development (see
-<Link.Page href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>)
-and 500&nbsp;ms otherwise. However, in most cases, the response time is less than
-20&nbsp;ms to 30&nbsp;ms.
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
+30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an
 `ERROR` result for that rule and you can check the `message` property on the

--- a/src/content/docs/shield/reference.mdx
+++ b/src/content/docs/shield/reference.mdx
@@ -194,10 +194,8 @@ This example logs the full result as well as the shield rule:
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms
-in development (see <Link.Page
-href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>) and 500&nbsp;ms
-otherwise. However, in most cases, the response time is less than 20&nbsp;ms to
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
 30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an

--- a/src/content/docs/signup-protection/reference.mdx
+++ b/src/content/docs/signup-protection/reference.mdx
@@ -275,10 +275,8 @@ users who sign up with a free email address.
 ## Error handling
 
 Arcjet is designed to fail open so that a service issue or misconfiguration does
-not block all requests. The SDK also times out and fails open after 1000&nbsp;ms
-in development (see <Link.Page
-href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>) and 500&nbsp;ms
-otherwise. However, in most cases, the response time is less than 20&nbsp;ms to
+not block all requests. The SDK also times out and fails open after 2000&nbsp;ms
+by default. However, in most cases, the response time is less than 20&nbsp;ms to
 30&nbsp;ms.
 
 If there is an error condition when processing the rule, Arcjet returns an

--- a/src/snippets/reference/astro/ClientOverride.mjs
+++ b/src/snippets/reference/astro/ClientOverride.mjs
@@ -12,11 +12,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 export default defineConfig({

--- a/src/snippets/reference/bun/ClientOverride.js
+++ b/src/snippets/reference/bun/ClientOverride.js
@@ -9,11 +9,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(Bun.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 import { env } from "bun";
 

--- a/src/snippets/reference/bun/ClientOverride.ts
+++ b/src/snippets/reference/bun/ClientOverride.ts
@@ -9,11 +9,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(Bun.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 import { env } from "bun";
 

--- a/src/snippets/reference/nextjs/ClientOverride.js
+++ b/src/snippets/reference/nextjs/ClientOverride.js
@@ -9,11 +9,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({

--- a/src/snippets/reference/nextjs/ClientOverride.ts
+++ b/src/snippets/reference/nextjs/ClientOverride.ts
@@ -9,11 +9,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({

--- a/src/snippets/reference/nodejs/ClientOverride.js
+++ b/src/snippets/reference/nodejs/ClientOverride.js
@@ -9,11 +9,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({

--- a/src/snippets/reference/nodejs/ClientOverride.ts
+++ b/src/snippets/reference/nodejs/ClientOverride.ts
@@ -9,11 +9,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({

--- a/src/snippets/reference/remix/ClientOverride.js
+++ b/src/snippets/reference/remix/ClientOverride.js
@@ -9,11 +9,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({

--- a/src/snippets/reference/remix/ClientOverride.ts
+++ b/src/snippets/reference/remix/ClientOverride.ts
@@ -9,11 +9,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({

--- a/src/snippets/reference/sveltekit/ClientOverride.js
+++ b/src/snippets/reference/sveltekit/ClientOverride.js
@@ -10,11 +10,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({

--- a/src/snippets/reference/sveltekit/ClientOverride.ts
+++ b/src/snippets/reference/sveltekit/ClientOverride.ts
@@ -10,11 +10,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({

--- a/tests/llms-txt.test.ts-snapshots/reference-astro-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-astro-chromium-linux.md
@@ -1026,7 +1026,7 @@ Error handling
 
 [Section titled “Error handling”](#error-handling)
 
-Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 1000 ms in development (see [`ARCJET_ENV`](/environment#arcjet-env)) and 500 ms otherwise. However, in most cases, the response time is less than 20 ms to 30 ms.
+Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 2000 ms by default. However, in most cases, the response time is less than 20 ms to 30 ms.
 
 If there is an error condition when processing the rule, Arcjet returns an `ERROR` result for that rule and you can check the `message` property on the rule’s error result for more information.
 
@@ -1343,11 +1343,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 export default defineConfig({

--- a/tests/llms-txt.test.ts-snapshots/reference-bun-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-bun-chromium-linux.md
@@ -895,7 +895,7 @@ Error handling
 
 [Section titled “Error handling”](#error-handling)
 
-Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 1000 ms in development (see [`ARCJET_ENV`](/environment#arcjet-env)) and 500 ms otherwise. However, in most cases, the response time is less than 20 ms to 30 ms.
+Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 2000 ms by default. However, in most cases, the response time is less than 20 ms to 30 ms.
 
 If there is an error condition when processing the rule, Arcjet returns an `ERROR` result for that rule and you can check the `message` property on the rule’s error result for more information.
 
@@ -1194,11 +1194,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(Bun.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 import { env } from "bun";
 
@@ -1244,11 +1242,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(Bun.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 import { env } from "bun";
 

--- a/tests/llms-txt.test.ts-snapshots/reference-nestjs-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-nestjs-chromium-linux.md
@@ -622,7 +622,7 @@ Error handling
 
 [Section titled “Error handling”](#error-handling)
 
-Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 1000 ms in development (see [`ARCJET_ENV`](/environment#arcjet-env)) and 500 ms otherwise. However, in most cases, the response time is less than 20 ms to 30 ms.
+Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 2000 ms by default. However, in most cases, the response time is less than 20 ms to 30 ms.
 
 If there is an error condition when processing the rule, Arcjet returns an `ERROR` result for that rule and you can check the `message` property on the rule’s error result for more information.
 

--- a/tests/llms-txt.test.ts-snapshots/reference-nextjs-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-nextjs-chromium-linux.md
@@ -1400,7 +1400,7 @@ Error handling
 
 [Section titled “Error handling”](#error-handling)
 
-Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 1000 ms in development (see [`ARCJET_ENV`](/environment#arcjet-env)) and 500 ms otherwise. However, in most cases, the response time is less than 20 ms to 30 ms.
+Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 2000 ms by default. However, in most cases, the response time is less than 20 ms to 30 ms.
 
 If there is an error condition when processing the rule, Arcjet returns an `ERROR` result for that rule and you can check the `message` property on the rule’s error result for more information.
 
@@ -1999,11 +1999,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({
@@ -2031,11 +2029,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({

--- a/tests/llms-txt.test.ts-snapshots/reference-nodejs-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-nodejs-chromium-linux.md
@@ -810,7 +810,7 @@ Error handling
 
 [Section titled “Error handling”](#error-handling)
 
-Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 1000 ms in development (see [`ARCJET_ENV`](/environment#arcjet-env)) and 500 ms otherwise. However, in most cases, the response time is less than 20 ms to 30 ms.
+Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 2000 ms by default. However, in most cases, the response time is less than 20 ms to 30 ms.
 
 If there is an error condition when processing the rule, Arcjet returns an `ERROR` result for that rule and you can check the `message` property on the rule’s error result for more information.
 
@@ -1176,11 +1176,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({
@@ -1208,11 +1206,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({

--- a/tests/llms-txt.test.ts-snapshots/reference-nuxt-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-nuxt-chromium-linux.md
@@ -1014,7 +1014,7 @@ Error handling
 
 [Section titled “Error handling”](#error-handling)
 
-Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 1000 ms in development (see [`ARCJET_ENV`](/environment#arcjet-env)) and 500 ms otherwise. However, in most cases, the response time is less than 20 ms to 30 ms.
+Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 2000 ms by default. However, in most cases, the response time is less than 20 ms to 30 ms.
 
 If there is an error condition when processing the rule, Arcjet returns an `ERROR` result for that rule and you can check the `message` property on the rule’s error result for more information.
 
@@ -1285,11 +1285,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 export const arcjet = arcjetNuxt({
@@ -1322,11 +1320,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 export const arcjet = arcjetNuxt({

--- a/tests/llms-txt.test.ts-snapshots/reference-remix-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-remix-chromium-linux.md
@@ -784,7 +784,7 @@ Error handling
 
 [Section titled “Error handling”](#error-handling)
 
-Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 1000 ms in development (see [`ARCJET_ENV`](/environment#arcjet-env)) and 500 ms otherwise. However, in most cases, the response time is less than 20 ms to 30 ms.
+Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 2000 ms by default. However, in most cases, the response time is less than 20 ms to 30 ms.
 
 If there is an error condition when processing the rule, Arcjet returns an `ERROR` result for that rule and you can check the `message` property on the rule’s error result for more information.
 
@@ -1096,11 +1096,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({
@@ -1128,11 +1126,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(process.env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({

--- a/tests/llms-txt.test.ts-snapshots/reference-sveltekit-chromium-linux.md
+++ b/tests/llms-txt.test.ts-snapshots/reference-sveltekit-chromium-linux.md
@@ -842,7 +842,7 @@ Error handling
 
 [Section titled “Error handling”](#error-handling)
 
-Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 1000 ms in development (see [`ARCJET_ENV`](/environment#arcjet-env)) and 500 ms otherwise. However, in most cases, the response time is less than 20 ms to 30 ms.
+Arcjet is designed to fail open so that a service issue or misconfiguration does not block all requests. The SDK also times out and fails open after 2000 ms by default. However, in most cases, the response time is less than 20 ms to 30 ms.
 
 If there is an error condition when processing the rule, Arcjet returns an `ERROR` result for that rule and you can check the `message` property on the rule’s error result for more information.
 
@@ -1166,11 +1166,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({
@@ -1199,11 +1197,9 @@ const client = createRemoteClient({
   // environment variable.
   baseUrl: baseUrl(env),
   // timeout is the maximum time to wait for a response from the server.
-  // It defaults to 1000ms in development
-  // (see [`ARCJET_ENV`](https://docs.arcjet.com/environment#arcjet-env))
-  // and 500ms otherwise. This is a conservative limit to fail open by default.
+  // It defaults to 2000ms. This is a conservative limit to fail open by default.
   // In most cases, the response time will be <20-30ms.
-  timeout: 500,
+  timeout: 2000,
 });
 
 const aj = arcjet({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
JS adapters now default the Decide API timeout to **2000 ms**, matching Guard. The old 500 ms production / 1000 ms development split is gone. Explicit `timeout` still wins (including `0`). Email doubling (2s → 4s) and the prompt-injection 1s floor are unchanged.

This updates the docs to match [arcjet-js#6236](https://github.com/arcjet/arcjet-js/pull/6236) and `DEFAULT_CLIENT_TIMEOUT_MS = 2000` in `@arcjet/protocol/client`.

## Changes

- SDK reference error-handling copy (Next.js, Node.js, Astro, Bun, NestJS, Remix, SvelteKit, Nuxt) now says fail-open after 2000 ms by default.
- Product reference error-handling copy (bot protection, email validation, filters, rate limiting, signup protection, Shield, sensitive info) matches that 2000 ms default.
- `createRemoteClient` snippets document a 2000 ms default instead of the 1000/500 split.
- `/architecture` timeout section: default is 2000 ms in both environments; remove the development-vs-production split explanation.
- `/environment` no longer claims JS uses a development vs production timeout split. Both the JavaScript and Python SDKs default to 2000 ms in both environments, so this stays accurate if [#880](https://github.com/arcjet/arcjet-docs/pull/880) is still open.

Deno, Fastify, and React Router already point at the architecture timeout section rather than quoting 500/1000. Python `timeout_ms` configuration is left to #880.

## Test plan

- [x] Confirm JS SDK reference pages say fail-open after 2000 ms by default (no 500/1000 split)
- [x] Confirm `createRemoteClient` snippets say the default is 2000 ms
- [x] Confirm `/environment` does not describe a JS development vs production timeout split
- [x] Confirm `/architecture#timeout` documents a 2000 ms default
- [x] Confirm Deno, Fastify, and React Router still link to the architecture timeout section
- [x] `npm run pw:run -- tests/llms-txt.test.ts --update-snapshots=changed` (20 passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68d27e88-1517-4b41-8997-a224ebe49864?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68d27e88-1517-4b41-8997-a224ebe49864&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

