### PR TITLE
docs(go): ARCJET_KEY, Protect order, ContextWindowSize, 2s deadline, Guard buckets

### DIFF
--- a/src/content/docs/architecture.mdx
+++ b/src/content/docs/architecture.mdx
@@ -320,6 +320,11 @@ a user would connect to your application and then the application would connect
 to the closest Arcjet Cloud API,
 usually within the same region.
 
+The Go SDK applies a 2 second deadline when the incoming context has none,
+and 4 seconds when an email rule is configured. A caller-supplied deadline
+is not shortened or replaced. For more information, see the
+<Link.Page href="/reference/go#timeouts">Go SDK reference</Link.Page>.
+
 A shorter timeout may result in faster failure responses but could lead to
 increased error rates if the Cloud API needs time to respond.
 Conversely,

--- a/src/content/docs/environment.mdx
+++ b/src/content/docs/environment.mdx
@@ -68,25 +68,37 @@ trusted as they can be set by malicious users.
 The Arcjet Astro SDK uses `ARCJET_ENV` and the value at `import.meta.env.MODE`
 (from Vite) but does not use `NODE_ENV`.
 
+The Go SDK does not read `ARCJET_ENV` or `NODE_ENV` and has no
+development-mode switch. Set `Config.Platform` on the HTTP client to select
+a hosting platform. To override the detected client IP on a request, pass
+`WithIPSrc` to `Protect`. For more information, see the
+<Link.Page href="/reference/go#environment-variables">Go SDK reference</Link.Page>.
+
 <a name="arcjet-key" />
 
 ### `ARCJET_KEY`
 
 Arcjet key for your site (`string`). In most cases, this variable name is a
-recommended convention. Unlike the other variables, Arcjet SDKs do not read this
-value automatically: retrieve it from the environment yourself and pass it
-explicitly. For more information, see <Link.Page href="/environment#how-to-read-environment-variables">How to read environment variables</Link.Page>.
+recommended convention.
+
+The Go SDK reads `ARCJET_KEY` when `Key` is empty on `NewClient` or
+`NewGuardClient`. An explicit `Key` wins. The Astro SDK also reads this
+value automatically.
+
+The JS Guard SDK does not read environment variables. Python Guard and
+Python Protect require an explicit key – typically
+`os.environ["ARCJET_KEY"]` or `os.environ.get("ARCJET_KEY")` passed to
+`arcjet(key=...)`, `arcjet_sync(key=...)`, `launch_arcjet(key=...)`, or
+`launch_arcjet_sync(key=...)`. Other JS SDKs (except Astro) require you to
+retrieve the value and pass it yourself.
+
+For more information, see <Link.Page href="/environment#how-to-read-environment-variables">How to read environment variables</Link.Page>.
 
 You can find your site key in the [Arcjet dashboard](https://app.arcjet.com).
 Select your site, select "SDK configuration", then click to copy.
 
 Arcjet keys are secrets that are always prefixed with `ajkey_`.
 As this is a secret, do not commit it to source control or otherwise expose it.
-
-This value is read automatically when using the Arcjet Astro SDK. In the
-Python SDK, pass it explicitly to `arcjet(key=...)` or
-`arcjet_sync(key=...)` – typically read with
-`os.environ["ARCJET_KEY"]` or `os.environ.get("ARCJET_KEY")`.
 
 <a name="arcjet-log-level" />
 
@@ -227,9 +239,11 @@ manually at module load time.
 ## How to read environment variables
 
 Arcjet reads most environment variables automatically.
-The `ARCJET_KEY` value is not read automatically, except in Astro.
-How to read it and other environment variables depends on your framework or
-runtime:
+The Go SDK reads `ARCJET_KEY` when `Key` is empty. The Astro SDK also reads
+it automatically. Other JS SDKs and the Python SDK require you to pass the
+key explicitly.
+How you read `ARCJET_KEY` and other environment variables depends on your
+framework or runtime:
 
 In [Node.js](https://nodejs.org/docs/latest/api/process.html#processenv)
 and [Bun](https://bun.com/docs/runtime/environment-variables#reading-environment-variables)
@@ -241,6 +255,18 @@ you can read environment variables with `Deno.env.get()`.
 In SvelteKit you can read environment variables from
 [`$env/dynamic/private`](https://svelte.dev/docs/kit/$env-dynamic-private) and
 the like.
+
+In Go you can read environment variables with
+[`os.Getenv`](https://pkg.go.dev/os#Getenv). Passing
+`Key: os.Getenv("ARCJET_KEY")` is the explicit-wins pattern. If you omit
+`Key`, `NewClient` and `NewGuardClient` read `ARCJET_KEY` from the
+environment:
+
+```go
+aj, err := arcjet.NewClient(arcjet.Config{
+	Key: os.Getenv("ARCJET_KEY"),
+})
+```
 
 In Python you can read environment variables with
 [`os.environ`](https://docs.python.org/3/library/os.html#os.environ).
@@ -267,7 +293,7 @@ To read values in the same way as the JS SDKs,
 for example to figure out whether Arcjet is in development mode,
 you can use this package.
 
-There is no equivalent package for Python. The Python SDK reads environment
+There is no equivalent package for Python or Go. The Python SDK reads environment
 variables directly with `os.environ` or `os.getenv` in
 [`arcjet/_client.py`](https://github.com/arcjet/arcjet-py/blob/main/src/arcjet/_client.py),
 [`arcjet/_context.py`](https://github.com/arcjet/arcjet-py/blob/main/src/arcjet/_context.py),

--- a/src/content/docs/environment.mdx
+++ b/src/content/docs/environment.mdx
@@ -74,6 +74,12 @@ a hosting platform. To override the detected client IP on a request, pass
 `WithIPSrc` to `Protect`. For more information, see the
 <Link.Page href="/reference/go#environment-variables">Go SDK reference</Link.Page>.
 
+`Protect` and `ProtectDetails` apply a 2 second deadline when the incoming
+context has none, or 4 seconds when an email rule is configured. A
+caller-supplied deadline is not shortened or replaced. For more
+information about the deadline, see
+<Link.Page href="/reference/go#timeouts">Timeouts in the Go SDK reference</Link.Page>.
+
 <a name="arcjet-key" />
 
 ### `ARCJET_KEY`

--- a/src/content/docs/reference/go.mdx
+++ b/src/content/docs/reference/go.mdx
@@ -151,6 +151,24 @@ If the application is behind a trusted reverse proxy, configure `Config.Proxies`
 with the trusted proxy addresses or CIDRs so Arcjet receives the correct client
 IP.
 
+### Timeouts
+
+`Protect` and `ProtectDetails` apply a 2 second deadline when the incoming
+context has none. An email rule doubles that to 4 seconds. A prompt-injection
+rule has a 1 second floor that the 2 second base already meets. A client
+with both email and prompt-injection rules still uses 4 seconds (the email
+doubling). A caller-supplied deadline is not shortened or replaced.
+
+```go
+// The context has no deadline, so the SDK applies 2 seconds.
+decision, err := aj.Protect(context.Background(), r)
+
+ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+defer cancel()
+// The caller deadline is kept.
+decision, err = aj.Protect(ctx, r)
+```
+
 ### Override the client IP
 
 Arcjet normally detects the client IP address from the request. If your
@@ -270,6 +288,10 @@ Guard labels and rate-limit buckets are slugs: lowercase letters, digits,
 dashes, and dots, starting and ending with a letter or digit. Use a stable,
 hardcoded label for each operation and an explicit rate-limit key such as a
 user ID, session ID, or API key.
+
+If you omit `Bucket`, the SDK uses `default-token-bucket`,
+`default-fixed-window`, or `default-sliding-window`. Set `Bucket` explicitly
+so unrelated rules do not share a counter.
 
 Available Guard rules include rate limiting, prompt injection detection,
 content moderation (`GuardModerateContent`), sensitive information detection,

--- a/src/content/docs/reference/go.mdx
+++ b/src/content/docs/reference/go.mdx
@@ -124,7 +124,19 @@ func must[T any](value T, err error) T {
 ```
 
 Use `client.WithRule(...)` to derive a client with an additional route-specific
-rule. Pass dynamic inputs with the following `Protect` options:
+rule.
+
+When you configure multiple Protect rules, declaration order does not control
+evaluation. `NewClient` and `WithRule` sort once: `SensitiveInfo`, `Filter`,
+`Shield`, rate-limit rules (`TokenBucket`, `FixedWindow`, `SlidingWindow`),
+`DetectBot`, `ValidateEmail`, then `DetectPromptInjection`. Rules with the
+same priority keep their declaration order. The first denial from a
+`ModeLive` rule stops evaluation of later rules.
+
+`SensitiveInfo` runs first so a denial happens before another rule can
+forward the payload.
+
+Pass dynamic inputs with the following `Protect` options:
 
 - `WithCharacteristics(...)` for rate-limit keys such as a user or tenant ID.
 - `WithRequested(...)` for the number of tokens a token bucket consumes.
@@ -158,6 +170,38 @@ by `ProtectDetails`.
 > value and ensure it comes from a trusted source. Do not pass a
 > client-controlled header directly; doing so could allow clients to choose the
 > IP address used for fingerprinting, rate limiting, and other security checks.
+
+### Sensitive information detection
+
+Use `SensitiveInfo` on the HTTP client and pass the text to scan with
+`WithSensitiveInfoValue`. Detection runs locally.
+
+`SensitiveInfoOptions.ContextWindowSize` is the number of adjacent tokens
+passed to `Config.SensitiveInfoDetect` at a time. When the value is zero or
+negative, the SDK uses 1. This matches JS `contextWindowSize` and Python
+`context_window_size`.
+
+```go
+aj, err := arcjet.NewClient(arcjet.Config{
+	Key: os.Getenv("ARCJET_KEY"),
+	SensitiveInfoDetect: func(_ context.Context, tokens []string) []arcjet.EntityType {
+		// tokens is a window of ContextWindowSize
+		return make([]arcjet.EntityType, len(tokens))
+	},
+	Rules: []arcjet.Rule{
+		arcjet.SensitiveInfo(arcjet.SensitiveInfoOptions{
+			Mode:              arcjet.ModeLive,
+			ContextWindowSize: 3,
+		}),
+	},
+})
+```
+
+`GuardSensitiveInfoRule` does not expose `ContextWindowSize`. Guard scans
+use a window of 1.
+
+For more information about scanning request text, see
+<Link.Page href="/sensitive-info">Sensitive information detection</Link.Page>.
 
 ## Guard non-HTTP operations
 

--- a/src/content/docs/reference/go.mdx
+++ b/src/content/docs/reference/go.mdx
@@ -27,6 +27,25 @@ Set `ARCJET_KEY` in the environment. Retrieve it from the
 <Link.Page href="/cli">Arcjet CLI</Link.Page>, or the
 <Link.Page href="/mcp-server">MCP server</Link.Page>.
 
+## Environment variables
+
+`NewClient` and `NewGuardClient` read `ARCJET_KEY` when `Key` is empty. An
+explicit `Key` wins, so passing `Key: os.Getenv("ARCJET_KEY")` is still
+correct.
+
+This differs from the JS and Python SDKs. The JS Guard SDK does not read
+environment variables. Python Guard and Python Protect require an explicit
+key.
+
+The Go SDK does not read
+<Link.Page href="/environment#arcjet-env">`ARCJET_ENV`</Link.Page>
+and has no development-mode switch. Set `Config.Platform` on the HTTP
+client to select a hosting platform. To override the detected client IP on
+a request, pass `WithIPSrc` to `Protect`.
+
+For more information, see
+<Link.Page href="/environment">Concepts: Environment variables</Link.Page>.
+
 ## Choose an API
 
 | API | Use it for |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Merged Go SDK changes need docs. This PR keeps the `ARCJET_KEY` contract from [arcjet-go#55](https://github.com/arcjet/arcjet-go/pull/55) and folds in:

- [arcjet-go#59](https://github.com/arcjet/arcjet-go/pull/59) – local Protect evaluation matches JS `sortRule`. `NewClient` and `WithRule` sort once. Declaration order does not control evaluation. `SensitiveInfo` runs first so a denial happens before another rule can forward the payload.
- [arcjet-go#61](https://github.com/arcjet/arcjet-go/pull/61) – HTTP `SensitiveInfoOptions.ContextWindowSize` (default 1 when zero or negative). `GuardSensitiveInfoRule` does not expose the option.
- [arcjet-go#60](https://github.com/arcjet/arcjet-go/pull/60) – `Protect` / `ProtectDetails` apply a 2s deadline when the incoming context has none. An email rule doubles to 4s. A caller-supplied deadline is not shortened or replaced.
- [arcjet-go#56](https://github.com/arcjet/arcjet-go/pull/56) – empty Guard `Bucket` defaults to `default-token-bucket`, `default-fixed-window`, or `default-sliding-window`. Explicit `Bucket` is still preferred.

Live `/environment` said Arcjet SDKs do not read `ARCJET_KEY` automatically except Astro. That is wrong for Go.

## What

- `/environment`: Go reads `ARCJET_KEY` when `Key` is empty. Contrast JS Guard (does not read environment variables) and Python Guard / Protect (explicit key). No Go `ARCJET_ENV` switch; use `Config.Platform` and `WithIPSrc`. Go Protect deadline is 2s (4s with email).
- `/architecture` timeout: add the Go 2s / 4s deadline. Leave the JS 500/1000 split to [#884](https://github.com/arcjet/arcjet-docs/pull/884).
- Go SDK reference: `ARCJET_KEY` contract. Examples still pass `Key: os.Getenv("ARCJET_KEY")`.
- Go SDK reference: Protect rule evaluation order. Docs no longer imply declaration-order evaluation.
- Go SDK reference: HTTP `ContextWindowSize`. No Guard option invented. Sensitive-info pages have no Go slot, so no snippets there.
- Go SDK reference: Protect 2s deadline and Guard algorithm-specific bucket defaults. Docs do not teach a shared `"default"` bucket.

[Protect 2s deadline on the Go SDK reference](https://cursor.com/agents/bc-029d8e8a-5238-444b-b732-1bb61e31b6fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgo_protect_timeouts.png)

[Guard algorithm-specific bucket defaults](https://cursor.com/agents/bc-029d8e8a-5238-444b-b732-1bb61e31b6fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgo_guard_bucket_defaults.png)

[Protect evaluation order on the Go SDK reference](https://cursor.com/agents/bc-029d8e8a-5238-444b-b732-1bb61e31b6fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgo_protect_evaluation_order.png)

[HTTP ContextWindowSize on the Go SDK reference](https://cursor.com/agents/bc-029d8e8a-5238-444b-b732-1bb61e31b6fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgo_context_window_size.png)

[ARCJET_KEY section documents the Go env fallback and JS/Python contrast](https://cursor.com/agents/bc-029d8e8a-5238-444b-b732-1bb61e31b6fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenvironment_arcjet_key_go.png)

## Out of scope

- Additive vs open [#883](https://github.com/arcjet/arcjet-docs/pull/883) (Go Protect fail-open / required Guard `Mode`). This PR does not change error handling or `Mode`.
- Additive vs open [#884](https://github.com/arcjet/arcjet-docs/pull/884) (JS Decide timeout 2000 ms). This PR does not rewrite the JS 500/1000 figures.
- No remote-policy teaching.

## Testing

- Style check on the edited MDX (no new findings).
- Dev server returned HTTP 200 for `/environment`, `/reference/go`, and `/architecture`.
- Architecture screenshot tests passed; the timeout section is below the 5000px clip.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-029d8e8a-5238-444b-b732-1bb61e31b6fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-029d8e8a-5238-444b-b732-1bb61e31b6fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

